### PR TITLE
MODORDERS-56 Fix PoLine and sub object creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
     <aspectj.version>1.8.9</aspectj.version>
     <module_name>mod-orders</module_name>
     <http.port>8081</http.port>
+    <generated_sources_dir>${project.build.directory}/generated-sources</generated_sources_dir>
+    <jsonschema2pojo_output_dir>${generated_sources_dir}/jsonschema2pojo</jsonschema2pojo_output_dir>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
@@ -162,6 +164,28 @@
               </sources>
             </configuration>
           </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jsonschema2pojo</groupId>
+        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+        <version>0.4.37</version>
+        <configuration>
+          <includes>*.json</includes>
+          <outputDirectory>${jsonschema2pojo_output_dir}</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>acq-models</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${basedir}/ramls/acq-models/mod-orders-storage/schemas</sourceDirectory>
+              <targetPackage>org.folio.rest.acq.model</targetPackage>
+            </configuration>
+          </execution>          
         </executions>
       </plugin>
 

--- a/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
@@ -222,7 +222,7 @@ public class PostOrdersHelper {
   }
 
   private CompletableFuture<Void> createLocation(PoLine compPOL, JsonObject line, Location location) {
-    return createSubObjIfPresent(line, location, "location", "/location")
+    return createSubObjIfPresent(line, location, "location", "/locations")
       .thenAccept(id -> {
         if (id == null) {
           line.remove("location");

--- a/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
@@ -381,7 +381,7 @@ public class OrdersResourceImplTest {
       router.route(HttpMethod.POST, "/cost").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Cost.class));
       router.route(HttpMethod.POST, "/details").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Details.class));
       router.route(HttpMethod.POST, "/eresource").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Eresource.class));
-      router.route(HttpMethod.POST, "/location").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Location.class));
+      router.route(HttpMethod.POST, "/locations").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Location.class));
       router.route(HttpMethod.POST, "/physical").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Physical.class));
       router.route(HttpMethod.POST, "/vendor_detail").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.VendorDetail.class));
 

--- a/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersResourceImplTest.java
@@ -377,11 +377,13 @@ public class OrdersResourceImplTest {
       router.route().handler(BodyHandler.create());
       router.route(HttpMethod.POST, "/purchase_order").handler(this::handlePostPurchaseOrder);
       router.route(HttpMethod.POST, "/po_line").handler(this::handlePostPOLine);
-      router.route(HttpMethod.POST, "/details").handler(this::handlePostAssignId);
-      router.route(HttpMethod.POST, "/cost").handler(this::handlePostAssignId);
-      router.route(HttpMethod.POST, "/vendor_detail").handler(this::handlePostAssignId);
-      router.route(HttpMethod.POST, "/eresource").handler(this::handlePostAssignId);
-      router.route(HttpMethod.POST, "/location").handler(this::handlePostAssignId);
+      router.route(HttpMethod.POST, "/adjustment").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Adjustment.class));
+      router.route(HttpMethod.POST, "/cost").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Cost.class));
+      router.route(HttpMethod.POST, "/details").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Details.class));
+      router.route(HttpMethod.POST, "/eresource").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Eresource.class));
+      router.route(HttpMethod.POST, "/location").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Location.class));
+      router.route(HttpMethod.POST, "/physical").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.Physical.class));
+      router.route(HttpMethod.POST, "/vendor_detail").handler(ctx -> handlePostGenericSubObj(ctx, org.folio.rest.acq.model.VendorDetail.class));
 
       router.route(HttpMethod.GET, "/purchase_order/:id").handler(this::handleGetPurchaseOrderById);
       router.route(HttpMethod.GET, "/po_line").handler(this::handleGetPoLine);
@@ -533,18 +535,16 @@ public class OrdersResourceImplTest {
     private void handlePostPurchaseOrder(RoutingContext ctx) {
       logger.info("got: " + ctx.getBodyAsString());
 
-      // TODO validate against purchase_order schema
-
-      JsonObject body = ctx.getBodyAsJson();
-      body.put("id", UUID.randomUUID().toString());
+      org.folio.rest.acq.model.PurchaseOrder po = ctx.getBodyAsJson().mapTo(org.folio.rest.acq.model.PurchaseOrder.class);
+      po.setId(UUID.randomUUID().toString());
 
       ctx.response()
         .setStatusCode(201)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .end(body.encodePrettily());
+        .end(JsonObject.mapFrom(po).encodePrettily());
     }
 
-    private void handlePostAssignId(RoutingContext ctx) {
+    private void handlePostGenericSubObj(RoutingContext ctx, Class<?> clazz) {
       logger.info("got: " + ctx.getBodyAsString());
 
       String echoStatus = ctx.request().getHeader(X_ECHO_STATUS);
@@ -565,8 +565,7 @@ public class OrdersResourceImplTest {
       switch (status) {
       case 201:
         contentType = APPLICATION_JSON;
-        JsonObject body = ctx.getBodyAsJson();
-        body.put("id", UUID.randomUUID().toString());
+        JsonObject body = JsonObject.mapFrom(ctx.getBodyAsJson().mapTo(clazz)).put("id", UUID.randomUUID().toString());
         respBody = body.encodePrettily();
         break;
       case 403:
@@ -584,18 +583,17 @@ public class OrdersResourceImplTest {
     }
 
     private void handlePostPOLine(RoutingContext ctx) {
-      logger.info("got: " + ctx.getBodyAsString());
+      logger.info("got po_line: " + ctx.getBodyAsString());
 
-      // TODO validate against po_line schema
-
-      JsonObject body = ctx.getBodyAsJson();
-      body.put("id", UUID.randomUUID().toString());
+      org.folio.rest.acq.model.PoLine pol = ctx.getBodyAsJson().mapTo(org.folio.rest.acq.model.PoLine.class);
+      pol.setId(UUID.randomUUID().toString());
 
       ctx.response()
         .setStatusCode(201)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .end(body.encodePrettily());
-    }
+        .end(JsonObject.mapFrom(pol).encodePrettily());
+    }   
+
   }
 
 }


### PR DESCRIPTION
* Now builds pojos for all the mod-orders-storage schemas - helpful for validation of objects in unit test mocks
* Implemented sub-obj creation for Physical and Adjustment
* Stub/Temporarily remove other sub-objs that aren't being created (marked with TODO) - alerts, claims, fund_distribution, reporting_codes, source
* Updated the unit test mocks to validate against the schema via the auto-generated pojos

See [MODORDERS-56](https://issues.folio.org/browse/MODORDERS-56) for additional details.
