### PR TITLE
generate poNumber and polNumber

### DIFF
--- a/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
@@ -47,14 +47,15 @@ public class PostOrdersHelper {
   public CompletableFuture<CompositePurchaseOrder> createPOandPOLines(CompositePurchaseOrder compPO) {
     CompletableFuture<CompositePurchaseOrder> future = new VertxCompletableFuture<>(ctx);
 
+    compPO.getPurchaseOrder().setPoNumber(generatePoNumber());
+
     try {
       Buffer poBuf = JsonObject.mapFrom(compPO.getPurchaseOrder()).toBuffer();
       httpClient.request(HttpMethod.POST, poBuf, "/purchase_order", okapiHeaders)
         .thenApply(OrdersResourceImpl::verifyAndExtractBody)
         .thenAccept(poBody -> {
           PurchaseOrder po = poBody.mapTo(PurchaseOrder.class);
-          String poNumber = generatePoNumber();
-          po.setPoNumber(poNumber);
+          String poNumber = po.getPoNumber();
           String poId = po.getId();
           compPO.setPurchaseOrder(po);
 


### PR DESCRIPTION
see [MODORDERS-29](https://issues.folio.org/browse/MODORDERS-29)

### PO Number ###
The algorithm I chose is based on a hex representation of milliseconds since an arbitrary epoch (9/1/2018), with 1-2 hex digits at the end (obtained from nanotime) for entropy.  The entire string is upper-cased.

### POL Number ###
Append a dash followed by a sequential number (1-999)

**Example:**

* PONumber: `2274C0AF60`
* POLNumbers:  `2274C0AF60-1`, `2274C0AF60-2`, `2274C0AF60-3`

If we need to change the algorithm later, we can.  I just wanted to get _something_ in place so we can move forward.
