### PR TITLE
MODORDERS-37 Return mock data from GET /orders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,15 @@
 ## 1.0.0 Unreleased
+ * [MODORDERS-37](https://issues.folio.org/browse/MODORDERS-37)
+ * [MODORDERS-34](https://issues.folio.org/browse/MODORDERS-34)
+ * [MODORDERS-29](https://issues.folio.org/browse/MODORDERS-29)
+ * [MODORDERS-28](https://issues.folio.org/browse/MODORDERS-28)
+ * [MODORDERS-27](https://issues.folio.org/browse/MODORDERS-27)
+ * [MODORDERS-25](https://issues.folio.org/browse/MODORDERS-25)
+ * [MODORDERS-24](https://issues.folio.org/browse/MODORDERS-24)
+ * [MODORDERS-23](https://issues.folio.org/browse/MODORDERS-23)
+ * [MODORDERS-18](https://issues.folio.org/browse/MODORDERS-18)
+ * [MODORDERS-17](https://issues.folio.org/browse/MODORDERS-17)
+ * [MODORDERS-16](https://issues.folio.org/browse/MODORDERS-16)
+ * [MODORDERS-15](https://issues.folio.org/browse/MODORDERS-15)
+ * [MODORDERS-14](https://issues.folio.org/browse/MODORDERS-14)
  * Initial commit

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,13 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -1,0 +1,22 @@
+package org.folio.orders.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+public class HelperUtils {
+
+  private HelperUtils() {
+
+  }
+
+  public static String getMockData(String path) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    try (Stream<String> lines = Files.lines(Paths.get(path))) {
+      lines.forEach(sb::append);
+    }
+    return sb.toString();
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
@@ -1,0 +1,106 @@
+package org.folio.rest.impl;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.log4j.Logger;
+import org.folio.orders.rest.exceptions.HttpException;
+import org.folio.orders.utils.HelperUtils;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrders;
+import org.folio.rest.jaxrs.resource.OrdersResource.GetOrdersResponse;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+
+public class GetOrdersHelper {
+
+  private static final Logger logger = Logger.getLogger(GetOrdersHelper.class);
+
+  public static final String MOCK_DATA_PATH = "src/test/resources/mockdata/getOrders.json";
+
+  private final HttpClientInterface httpClient;
+  private final Context ctx;
+  private final Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler;
+  private final Map<String, String> okapiHeaders;
+
+  public GetOrdersHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context ctx) {
+    this.httpClient = httpClient;
+    this.okapiHeaders = okapiHeaders;
+    this.ctx = ctx;
+    this.asyncResultHandler = asyncResultHandler;
+  }
+
+  public CompletableFuture<CompositePurchaseOrders> getOrders(String query, int offset, int limit, String lang) {
+    CompletableFuture<CompositePurchaseOrders> future = new VertxCompletableFuture<>(ctx);
+
+    //TODO replace this with a call to mod-orders-storage
+    getMockOrders(query, offset, limit, lang)
+      .thenAccept(orders -> {
+        logger.info("Returning mock data: " + JsonObject.mapFrom(orders).encodePrettily());
+        future.complete(orders);
+      })
+      .exceptionally(t -> {
+        logger.error("Error getting orders", t);
+        future.completeExceptionally(t);
+        return null;
+      });
+
+    return future;
+  }
+
+  private CompletableFuture<CompositePurchaseOrders> getMockOrders(String query, int offset, int limit, String lang) {
+    return VertxCompletableFuture.supplyAsync(ctx, () -> {
+      try {
+        JsonObject json = new JsonObject(HelperUtils.getMockData(MOCK_DATA_PATH));
+        return json.mapTo(CompositePurchaseOrders.class);
+      } catch (IOException e) {
+        logger.error("Failed to read mock data", e);
+        throw new CompletionException(e);
+      }
+    });
+  }
+
+  public Void handleError(Throwable throwable) {
+    final Future<javax.ws.rs.core.Response> result;
+
+    logger.error("Exception querying for orders", throwable.getCause());
+
+    final Throwable t = throwable.getCause();
+    if (t instanceof HttpException) {
+      final int code = ((HttpException) t).getCode();
+      final String message = ((HttpException) t).getMessage();
+      switch (code) {
+      case 400:
+        result = Future.succeededFuture(GetOrdersResponse.withPlainBadRequest(message));
+        break;
+      case 500:
+        result = Future.succeededFuture(GetOrdersResponse.withPlainInternalServerError(message));
+        break;
+      case 401:
+        result = Future.succeededFuture(GetOrdersResponse.withPlainUnauthorized(message));
+        break;
+      default:
+        result = Future.succeededFuture(GetOrdersResponse.withPlainInternalServerError(message));
+      }
+    } else {
+      result = Future.succeededFuture(GetOrdersResponse.withPlainInternalServerError(throwable.getMessage()));
+    }
+
+    httpClient.closeClient();
+
+    asyncResultHandler.handle(result);
+
+    return null;
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
@@ -1,12 +1,11 @@
 package org.folio.rest.impl;
 
-import static org.junit.Assert.*;
+import static org.folio.orders.utils.HelperUtils.getMockData;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.UUID;
 
 import org.apache.log4j.Logger;
@@ -83,6 +82,7 @@ public class OrdersResourceImplTest {
   @AfterClass
   public static void tearDownOnce(TestContext context) {
     vertx.close(context.asyncAssertSuccess());
+    mockServer.close();
   }
 
   @Test
@@ -217,6 +217,31 @@ public class OrdersResourceImplTest {
     assertEquals("Access requires permission: foo.bar.baz", respBody);
   }
 
+  @Test
+  public void testGetOrders(TestContext ctx) throws Exception {
+    logger.info("=== Test Get Orders ===");
+
+    String expected = new JsonObject(getMockData(GetOrdersHelper.MOCK_DATA_PATH)).encodePrettily();
+
+    final Response resp = RestAssured
+      .with()
+        .header(X_OKAPI_URL)
+        .header(X_OKAPI_TENANT)
+        .queryParam("query", "approval_status%3D%22Pending%22")
+        .queryParam("limit", "30")
+      .get(rootPath)
+        .then()
+          .contentType(APPLICATION_JSON)
+          .statusCode(200)
+          .extract()
+            .response();
+
+    String actual = new JsonObject(resp.getBody().asString()).encodePrettily();
+    logger.info(actual);
+
+    assertEquals(expected, actual);
+  }
+
   public static class MockServer {
 
     private static final Logger logger = Logger.getLogger(MockServer.class);
@@ -348,9 +373,4 @@ public class OrdersResourceImplTest {
     }
   }
 
-  public static String getMockData(String path) throws IOException {
-    StringBuilder sb = new StringBuilder();
-    Files.lines(Paths.get(path)).forEach(sb::append);
-    return sb.toString();
-  }
 }

--- a/src/test/resources/mockdata/getOrders.json
+++ b/src/test/resources/mockdata/getOrders.json
@@ -1,0 +1,94 @@
+{
+  "composite_purchase_orders" : [ {
+    "purchase_order": {
+      "id" : "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
+      "po_number" : "268758"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "e5ae4afd-3fa9-494e-a972-f541df9b877e",
+      "po_number" : "268879"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "00ed10af-fac2-46ad-9f94-a298358646a2",
+      "po_number" : "S58227"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "07f65192-44a4-483d-97aa-b137bbd96390",
+      "po_number" : "S60402"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "e20af8c8-b07d-47a1-9ebd-f1187e9335bd",
+      "po_number" : "306251"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "e41e0161-2bc6-41f3-a6e7-34fc13250bf1",
+      "po_number" : "306857"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "8c328a18-5761-4329-95f6-599412c32310",
+      "po_number" : "14383007"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33",
+      "po_number" : "313000"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "f4dc647c-ec82-442e-b13d-f9505b7ce8e9",
+      "po_number" : "312325"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
+      "po_number" : "52590"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "589a6016-3463-49f6-8aa2-dc315d0665fd",
+      "po_number" : "101101"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "55b97a4a-6601-4488-84e1-8b0d47a3f523",
+      "po_number" : "101113"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "9447d062-89ec-486e-a14b-572f3efb9f8c",
+      "po_number" : "101125"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "1d6a455f-29c5-4e51-84d9-e28450ef86ad",
+      "po_number" : "36547"
+    },
+    "po_lines" : [ ]
+  }, {
+    "purchase_order": {
+      "id" : "c27e60f9-6361-44c1-976e-0c4821a33a7d",
+      "po_number" : "38434"
+    },
+    "po_lines" : [ ]
+  } ],
+  "total_records" : 15
+}


### PR DESCRIPTION
Return mock data from the GET /orders endpoint.

For now always return the same data, regardless of query arguments (query/limit/etc.).  

See [MODORDERS-37](https://issues.folio.org/browse/MODORDERS-37) for additional details.