### PR TITLE
MODORDERS-48 (follow-on) remove empty/null renewal.cycle fields

### DIFF
--- a/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -18,7 +18,7 @@
     "notes": [],
     "manual_po": false,
     "po_number": "S60402",
-    "order_type": "Onging",
+    "order_type": "Ongoing",
     "re_encumber": false,
     "total_estimated_price": 200000.00,
     "total_items": 80,

--- a/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -134,7 +134,6 @@
       "publisher": "American Chemical Society",
       "purchase_order_id": "c79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB4bb",
       "receipt_date": null,
-      "receipt_status": "",
       "renewal": {
         "id": "9e414baa-8cf2-4916-a90f-d1da4009e06e",
         "cycle": "One Year",

--- a/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
+++ b/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
@@ -18,7 +18,7 @@
     "notes": [],
     "manual_po": false,
     "po_number": "36547",
-    "order_type": "On-Time",
+    "order_type": "One-Time",
     "re_encumber": false,
     "total_estimated_price": 25.00,
     "total_items": 1,

--- a/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
+++ b/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
@@ -134,7 +134,6 @@
       "publisher": "",
       "purchase_order_id": "c79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3zb",
       "receipt_date": null,
-      "receipt_status": "",
       "renewal": {
         "id": "9e414baa-8cf2-4916-a90f-d1da4009e06e",
         "interval": 0,

--- a/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
+++ b/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
@@ -137,7 +137,6 @@
       "receipt_status": "",
       "renewal": {
         "id": "9e414baa-8cf2-4916-a90f-d1da4009e06e",
-        "cycle": "",
         "interval": 0,
         "manual_renewal": true,
         "review_period": 0,

--- a/src/main/resources/mockdata/9447d062-89ec-486e-a14b-572f3efb9f8c.json
+++ b/src/main/resources/mockdata/9447d062-89ec-486e-a14b-572f3efb9f8c.json
@@ -137,7 +137,6 @@
       "receipt_status": "Pending",
       "renewal": {
         "id": "9e414baa-8cf2-4916-a90f-d1da4009e02e",
-        "cycle": "",
         "interval": 0,
         "manual_renewal": true,
         "review_period": 0,

--- a/src/main/resources/mockdata/c27e60f9-6361-44c1-976e-0c4821a33a7d.json
+++ b/src/main/resources/mockdata/c27e60f9-6361-44c1-976e-0c4821a33a7d.json
@@ -117,7 +117,7 @@
         "quantity_electronic": 0,
         "quantity_physical": 2
       },
-      "order_format": "Services",
+      "order_format": "Service",
       "owner": "Monographs",
       "payment_status": "Pending",
       "physical": {

--- a/src/main/resources/mockdata/e20af8c8-b07d-47a1-9ebd-f1187e9335bd.json
+++ b/src/main/resources/mockdata/e20af8c8-b07d-47a1-9ebd-f1187e9335bd.json
@@ -139,7 +139,6 @@
       "receipt_status": "Pending",
       "renewal": {
         "id": "9e414baa-8cf2-4916-a90f-d1da4009e00e",
-        "cycle": null,
         "interval": 0,
         "manual_renewal": true,
         "review_period": 0,

--- a/src/main/resources/mockdata/e41e0161-2bc6-41f3-a6e7-34fc13250bf1.json
+++ b/src/main/resources/mockdata/e41e0161-2bc6-41f3-a6e7-34fc13250bf1.json
@@ -139,7 +139,6 @@
       "receipt_status": "Pending",
       "renewal": {
         "id": "9e414baa-8cf2-4916-a90f-d1da4009e19e",
-        "cycle": null,
         "interval": 0,
         "manual_renewal": true,
         "review_period": 0,

--- a/src/main/resources/mockdata/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/main/resources/mockdata/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -160,7 +160,7 @@
         "instructions": "",
         "note_from_vendor": "",
         "ref_number": "999632785",
-        "ref_number_type": "Supplier’s unique order line reference number",
+        "ref_number_type": "Supplier's unique order line reference number",
         "vendor_account": "12345-50",
         "po_line_id": "50fb63b0-cdf1-11e8-a8d5-f2801f1b9fd1"
       }

--- a/src/main/resources/mockdata/f4dc647c-ec82-442e-b13d-f9505b7ce8e9.json
+++ b/src/main/resources/mockdata/f4dc647c-ec82-442e-b13d-f9505b7ce8e9.json
@@ -119,7 +119,7 @@
       },
       "order_format": "Electronic Resource",
       "owner": "Evans",
-      "payment_status": "Awaiting payment",
+      "payment_status": "Awaiting Payment",
       "physical": {
         "id": "50fb857a-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "",


### PR DESCRIPTION
There were a few minor issues we missed in MODORDERS-48... e.g. typos, enum fields set to "" or null, etc.