### PR TITLE
MODORDERS-62 Update to RAML 1.0 and RMB 23

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "ramls/raml-util"]
 	path = ramls/raml-util
 	url = https://github.com/folio-org/raml
+	branch = raml1.0
 [submodule "ramls/acq-models"]
 	path = ramls/acq-models
 	url = https://github.com/folio-org/acq-models.git

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 1.0.0 Unreleased
+ * [MODORDERS-62](https://issues.folio.org/browse/MODORDERS-62) - Migrate to RAML1.0 and RMB 23
  * [MODORDERS-51](https://issues.folio.org/browse/MODORDERS-51)
  * [MODORDERS-50](https://issues.folio.org/browse/MODORDERS-50)
  * [MODORDERS-49](https://issues.folio.org/browse/MODORDERS-49)

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>19.3.1</raml-module-builder.version>
+    <raml-module-builder.version>23.2.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.5.1</version>
+      <version>3.5.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -117,6 +117,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+    </dependency>
+    <!-- The RMB runtime defines usage of log4j2 for vert.x logging interface. Including Log4j 2 SLF4J Binding to allow SLF4J API to use Log4j 2 as the implementation. -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.11.1</version>
     </dependency>
   </dependencies>
 

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -1,4 +1,4 @@
-#%RAML 0.8
+#%RAML 1.0
 title: Orders
 baseUri: https://github.com/folio-org/mod-orders
 version: v1
@@ -8,40 +8,25 @@ documentation:
   - title: Orders Business Logic API
     content: <b>API for managing purchase orders</b>
 
-schemas:
-  - composite_purchase_orders: !include acq-models/composite_purchase_orders.json
-  - composite_purchase_order.json: !include acq-models/composite_purchase_order.json
-  - composite_po_line.json: !include acq-models/composite_po_line.json
-  - mod-orders-storage/schemas/purchase_order.json: !include acq-models/mod-orders-storage/schemas/purchase_order.json
-  - mod-orders-storage/schemas/adjustment.json: !include acq-models/mod-orders-storage/schemas/adjustment.json
-  - mod-orders-storage/schemas/alert.json: !include acq-models/mod-orders-storage/schemas/alert.json
-  - mod-orders-storage/schemas/claim.json: !include acq-models/mod-orders-storage/schemas/claim.json
-  - mod-orders-storage/schemas/cost.json: !include acq-models/mod-orders-storage/schemas/cost.json
-  - mod-orders-storage/schemas/details.json: !include acq-models/mod-orders-storage/schemas/details.json
-  - mod-orders-storage/schemas/fund_distribution.json: !include acq-models/mod-orders-storage/schemas/fund_distribution.json
-  - mod-orders-storage/schemas/eresource.json: !include acq-models/mod-orders-storage/schemas/eresource.json
-  - mod-orders-storage/schemas/license.json: !include acq-models/mod-orders-storage/schemas/license.json
-  - mod-orders-storage/schemas/location.json: !include acq-models/mod-orders-storage/schemas/location.json
-  - mod-orders-storage/schemas/physical.json: !include acq-models/mod-orders-storage/schemas/physical.json
-  - mod-orders-storage/schemas/renewal.json: !include acq-models/mod-orders-storage/schemas/renewal.json
-  - mod-orders-storage/schemas/reporting_code.json: !include acq-models/mod-orders-storage/schemas/reporting_code.json
-  - mod-orders-storage/schemas/source.json: !include acq-models/mod-orders-storage/schemas/source.json
-  - mod-orders-storage/schemas/vendor_detail.json: !include acq-models/mod-orders-storage/schemas/vendor_detail.json
-  - errors: !include raml-util/schemas/errors.schema
-  - error.schema: !include raml-util/schemas/error.schema
-  - parameters.schema: !include raml-util/schemas/parameters.schema
+types:
+  composite_purchase_orders: !include acq-models/composite_purchase_orders.json
+  composite_purchase_order: !include acq-models/composite_purchase_order.json
+  composite_po_line: !include acq-models/composite_po_line.json
+  errors: !include raml-util/schemas/errors.schema
+  UUID:
+    type: string
+    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
 
 traits:
-  - secured: !include raml-util/traits/auth.raml
-  - orderable: !include raml-util/traits/orderable.raml
-  - pageable: !include raml-util/traits/pageable.raml
-  - searchable: !include raml-util/traits/searchable.raml
-  - language: !include raml-util/traits/language.raml
-  - validate: !include raml-util/traits/validation.raml
+  orderable: !include raml-util/traits/orderable.raml
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+  language: !include raml-util/traits/language.raml
+  validate: !include raml-util/traits/validation.raml
 
 resourceTypes:
-  - collection: !include raml-util/rtypes/collection.raml
-  - collection-item: !include raml-util/rtypes/item-collection.raml
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
 
 /orders:
   displayName: Orders
@@ -50,7 +35,7 @@ resourceTypes:
       exampleCollection: !include acq-models/examples/composite_purchase_orders.sample
       exampleItem: !include acq-models/examples/composite_purchase_order.sample
       schemaCollection: composite_purchase_orders
-      schemaItem: composite_purchase_order.json
+      schemaItem: composite_purchase_order
   get:
     description: Return a list of purchase orders
     is: [
@@ -64,14 +49,13 @@ resourceTypes:
       201:
         body:
           application/json:
-            schema: composite_purchase_order.json
+            type: composite_purchase_order
   /{id}:
     uriParameters:
       id:
         description: The UUID of a purchase order
-        type: string
-        pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
+        type: UUID
     type:
       collection-item:
         exampleItem: !include acq-models/examples/composite_purchase_order.sample
-        schema: composite_purchase_order.json
+        schema: composite_purchase_order

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -12,7 +12,6 @@ import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.rest.jaxrs.model.Adjustment;
 import org.folio.rest.jaxrs.model.PoLine;
@@ -23,6 +22,7 @@ import io.vertx.core.Context;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class HelperUtils {

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -1,6 +1,7 @@
 package org.folio.orders.utils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -50,7 +51,7 @@ public class HelperUtils {
 
   public static String getMockData(String path) throws IOException {
     try {
-      return IOUtils.toString(HelperUtils.class.getClassLoader().getResourceAsStream(path));
+      return IOUtils.toString(HelperUtils.class.getClassLoader().getResourceAsStream(path), StandardCharsets.UTF_8);
     } catch (NullPointerException e) {
       StringBuilder sb = new StringBuilder();
       try (Stream<String> lines = Files.lines(Paths.get(path))) {

--- a/src/main/java/org/folio/rest/impl/DeleteOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/DeleteOrdersByIdHelper.java
@@ -5,10 +5,9 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.Response;
 
-import org.apache.log4j.Logger;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.HelperUtils;
-import org.folio.rest.jaxrs.resource.OrdersResource.GetOrdersByIdResponse;
+import org.folio.rest.jaxrs.resource.Orders.GetOrdersByIdResponse;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.AsyncResult;
@@ -16,10 +15,12 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class DeleteOrdersByIdHelper {
-  private static final Logger logger = Logger.getLogger(DeleteOrdersByIdHelper.class);
+  private static final Logger logger = LoggerFactory.getLogger(DeleteOrdersByIdHelper.class);
 
   private final HttpClientInterface httpClient;
   private final Context ctx;
@@ -59,19 +60,19 @@ public class DeleteOrdersByIdHelper {
     final Throwable t = throwable.getCause();
     if (t instanceof HttpException) {
       final int code = ((HttpException) t).getCode();
-      final String message = ((HttpException) t).getMessage();
+      final String message = t.getMessage();
       switch (code) {
       case 404:
-        result = Future.succeededFuture(GetOrdersByIdResponse.withPlainNotFound(message));
+        result = Future.succeededFuture(GetOrdersByIdResponse.respond404WithTextPlain(message));
         break;
       case 500:
-        result = Future.succeededFuture(GetOrdersByIdResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(message));
         break;
       default:
-        result = Future.succeededFuture(GetOrdersByIdResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(message));
       }
     } else {
-      result = Future.succeededFuture(GetOrdersByIdResponse.withPlainInternalServerError(throwable.getMessage()));
+      result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(throwable.getMessage()));
     }
 
     httpClient.closeClient();

--- a/src/main/java/org/folio/rest/impl/GetOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersByIdHelper.java
@@ -5,11 +5,10 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.Response;
 
-import org.apache.log4j.Logger;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
-import org.folio.rest.jaxrs.resource.OrdersResource.GetOrdersByIdResponse;
+import org.folio.rest.jaxrs.resource.Orders.GetOrdersByIdResponse;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.AsyncResult;
@@ -17,11 +16,13 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class GetOrdersByIdHelper {
 
-  private static final Logger logger = Logger.getLogger(GetOrdersByIdHelper.class);
+  private static final Logger logger = LoggerFactory.getLogger(GetOrdersByIdHelper.class);
 
   private final HttpClientInterface httpClient;
   private final Context ctx;
@@ -91,19 +92,19 @@ public class GetOrdersByIdHelper {
     final Throwable t = throwable.getCause();
     if (t instanceof HttpException) {
       final int code = ((HttpException) t).getCode();
-      final String message = ((HttpException) t).getMessage();
+      final String message = t.getMessage();
       switch (code) {
       case 404:
-        result = Future.succeededFuture(GetOrdersByIdResponse.withPlainNotFound(message));
+        result = Future.succeededFuture(GetOrdersByIdResponse.respond404WithTextPlain(message));
         break;
       case 500:
-        result = Future.succeededFuture(GetOrdersByIdResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(message));
         break;
       default:
-        result = Future.succeededFuture(GetOrdersByIdResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(message));
       }
     } else {
-      result = Future.succeededFuture(GetOrdersByIdResponse.withPlainInternalServerError(throwable.getMessage()));
+      result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(throwable.getMessage()));
     }
 
     httpClient.closeClient();

--- a/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
@@ -6,11 +6,10 @@ import java.util.concurrent.CompletionException;
 
 import javax.ws.rs.core.Response;
 
-import org.apache.log4j.Logger;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrders;
-import org.folio.rest.jaxrs.resource.OrdersResource.GetOrdersResponse;
+import org.folio.rest.jaxrs.resource.Orders.GetOrdersResponse;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.AsyncResult;
@@ -18,11 +17,13 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class GetOrdersHelper {
 
-  private static final Logger logger = Logger.getLogger(GetOrdersHelper.class);
+  private static final Logger logger = LoggerFactory.getLogger(GetOrdersHelper.class);
 
   public static final String MOCK_DATA_PATH = "mockdata/getOrders.json";
 
@@ -77,22 +78,22 @@ public class GetOrdersHelper {
     final Throwable t = throwable.getCause();
     if (t instanceof HttpException) {
       final int code = ((HttpException) t).getCode();
-      final String message = ((HttpException) t).getMessage();
+      final String message = t.getMessage();
       switch (code) {
       case 400:
-        result = Future.succeededFuture(GetOrdersResponse.withPlainBadRequest(message));
+        result = Future.succeededFuture(GetOrdersResponse.respond400WithTextPlain(message));
         break;
       case 500:
-        result = Future.succeededFuture(GetOrdersResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(GetOrdersResponse.respond500WithTextPlain(message));
         break;
       case 401:
-        result = Future.succeededFuture(GetOrdersResponse.withPlainUnauthorized(message));
+        result = Future.succeededFuture(GetOrdersResponse.respond401WithTextPlain(message));
         break;
       default:
-        result = Future.succeededFuture(GetOrdersResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(GetOrdersResponse.respond500WithTextPlain(message));
       }
     } else {
-      result = Future.succeededFuture(GetOrdersResponse.withPlainInternalServerError(throwable.getMessage()));
+      result = Future.succeededFuture(GetOrdersResponse.respond500WithTextPlain(throwable.getMessage()));
     }
 
     httpClient.closeClient();

--- a/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import org.apache.log4j.Logger;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.Adjustment;
@@ -18,7 +17,7 @@ import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.VendorDetail;
-import org.folio.rest.jaxrs.resource.OrdersResource.PostOrdersResponse;
+import org.folio.rest.jaxrs.resource.Orders.PostOrdersResponse;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.AsyncResult;
@@ -28,11 +27,13 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class PostOrdersHelper {
 
-  private static final Logger logger = Logger.getLogger(PostOrdersHelper.class);
+  private static final Logger logger = LoggerFactory.getLogger(PostOrdersHelper.class);
 
   // epoch time @ 9/1/2018.
   // if you change this, you run the risk of duplicate poNumbers
@@ -323,22 +324,22 @@ public class PostOrdersHelper {
     final Throwable t = throwable.getCause();
     if (t instanceof HttpException) {
       final int code = ((HttpException) t).getCode();
-      final String message = ((HttpException) t).getMessage();
+      final String message = t.getMessage();
       switch (code) {
       case 400:
-        result = Future.succeededFuture(PostOrdersResponse.withPlainBadRequest(message));
+        result = Future.succeededFuture(PostOrdersResponse.respond400WithTextPlain(message));
         break;
       case 500:
-        result = Future.succeededFuture(PostOrdersResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(PostOrdersResponse.respond500WithTextPlain(message));
         break;
       case 401:
-        result = Future.succeededFuture(PostOrdersResponse.withPlainUnauthorized(message));
+        result = Future.succeededFuture(PostOrdersResponse.respond401WithTextPlain(message));
         break;
       default:
-        result = Future.succeededFuture(PostOrdersResponse.withPlainInternalServerError(message));
+        result = Future.succeededFuture(PostOrdersResponse.respond500WithTextPlain(message));
       }
     } else {
-      result = Future.succeededFuture(PostOrdersResponse.withPlainInternalServerError(throwable.getMessage()));
+      result = Future.succeededFuture(PostOrdersResponse.respond500WithTextPlain(throwable.getMessage()));
     }
 
     httpClient.closeClient();

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.log4j.Logger;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Adjustment;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
@@ -34,6 +33,8 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -42,9 +43,9 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 
 @RunWith(VertxUnitRunner.class)
-public class OrdersResourceImplTest {
+public class OrdersImplTest {
 
-  private static final Logger logger = Logger.getLogger(OrdersResourceImplTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(OrdersImplTest.class);
 
   private static final String APPLICATION_JSON = "application/json";
   private static final String TEXT_PLAIN = "text/plain";
@@ -53,10 +54,10 @@ public class OrdersResourceImplTest {
   private static final int okapiPort = NetworkUtils.nextFreePort();
   private static final int mockPort = NetworkUtils.nextFreePort();
 
-  private final Header X_OKAPI_URL = new Header("X-Okapi-Url", "http://localhost:" + mockPort);
-  private final Header X_OKAPI_TENANT = new Header("X-Okapi-Tenant", "ordersresourceimpltest");
+  private static final Header X_OKAPI_URL = new Header("X-Okapi-Url", "http://localhost:" + mockPort);
+  private static final Header X_OKAPI_TENANT = new Header("X-Okapi-Tenant", "ordersimpltest");
 
-  public final static String X_ECHO_STATUS = "X-Okapi-Echo-Status";
+  private static final String X_ECHO_STATUS = "X-Okapi-Echo-Status";
 
   // API paths
   private final String rootPath = "/orders";
@@ -368,7 +369,7 @@ public class OrdersResourceImplTest {
   
   public static class MockServer {
 
-    private static final Logger logger = Logger.getLogger(MockServer.class);
+    private static final Logger logger = LoggerFactory.getLogger(MockServer.class);
 
     public final int port;
     public final Vertx vertx;


### PR DESCRIPTION
- Migrate order.raml to 1.0 version
- RMB version changed from 19.3.1 to 23.2.0
- Updating ramls/raml-util submodule to latest commit
- Switching from apache log4j to vert.x Logger (the RMB runtime defines `Log4j2LogDelegateFactory` for vert.x Logger)
- Generated interface does not have the 'Resource' suffix and the response codes have changed
  - OrdersResourceImpl renamed to OrdersImpl (and corresponding unit test class)
  - Helper classes udated to use new method names

Note: the [RMB upgrade notes](https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md) describes details on what is required for migration.