### PR TITLE
Remove renewal so create does not break

### DIFF
--- a/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
@@ -116,7 +116,8 @@ public class PostOrdersHelper {
     line.remove("claims");
     line.remove("fund_distribution");
     line.remove("reporting_codes");
-    line.remove("source");    
+    line.remove("source");
+    line.remove("renewal"); 
     
     subObjFuts.add(createAdjustment(compPOL, line, compPOL.getAdjustment()));
     subObjFuts.add(createCost(compPOL, line, compPOL.getCost()));

--- a/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
@@ -118,6 +118,7 @@ public class PostOrdersHelper {
     line.remove("reporting_codes");
     line.remove("source");
     line.remove("renewal"); 
+    line.remove("license"); 
     
     subObjFuts.add(createAdjustment(compPOL, line, compPOL.getAdjustment()));
     subObjFuts.add(createCost(compPOL, line, compPOL.getCost()));


### PR DESCRIPTION
Fix for below:
On creating a new order by doing POST /orders throws this error -
Json content error Can not deserialize instance of java.lang.String out of START_OBJECT token
 at [Source: java.io.StringReader@6b35e036; line: 1, column: 1067] (through reference chain: org.folio.rest.jaxrs.model.PoLine["renewal"])

This means `renewal` is missing and it is not created via mod-orders-storage. Also, it is not being removed from the po_line(temporary workaround)

Adding `license` to the removal list. 