### PR TITLE
MODORDERS-53 Update mock data, code and tests to work with latest schema changes

### DIFF
--- a/src/main/resources/mockdata/00ed10af-fac2-46ad-9f94-a298358646a2.json
+++ b/src/main/resources/mockdata/00ed10af-fac2-46ad-9f94-a298358646a2.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "00ed10af-fac2-46ad-9f94-a298358646a2",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-07-12T00:00:00.000Z",
-    "created_by": "28d0f6e0-d137-11e8-a8d5-f2801f1b9fd1",
-    "manual_po": false,
-    "notes": [],
-    "po_number": "S58227",
-    "order_type": "Ongoing",
-    "re_encumber": false,
-    "total_estimated_price": 842.00,
-    "total_items": 2,
-    "vendor": "50fb86a6-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Closed"
+  "id": "00ed10af-fac2-46ad-9f94-a298358646a2",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-07-12T00:00:00.000Z",
+  "created_by": "28d0f6e0-d137-11e8-a8d5-f2801f1b9fd1",
+  "manual_po": false,
+  "notes": [],
+  "po_number": "S58227",
+  "order_type": "Ongoing",
+  "re_encumber": false,
+  "total_estimated_price": 842.00,
+  "total_items": 2,
+  "vendor": "50fb86a6-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Closed",
   "po_lines": [
     {
       "id": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33.json
+++ b/src/main/resources/mockdata/05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-07-19T00:00:00.000Z",
-    "created_by": "28d100f4-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": ["DVD plus 3 years streaming"],
-    "manual_po": false,
-    "po_number": "313000",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 500.00,
-    "total_items": 2,
-    "vendor": "50fb8a2a-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Open"
+  "id": "05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-07-19T00:00:00.000Z",
+  "created_by": "28d100f4-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": ["DVD plus 3 years streaming"],
+  "manual_po": false,
+  "po_number": "313000",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 500.00,
+  "total_items": 2,
+  "vendor": "50fb8a2a-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "id": "50fb53f2-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/0610be6d-0ddd-494b-b867-19f63d8b5d6d.json
+++ b/src/main/resources/mockdata/0610be6d-0ddd-494b-b867-19f63d8b5d6d.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
-    "created": "2015-07-08T00:00:00.000Z",
-    "created_by": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": ["2 titles received: Publication and London topographical record"],
-    "manual_po": false,
-    "po_number": "52590",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 0.00,
-    "total_items": 1,
-    "vendor": "50fb8c82-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Pending"
+  "id": "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
+  "created": "2015-07-08T00:00:00.000Z",
+  "created_by": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": ["2 titles received: Publication and London topographical record"],
+  "manual_po": false,
+  "po_number": "52590",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 0.00,
+  "total_items": 1,
+  "vendor": "50fb8c82-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Pending",
   "po_lines": [
     {
       "id": "50fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "07f65192-44a4-483d-97aa-b137bbd96390",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-07-18T00:00:00.000Z",
-    "created_by": "28d102a2-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [],
-    "manual_po": false,
-    "po_number": "S60402",
-    "order_type": "Ongoing",
-    "re_encumber": false,
-    "total_estimated_price": 200000.00,
-    "total_items": 80,
-    "vendor": "50fb8b56-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Closed"
+  "id": "07f65192-44a4-483d-97aa-b137bbd96390",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-07-18T00:00:00.000Z",
+  "created_by": "28d102a2-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manual_po": false,
+  "po_number": "S60402",
+  "order_type": "Ongoing",
+  "re_encumber": false,
+  "total_estimated_price": 200000.00,
+  "total_items": 80,
+  "vendor": "50fb8b56-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Closed",
   "po_lines": [
     {
       "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
+++ b/src/main/resources/mockdata/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
-    "adjustment": {
-      "credit": 0.0,
-      "discount": 0.0,
-      "insurance": 0.0,
-      "overhead": 0.0,
-      "shipment": 0.0,
-      "tax_1": 0.0,
-      "tax_2": 0.0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-06-29T00:00:00.000Z",
-    "created_by": "28d0f99c-d137-11e8-a8d5-f2801f1b9fd1",
-    "manual_po": false,
-    "notes": [],
-    "po_number": "268758",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 127.94,
-    "total_items": 3,
-    "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Open"
+  "id": "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
+  "adjustment": {
+    "credit": 0.0,
+    "discount": 0.0,
+    "insurance": 0.0,
+    "overhead": 0.0,
+    "shipment": 0.0,
+    "tax_1": 0.0,
+    "tax_2": 0.0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-06-29T00:00:00.000Z",
+  "created_by": "28d0f99c-d137-11e8-a8d5-f2801f1b9fd1",
+  "manual_po": false,
+  "notes": [],
+  "po_number": "268758",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 127.94,
+  "total_items": 3,
+  "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "id": "50fb4bfa-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
+++ b/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "1d6a455f-29c5-4e51-84d9-e28450ef86ad",
-    "adjustment": {
-      "credit": -3.99,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "28d0ff6e-d137-11e8-a8d5-f2801f1b9fd1",
-    "created": "2019-05-15T00:00:00.000Z",
-    "created_by": "28d0fb04-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [],
-    "manual_po": false,
-    "po_number": "36547",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 25.00,
-    "total_items": 1,
-    "vendor": "168f8a86-d26c-406e-813f-c9927f241vc3",
-    "workflow_status": "Closed"
+  "id": "1d6a455f-29c5-4e51-84d9-e28450ef86ad",
+  "adjustment": {
+    "credit": -3.99,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "28d0ff6e-d137-11e8-a8d5-f2801f1b9fd1",
+  "created": "2019-05-15T00:00:00.000Z",
+  "created_by": "28d0fb04-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manual_po": false,
+  "po_number": "36547",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 25.00,
+  "total_items": 1,
+  "vendor": "168f8a86-d26c-406e-813f-c9927f241vc3",
+  "workflow_status": "Closed",
   "po_lines": [
     {
       "id": "50fb52bc-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/55b97a4a-6601-4488-84e1-8b0d47a3f523.json
+++ b/src/main/resources/mockdata/55b97a4a-6601-4488-84e1-8b0d47a3f523.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "55b97a4a-6601-4488-84e1-8b0d47a3f523",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-07-19T00:00:00.000Z",
-    "created_by": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [],
-    "manual_po": false,
-    "po_number": "101113",
-    "order_type": "Ongoing",
-    "re_encumber": false,
-    "total_estimated_price": 240.00,
-    "total_items": 1,
-    "vendor": "50fb8da4-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Pending"
+  "id": "55b97a4a-6601-4488-84e1-8b0d47a3f523",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-07-19T00:00:00.000Z",
+  "created_by": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manual_po": false,
+  "po_number": "101113",
+  "order_type": "Ongoing",
+  "re_encumber": false,
+  "total_estimated_price": 240.00,
+  "total_items": 1,
+  "vendor": "50fb8da4-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Pending",
   "po_lines": [
     {
       "id": "50fb5956-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/589a6016-3463-49f6-8aa2-dc315d0665fd.json
+++ b/src/main/resources/mockdata/589a6016-3463-49f6-8aa2-dc315d0665fd.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "589a6016-3463-49f6-8aa2-dc315d0665fd",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
-    "created": "2018-07-19T00:00:00.000Z",
-    "created_by": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [],
-    "manual_po": true,
-    "po_number": "101101",
-    "order_type": "Ongoing",
-    "re_encumber": false,
-    "total_estimated_price": 900.00,
-    "total_items": 1,
-    "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Pending"
+  "id": "589a6016-3463-49f6-8aa2-dc315d0665fd",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
+  "created": "2018-07-19T00:00:00.000Z",
+  "created_by": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manual_po": true,
+  "po_number": "101101",
+  "order_type": "Ongoing",
+  "re_encumber": false,
+  "total_estimated_price": 900.00,
+  "total_items": 1,
+  "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Pending",
   "po_lines": [
     {
       "id": "50fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/8c328a18-5761-4329-95f6-599412c32310.json
+++ b/src/main/resources/mockdata/8c328a18-5761-4329-95f6-599412c32310.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "8c328a18-5761-4329-95f6-599412c32310",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-07-18T00:00:00.000Z",
-    "created_by": "28d10432-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [],
-    "manual_po": true,
-    "po_number": "14383007",
-    "order_type": "Ongoing",
-    "re_encumber": false,
-    "total_estimated_price": 0.00,
-    "total_items": 1,
-    "vendor": "50fb8c82-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Open"
+  "id": "8c328a18-5761-4329-95f6-599412c32310",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-07-18T00:00:00.000Z",
+  "created_by": "28d10432-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manual_po": true,
+  "po_number": "14383007",
+  "order_type": "Ongoing",
+  "re_encumber": false,
+  "total_estimated_price": 0.00,
+  "total_items": 1,
+  "vendor": "50fb8c82-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "id": "50fb580c-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/9447d062-89ec-486e-a14b-572f3efb9f8c.json
+++ b/src/main/resources/mockdata/9447d062-89ec-486e-a14b-572f3efb9f8c.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "9447d062-89ec-486e-a14b-572f3efb9f8c",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-07-19T00:00:00.000Z",
-    "created_by": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [],
-    "manual_po": false,
-    "po_number": "101125",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 200.00,
-    "total_items": 2,
-    "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Pending"
+  "id": "9447d062-89ec-486e-a14b-572f3efb9f8c",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-07-19T00:00:00.000Z",
+  "created_by": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manual_po": false,
+  "po_number": "101125",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 200.00,
+  "total_items": 2,
+  "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Pending",
   "po_lines": [
     {
       "id": "50fb6130-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/c27e60f9-6361-44c1-976e-0c4821a33a7d.json
+++ b/src/main/resources/mockdata/c27e60f9-6361-44c1-976e-0c4821a33a7d.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "c27e60f9-6361-44c1-976e-0c4821a33a7d",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2014-09-22T00:00:00.000Z",
-    "created_by": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": ["Cataloging record service"],
-    "manual_po": true,
-    "po_number": "38434",
-    "order_type": "Ongoing",
-    "re_encumber": false,
-    "total_estimated_price": 0.00,
-    "total_items": 1,
-    "vendor": "50fb922c-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Pending"
+  "id": "c27e60f9-6361-44c1-976e-0c4821a33a7d",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2014-09-22T00:00:00.000Z",
+  "created_by": "28d10afe-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": ["Cataloging record service"],
+  "manual_po": true,
+  "po_number": "38434",
+  "order_type": "Ongoing",
+  "re_encumber": false,
+  "total_estimated_price": 0.00,
+  "total_items": 1,
+  "vendor": "50fb922c-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Pending",
   "po_lines": [
     {
       "id": "50fb627a-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/e20af8c8-b07d-47a1-9ebd-f1187e9335bd.json
+++ b/src/main/resources/mockdata/e20af8c8-b07d-47a1-9ebd-f1187e9335bd.json
@@ -1,32 +1,30 @@
 {
-  "purchase_order": {
-    "id": "e20af8c8-b07d-47a1-9ebd-f1187e9335bd",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-06-19T00:00:00.000Z",
-    "created_by": "28d10f5e-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [
-      "CAC one time funding proposal by Bob Barker"
-    ],
-    "manual_po": false,
-    "po_number": "306251",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 3000.00,
-    "total_items": 1,
-    "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Closed"
+  "id": "e20af8c8-b07d-47a1-9ebd-f1187e9335bd",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-06-19T00:00:00.000Z",
+  "created_by": "28d10f5e-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [
+    "CAC one time funding proposal by Bob Barker"
+  ],
+  "manual_po": false,
+  "po_number": "306251",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 3000.00,
+  "total_items": 1,
+  "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Closed",
   "po_lines": [
     {
       "id": "50fb64dc-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/e41e0161-2bc6-41f3-a6e7-34fc13250bf1.json
+++ b/src/main/resources/mockdata/e41e0161-2bc6-41f3-a6e7-34fc13250bf1.json
@@ -1,32 +1,30 @@
 {
-  "purchase_order": {
-    "id": "e41e0161-2bc6-41f3-a6e7-34fc13250bf1",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2018-07-23T00:00:00.000Z",
-    "created_by": "28d11102-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [
-      "Published twice a year"
-    ],
-    "manual_po": true,
-    "po_number": "306857",
-    "order_type": "Ongoing",
-    "re_encumber": false,
-    "total_estimated_price": 800.00,
-    "total_items": 1,
-    "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Open"
+  "id": "e41e0161-2bc6-41f3-a6e7-34fc13250bf1",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2018-07-23T00:00:00.000Z",
+  "created_by": "28d11102-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [
+    "Published twice a year"
+  ],
+  "manual_po": true,
+  "po_number": "306857",
+  "order_type": "Ongoing",
+  "re_encumber": false,
+  "total_estimated_price": 800.00,
+  "total_items": 1,
+  "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "id": "50fb6608-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/main/resources/mockdata/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "e5ae4afd-3fa9-494e-a972-f541df9b877e",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "",
-    "created": "2014-07-06T00:00:00.000Z",
-    "created_by": "28d10cfc-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": [],
-    "manual_po": false,
-    "po_number": "268879",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 75.22,
-    "total_items": 1,
-    "vendor": "50fb922c-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Closed"
+  "id": "e5ae4afd-3fa9-494e-a972-f541df9b877e",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "",
+  "created": "2014-07-06T00:00:00.000Z",
+  "created_by": "28d10cfc-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manual_po": false,
+  "po_number": "268879",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 75.22,
+  "total_items": 1,
+  "vendor": "50fb922c-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Closed",
   "po_lines": [
     {
       "id": "50fb63b0-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/f4dc647c-ec82-442e-b13d-f9505b7ce8e9.json
+++ b/src/main/resources/mockdata/f4dc647c-ec82-442e-b13d-f9505b7ce8e9.json
@@ -1,30 +1,28 @@
 {
-  "purchase_order": {
-    "id": "f4dc647c-ec82-442e-b13d-f9505b7ce8e9",
-    "adjustment": {
-      "credit": 0,
-      "discount": 0,
-      "insurance": 0,
-      "overhead": 0,
-      "shipment": 0,
-      "tax_1": 0,
-      "tax_2": 0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "28d11a26-d137-11e8-a8d5-f2801f1b9fd1",
-    "created": "2018-07-13T00:00:00.000Z",
-    "created_by": "28d11576-d137-11e8-a8d5-f2801f1b9fd1",
-    "notes": ["REF<DXiao>", "REF<DHalling>", "Notify<Mary Ann Barker barker@tamu.edu>", "Licensing <1-year streaming license>"],
-    "manual_po": false,
-    "po_number": "312325",
-    "order_type": "One-Time",
-    "re_encumber": false,
-    "total_estimated_price": 150.00,
-    "total_items": 1,
-    "vendor": "50fb8a2a-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "workflow_status": "Open"
+  "id": "f4dc647c-ec82-442e-b13d-f9505b7ce8e9",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax_1": 0,
+    "tax_2": 0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "28d11a26-d137-11e8-a8d5-f2801f1b9fd1",
+  "created": "2018-07-13T00:00:00.000Z",
+  "created_by": "28d11576-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": ["REF<DXiao>", "REF<DHalling>", "Notify<Mary Ann Barker barker@tamu.edu>", "Licensing <1-year streaming license>"],
+  "manual_po": false,
+  "po_number": "312325",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 150.00,
+  "total_items": 1,
+  "vendor": "50fb8a2a-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "id": "50fb695a-cdf1-11e8-a8d5-f2801f1b9fd1",

--- a/src/main/resources/mockdata/getOrders.json
+++ b/src/main/resources/mockdata/getOrders.json
@@ -1,93 +1,63 @@
 {
   "composite_purchase_orders" : [ {
-    "purchase_order": {
-      "id" : "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
-      "po_number" : "268758"
-    },
+    "id" : "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
+    "po_number" : "268758",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "e5ae4afd-3fa9-494e-a972-f541df9b877e",
-      "po_number" : "268879"
-    },
+    "id" : "e5ae4afd-3fa9-494e-a972-f541df9b877e",
+    "po_number" : "268879",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "00ed10af-fac2-46ad-9f94-a298358646a2",
-      "po_number" : "S58227"
-    },
+    "id" : "00ed10af-fac2-46ad-9f94-a298358646a2",
+    "po_number" : "S58227",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "07f65192-44a4-483d-97aa-b137bbd96390",
-      "po_number" : "S60402"
-    },
+    "id" : "07f65192-44a4-483d-97aa-b137bbd96390",
+    "po_number" : "S60402",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "e20af8c8-b07d-47a1-9ebd-f1187e9335bd",
-      "po_number" : "306251"
-    },
+    "id" : "e20af8c8-b07d-47a1-9ebd-f1187e9335bd",
+    "po_number" : "306251",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "e41e0161-2bc6-41f3-a6e7-34fc13250bf1",
-      "po_number" : "306857"
-    },
+    "id" : "e41e0161-2bc6-41f3-a6e7-34fc13250bf1",
+    "po_number" : "306857",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "8c328a18-5761-4329-95f6-599412c32310",
-      "po_number" : "14383007"
-    },
+    "id" : "8c328a18-5761-4329-95f6-599412c32310",
+    "po_number" : "14383007",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33",
-      "po_number" : "313000"
-    },
+    "id" : "05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33",
+    "po_number" : "313000",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "f4dc647c-ec82-442e-b13d-f9505b7ce8e9",
-      "po_number" : "312325"
-    },
+    "id" : "f4dc647c-ec82-442e-b13d-f9505b7ce8e9",
+    "po_number" : "312325",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
-      "po_number" : "52590"
-    },
+    "id" : "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
+    "po_number" : "52590",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "589a6016-3463-49f6-8aa2-dc315d0665fd",
-      "po_number" : "101101"
-    },
+    "id" : "589a6016-3463-49f6-8aa2-dc315d0665fd",
+    "po_number" : "101101",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "55b97a4a-6601-4488-84e1-8b0d47a3f523",
-      "po_number" : "101113"
-    },
+    "id" : "55b97a4a-6601-4488-84e1-8b0d47a3f523",
+    "po_number" : "101113",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "9447d062-89ec-486e-a14b-572f3efb9f8c",
-      "po_number" : "101125"
-    },
+    "id" : "9447d062-89ec-486e-a14b-572f3efb9f8c",
+    "po_number" : "101125",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "1d6a455f-29c5-4e51-84d9-e28450ef86ad",
-      "po_number" : "36547"
-    },
+    "id" : "1d6a455f-29c5-4e51-84d9-e28450ef86ad",
+    "po_number" : "36547",
     "po_lines" : [ ]
   }, {
-    "purchase_order": {
-      "id" : "c27e60f9-6361-44c1-976e-0c4821a33a7d",
-      "po_number" : "38434"
-    },
+    "id" : "c27e60f9-6361-44c1-976e-0c4821a33a7d",
+    "po_number" : "38434",
     "po_lines" : [ ]
   } ],
   "total_records" : 15

--- a/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
@@ -111,8 +111,8 @@ public class OrdersResourceImplTest {
 
     logger.info(JsonObject.mapFrom(resp));
 
-    String poId = resp.getPurchaseOrder().getId();
-    String poNumber = resp.getPurchaseOrder().getPoNumber();
+    String poId = resp.getId();
+    String poNumber = resp.getPoNumber();
     
     assertNotNull(poId);
     assertNotNull(poNumber);
@@ -163,7 +163,7 @@ public class OrdersResourceImplTest {
     ctx.assertEquals("must match \"^[a-zA-Z0-9]{5,16}$\"", errors.getErrors().get(0).getMessage());
     ctx.assertFalse(errors.getErrors().get(0).getParameters().isEmpty());
     ctx.assertNotNull(errors.getErrors().get(0).getParameters().get(0));
-    ctx.assertEquals("purchaseOrder.poNumber", errors.getErrors().get(0).getParameters().get(0).getKey());
+    ctx.assertEquals("poNumber", errors.getErrors().get(0).getParameters().get(0).getKey());
     ctx.assertEquals("123", errors.getErrors().get(0).getParameters().get(0).getValue());
   }
 
@@ -255,7 +255,7 @@ public class OrdersResourceImplTest {
     logger.info("=== Test Get Order By Id ===");
 
     JsonObject ordersList = new JsonObject(getMockData(GetOrdersHelper.MOCK_DATA_PATH));
-    String id = ordersList.getJsonArray("composite_purchase_orders").getJsonObject(0).getJsonObject("purchase_order").getString("id");
+    String id = ordersList.getJsonArray("composite_purchase_orders").getJsonObject(0).getString("id");
     logger.info("using mock datafile: " + GetOrderHelper.BASE_MOCK_DATA_PATH + id + ".json");
 
     final CompositePurchaseOrder resp = RestAssured
@@ -272,7 +272,7 @@ public class OrdersResourceImplTest {
 
     logger.info(JsonObject.mapFrom(resp));
 
-    assertEquals(id, resp.getPurchaseOrder().getId());
+    assertEquals(id, resp.getId());
   }
 
   @Test
@@ -355,6 +355,8 @@ public class OrdersResourceImplTest {
     private void handlePostPurchaseOrder(RoutingContext ctx) {
       logger.info("got: " + ctx.getBodyAsString());
 
+      //TODO validate against purchase_order schema
+
       JsonObject body = ctx.getBodyAsJson();
       body.put("id", UUID.randomUUID().toString());
 
@@ -405,6 +407,8 @@ public class OrdersResourceImplTest {
 
     private void handlePostPOLine(RoutingContext ctx) {
       logger.info("got: " + ctx.getBodyAsString());
+
+      //TODO validate against po_line schema
 
       JsonObject body = ctx.getBodyAsJson();
       body.put("id", UUID.randomUUID().toString());

--- a/src/test/resources/po_creation_failure.json
+++ b/src/test/resources/po_creation_failure.json
@@ -1,7 +1,5 @@
 {
-  "purchase_order": {
-    "po_number": "123"
-  },
+  "po_number": "123",
   "po_lines": [
     {
       "po_line_number": "12345-1"

--- a/src/test/resources/po_line_creation_failure.json
+++ b/src/test/resources/po_line_creation_failure.json
@@ -1,7 +1,5 @@
 {
-  "purchase_order": {
-    "po_number": "TESTDATA0123"
-  },
+  "po_number": "TESTDATA0123",
   "po_lines": [
     {
       "po_line_number": "8675309-1"

--- a/src/test/resources/po_listed_electronic_monograph.json
+++ b/src/test/resources/po_listed_electronic_monograph.json
@@ -1,33 +1,31 @@
 {
-  "purchase_order": {
-    "adjustment": {
-      "credit": 0.0,
-      "discount": 0.0,
-      "insurance": 0.0,
-      "overhead": 0.0,
-      "shipment": 0.0,
-      "tax_1": 0.0,
-      "tax_2": 0.0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
-    "created": "2010-10-08T03:53:00.000Z",
-    "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
-    "manual_po": false,
-    "notes": [
-      "ABCDEFGHIJKLMNO",
-      "ABCDEFGHIJKLMNOPQRST",
-      "ABCDEFGHIJKLMNOPQRSTUV"
-    ],
-    "order_type": "One-Time",
-    "po_number": "268758",
-    "re_encumber": false,
-    "total_estimated_price": 49.98,
-    "total_items": 2,
-    "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
-    "workflow_status": "Open"    
+  "adjustment": {
+    "credit": 0.0,
+    "discount": 0.0,
+    "insurance": 0.0,
+    "overhead": 0.0,
+    "shipment": 0.0,
+    "tax_1": 0.0,
+    "tax_2": 0.0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "created": "2010-10-08T03:53:00.000Z",
+  "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "manual_po": false,
+  "notes": [
+    "ABCDEFGHIJKLMNO",
+    "ABCDEFGHIJKLMNOPQRST",
+    "ABCDEFGHIJKLMNOPQRSTUV"
+  ],
+  "order_type": "One-Time",
+  "po_number": "268758",
+  "re_encumber": false,
+  "total_estimated_price": 49.98,
+  "total_items": 2,
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "acquisition_method": "Purchase At Vendor System",

--- a/src/test/resources/po_listed_print_monograph.json
+++ b/src/test/resources/po_listed_print_monograph.json
@@ -1,32 +1,30 @@
 {
-  "purchase_order": {
-    "adjustment": {
-      "credit": 0.0,
-      "discount": 0.0,
-      "insurance": 0.0,
-      "overhead": 0.0,
-      "shipment": 0.0,
-      "tax_1": 0.0,
-      "tax_2": 0.0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
-    "created": "2010-10-08T03:53:00.000Z",
-    "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
-    "notes": [
-      "ABCDEFGHIJKLMNO",
-      "ABCDEFGHIJKLMNOPQRST",
-      "ABCDEFGHIJKLMNOPQRSTUV"
-    ],
-    "order_type": "One-Time",
-    "po_number": "268758",
-    "re_encumber": false,
-    "total_estimated_price": 49.98,
-    "total_items": 2,
-    "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
-    "workflow_status": "Open"    
+  "adjustment": {
+    "credit": 0.0,
+    "discount": 0.0,
+    "insurance": 0.0,
+    "overhead": 0.0,
+    "shipment": 0.0,
+    "tax_1": 0.0,
+    "tax_2": 0.0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "created": "2010-10-08T03:53:00.000Z",
+  "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "notes": [
+    "ABCDEFGHIJKLMNO",
+    "ABCDEFGHIJKLMNOPQRST",
+    "ABCDEFGHIJKLMNOPQRSTUV"
+  ],
+  "order_type": "One-Time",
+  "po_number": "268758",
+  "re_encumber": false,
+  "total_estimated_price": 49.98,
+  "total_items": 2,
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "acquisition_method": "Purchase At Vendor System",

--- a/src/test/resources/po_listed_print_serial.json
+++ b/src/test/resources/po_listed_print_serial.json
@@ -1,33 +1,31 @@
 {
-  "purchase_order": {
-    "adjustment": {
-      "credit": 0.0,
-      "discount": 0.0,
-      "insurance": 0.0,
-      "overhead": 0.0,
-      "shipment": 0.0,
-      "tax_1": 0.0,
-      "tax_2": 0.0,
-      "use_pro_rate": false
-    },
-    "approved": true,
-    "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
-    "created": "2010-10-08T03:53:00.000Z",
-    "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
-    "manual_po": false,
-    "notes": [
-      "ABCDEFGHIJKLMNO",
-      "ABCDEFGHIJKLMNOPQRST",
-      "ABCDEFGHIJKLMNOPQRSTUV"
-    ],
-    "order_type": "Ongoing",
-    "po_number": "268758",
-    "re_encumber": false,
-    "total_estimated_price": 49.98,
-    "total_items": 2,
-    "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
-    "workflow_status": "Open"    
+  "adjustment": {
+    "credit": 0.0,
+    "discount": 0.0,
+    "insurance": 0.0,
+    "overhead": 0.0,
+    "shipment": 0.0,
+    "tax_1": 0.0,
+    "tax_2": 0.0,
+    "use_pro_rate": false
   },
+  "approved": true,
+  "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "created": "2010-10-08T03:53:00.000Z",
+  "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "manual_po": false,
+  "notes": [
+    "ABCDEFGHIJKLMNO",
+    "ABCDEFGHIJKLMNOPQRST",
+    "ABCDEFGHIJKLMNOPQRSTUV"
+  ],
+  "order_type": "Ongoing",
+  "po_number": "268758",
+  "re_encumber": false,
+  "total_estimated_price": 49.98,
+  "total_items": 2,
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "workflow_status": "Open",
   "po_lines": [
     {
       "acquisition_method": "Purchase At Vendor System",


### PR DESCRIPTION
The latest schema changes include pulling the purchase_order fields up to the top-level of composite_purchase_order.

See [MODORDERS-53](https://issues.folio.org/browse/MODORDERS-53) for additional details.

Due to a discrepancy between composite_purchase_order and purchase_order schemas, I added a bit of code to strip off any adjustment fields in orders during placement.  The top/po-level adjustments are calculated based on the po_line adjustment data (summation).  I added a rudimentary impl of this too while I was at it.

*NOTE* the acq-models submodule was updated to point to the MODORDERS-53 branch of that repo.  Once https://github.com/folio-org/acq-models/pull/38 is merged, I'll update it to be the latest commit.  There shouldn't be any schemas differences, just the submodule branch/commit.