### PR TITLE
Modorders 75 order line endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 1.0.0 Unreleased
+ * [MODORDERS-75](https://issues.folio.org/browse/MODORDERS-75) - Define order line endpoints
  * [MODORDERS-62](https://issues.folio.org/browse/MODORDERS-62) - Migrate to RAML1.0 and RMB 23
  * [MODORDERS-51](https://issues.folio.org/browse/MODORDERS-51)
  * [MODORDERS-50](https://issues.folio.org/browse/MODORDERS-50)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -55,6 +55,38 @@
             "purchase_order.item.delete",
             "po_line.item.delete"
           ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/orders/{id}/lines",
+          "permissionsRequired": ["orders.po_line.item.post"],
+          "modulePermissions": [
+            "po_line.item.post"
+          ]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/orders/{id}/lines/{polineId}",
+          "permissionsRequired": ["orders.po_line.item.get"],
+          "modulePermissions": [
+            "po_line.item.get"
+          ]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/orders/{id}/lines/{polineId}",
+          "permissionsRequired": ["orders.po_line.item.put"],
+          "modulePermissions": [
+            "po_line.item.put"
+          ]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/orders/{id}/lines/{polineId}",
+          "permissionsRequired": ["orders.po_line.item.delete"],
+          "modulePermissions": [
+            "po_line.item.delete"
+          ]
         }
       ]
     }
@@ -96,6 +128,26 @@
       "description": "Delete an existing order"
     },
     {
+      "permissionName": "orders.po_line.item.post",
+      "displayName": "Orders - create a new PO line",
+      "description": "Create a new PO line"
+    },
+    {
+      "permissionName": "orders.po_line.item.get",
+      "displayName": "Orders - get an existing PO line",
+      "description": "Get an existing PO line"
+    },
+    {
+      "permissionName": "orders.po_line.item.put",
+      "displayName": "Orders - modify an existing PO line",
+      "description": "Modify an existing PO line"
+    },
+    {
+      "permissionName": "orders.po_line.item.delete",
+      "displayName": "Orders - delete an existing PO line",
+      "description": "Delete an existing PO line"
+    },
+    {
       "permissionName": "orders.all",
       "displayName": "orders - all permissions",
       "description": "Entire set of permissions needed to use orders",
@@ -104,7 +156,11 @@
         "orders.item.post",
         "orders.item.get",
         "orders.item.put",
-        "orders.item.delete"
+        "orders.item.delete",
+        "orders.po_line.item.post",
+        "orders.po_line.item.get",
+        "orders.po_line.item.put",
+        "orders.po_line.item.delete"
       ]
     }
   ],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -66,7 +66,7 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/orders/{id}/lines/{polineId}",
+          "pathPattern": "/orders/{id}/lines/{lineId}",
           "permissionsRequired": ["orders.po_line.item.get"],
           "modulePermissions": [
             "po_line.item.get"
@@ -74,7 +74,7 @@
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/orders/{id}/lines/{polineId}",
+          "pathPattern": "/orders/{id}/lines/{lineId}",
           "permissionsRequired": ["orders.po_line.item.put"],
           "modulePermissions": [
             "po_line.item.put"
@@ -82,7 +82,7 @@
         },
         {
           "methods": ["DELETE"],
-          "pathPattern": "/orders/{id}/lines/{polineId}",
+          "pathPattern": "/orders/{id}/lines/{lineId}",
           "permissionsRequired": ["orders.po_line.item.delete"],
           "modulePermissions": [
             "po_line.item.delete"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -61,7 +61,16 @@
           "pathPattern": "/orders/{id}/lines",
           "permissionsRequired": ["orders.po_line.item.post"],
           "modulePermissions": [
-            "po_line.item.post"
+            "po_line.item.post",
+            "adjustment.item.post",
+            "alert.item.post",
+            "claim.item.post",
+            "cost.item.post",
+            "details.item.post",
+            "eresource.item.post",
+            "physical.item.post",
+            "renewal.item.post",
+            "vendor_detail.item.post"
           ]
         },
         {
@@ -69,7 +78,16 @@
           "pathPattern": "/orders/{id}/lines/{lineId}",
           "permissionsRequired": ["orders.po_line.item.get"],
           "modulePermissions": [
-            "po_line.item.get"
+            "po_line.item.get",
+            "adjustment.item.get",
+            "alert.item.get",
+            "claim.item.get",
+            "cost.item.get",
+            "details.item.get",
+            "eresource.item.get",
+            "physical.item.get",
+            "renewal.item.get",
+            "vendor_detail.item.get"
           ]
         },
         {
@@ -77,7 +95,25 @@
           "pathPattern": "/orders/{id}/lines/{lineId}",
           "permissionsRequired": ["orders.po_line.item.put"],
           "modulePermissions": [
-            "po_line.item.put"
+            "po_line.item.delete",
+            "po_line.item.post",
+            "adjustment.item.delete",
+            "adjustment.item.post",
+            "alert.item.delete",
+            "alert.item.delete",
+            "claim.item.post",
+            "cost.item.delete",
+            "cost.item.post",
+            "details.item.delete",
+            "details.item.post",
+            "eresource.item.delete",
+            "eresource.item.post",
+            "physical.item.delete",
+            "physical.item.post",
+            "renewal.item.delete",
+            "renewal.item.post",
+            "vendor_detail.item.delete",
+            "vendor_detail.item.post"
           ]
         },
         {
@@ -85,7 +121,16 @@
           "pathPattern": "/orders/{id}/lines/{lineId}",
           "permissionsRequired": ["orders.po_line.item.delete"],
           "modulePermissions": [
-            "po_line.item.delete"
+            "po_line.item.delete",
+            "adjustment.item.delete",
+            "alert.item.delete",
+            "claim.item.delete",
+            "cost.item.delete",
+            "details.item.delete",
+            "eresource.item.delete",
+            "physical.item.delete",
+            "renewal.item.delete",
+            "vendor_detail.item.delete"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -142,6 +142,42 @@
       "version": "1.0"
     },
     {
+      "id": "adjustment",
+      "version": "1.0"
+    },
+    {
+      "id": "alert",
+      "version": "1.0"
+    },
+    {
+      "id": "claim",
+      "version": "1.0"
+    },
+    {
+      "id": "cost",
+      "version": "1.0"
+    },
+    {
+      "id": "details",
+      "version": "1.0"
+    },
+    {
+      "id": "eresource",
+      "version": "1.0"
+    },
+    {
+      "id": "physical",
+      "version": "1.0"
+    },
+    {
+      "id": "renewal",
+      "version": "1.0"
+    },
+    {
+      "id": "vendor_detail",
+      "version": "1.0"
+    },
+    {
       "id": "po_line",
       "version": "1.0"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>23.2.0</raml-module-builder.version>
+    <raml-module-builder.version>23.2.1</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -26,6 +26,8 @@ traits:
 resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
   collection-item: !include raml-util/rtypes/item-collection.raml
+  # The post-empty-body.raml does not declare request body but it can be defined when this resource type is used
+  post-item: !include raml-util/rtypes/post-empty-body.raml
 
 /orders:
   displayName: Orders
@@ -60,8 +62,15 @@ resourceTypes:
         schema: composite_purchase_order
     /lines:
       displayName: Purchace Order Lines
+      description: Manage purchase order (PO) lines
+      type:
+        # Using `post-item` resource type because at the moment only POST is required. In case GET becomes also required, the `collection` resource type should be used instead
+        post-item:
+          exampleItem: !include acq-models/examples/composite_po_line.sample
+          schema: composite_po_line
       post:
-        description: Post a purchase order line (PO line)
+        displayName: Create a new purchace order line
+        description: Post a purchase order (PO) line
         is: [validate]
         body:
           application/json:
@@ -69,29 +78,11 @@ resourceTypes:
             example:
               strict: false
               value: !include acq-models/examples/composite_po_line.sample
-        responses:
-          201:
-            body:
-              application/json:
-                type: composite_po_line
-                example:
-                  strict: false
-                  value: !include acq-models/examples/composite_po_line.sample
-          400:
-            description: "Bad request"
-            body:
-              text/plain:
-                example: "Bad request"
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
-      /{polineId}:
+      /{lineId}:
         displayName: Purchace Order Line
         description: Manage purchase order line (PO line) by id
         uriParameters:
-          polineId:
+          lineId:
             description: The UUID of a purchase order line
             type: UUID
         type:

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -18,7 +18,6 @@ types:
     pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
 
 traits:
-  orderable: !include raml-util/traits/orderable.raml
   pageable: !include raml-util/traits/pageable.raml
   searchable: !include raml-util/traits/searchable.raml
   language: !include raml-util/traits/language.raml
@@ -59,3 +58,43 @@ resourceTypes:
       collection-item:
         exampleItem: !include acq-models/examples/composite_purchase_order.sample
         schema: composite_purchase_order
+    /lines:
+      displayName: Purchace Order Lines
+      post:
+        description: Post a purchase order line (PO line)
+        is: [validate]
+        body:
+          application/json:
+            type: composite_po_line
+            example:
+              strict: false
+              value: !include acq-models/examples/composite_po_line.sample
+        responses:
+          201:
+            body:
+              application/json:
+                type: composite_po_line
+                example:
+                  strict: false
+                  value: !include acq-models/examples/composite_po_line.sample
+          400:
+            description: "Bad request"
+            body:
+              text/plain:
+                example: "Bad request"
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "Internal server error"
+      /{polineId}:
+        displayName: Purchace Order Line
+        description: Manage purchase order line (PO line) by id
+        uriParameters:
+          polineId:
+            description: The UUID of a purchase order line
+            type: UUID
+        type:
+          collection-item:
+            exampleItem: !include acq-models/examples/composite_po_line.sample
+            schema: composite_po_line

--- a/src/main/java/org/folio/rest/impl/DeleteOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/DeleteOrdersByIdHelper.java
@@ -7,7 +7,7 @@ import javax.ws.rs.core.Response;
 
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.HelperUtils;
-import org.folio.rest.jaxrs.resource.Orders.GetOrdersByIdResponse;
+import org.folio.rest.jaxrs.resource.Orders.DeleteOrdersByIdResponse;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.AsyncResult;
@@ -63,16 +63,16 @@ public class DeleteOrdersByIdHelper {
       final String message = t.getMessage();
       switch (code) {
       case 404:
-        result = Future.succeededFuture(GetOrdersByIdResponse.respond404WithTextPlain(message));
+        result = Future.succeededFuture(DeleteOrdersByIdResponse.respond404WithTextPlain(message));
         break;
       case 500:
-        result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(message));
+        result = Future.succeededFuture(DeleteOrdersByIdResponse.respond500WithTextPlain(message));
         break;
       default:
-        result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(message));
+        result = Future.succeededFuture(DeleteOrdersByIdResponse.respond500WithTextPlain(message));
       }
     } else {
-      result = Future.succeededFuture(GetOrdersByIdResponse.respond500WithTextPlain(throwable.getMessage()));
+      result = Future.succeededFuture(DeleteOrdersByIdResponse.respond500WithTextPlain(throwable.getMessage()));
     }
 
     httpClient.closeClient();

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -3,7 +3,9 @@ package org.folio.rest.impl;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.resource.Orders;
 import org.folio.rest.tools.client.HttpClientFactory;
@@ -122,6 +124,30 @@ public class OrdersImpl implements Orders {
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     // TODO Auto-generated method stub
 
+  }
+
+  @Override
+  public void postOrdersLinesById(String id, CompositePoLine entity, Map<String, String> okapiHeaders,
+                                  Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("POST PO line is not implemented yet")));
+  }
+
+  @Override
+  public void getOrdersLinesByIdAndPolineId(String id, String polineId, String lang, Map<String, String> okapiHeaders,
+                                            Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("GET PO line by id is not implemented yet")));
+  }
+
+  @Override
+  public void deleteOrdersLinesByIdAndPolineId(String id, String polineId, String lang, Map<String, String> okapiHeaders,
+                                               Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("DELETE PO line by id is not implemented yet")));
+  }
+
+  @Override
+  public void putOrdersLinesByIdAndPolineId(String id, String polineId, String lang, CompositePoLine entity, Map<String, String> okapiHeaders,
+                                            Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("PUT PO line by id is not implemented yet")));
   }
 
   public static HttpClientInterface getHttpClient(Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -127,25 +127,25 @@ public class OrdersImpl implements Orders {
   }
 
   @Override
-  public void postOrdersLinesById(String id, CompositePoLine entity, Map<String, String> okapiHeaders,
+  public void postOrdersLinesById(String id, String lang, CompositePoLine entity, Map<String, String> okapiHeaders,
                                   Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("POST PO line is not implemented yet")));
   }
 
   @Override
-  public void getOrdersLinesByIdAndPolineId(String id, String polineId, String lang, Map<String, String> okapiHeaders,
+  public void getOrdersLinesByIdAndLineId(String id, String lineId, String lang, Map<String, String> okapiHeaders,
                                             Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("GET PO line by id is not implemented yet")));
   }
 
   @Override
-  public void deleteOrdersLinesByIdAndPolineId(String id, String polineId, String lang, Map<String, String> okapiHeaders,
+  public void deleteOrdersLinesByIdAndLineId(String id, String lineId, String lang, Map<String, String> okapiHeaders,
                                                Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("DELETE PO line by id is not implemented yet")));
   }
 
   @Override
-  public void putOrdersLinesByIdAndPolineId(String id, String polineId, String lang, CompositePoLine entity, Map<String, String> okapiHeaders,
+  public void putOrdersLinesByIdAndLineId(String id, String lineId, String lang, CompositePoLine entity, Map<String, String> okapiHeaders,
                                             Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     asyncResultHandler.handle(Future.failedFuture(new NotImplementedException("PUT PO line by id is not implemented yet")));
   }


### PR DESCRIPTION
- Defining PO line endpoints in raml and module descriptor files
- Defining permissions for PO line endpoints
- Adding composite PO line sample
- Add `post-item` as a resource type (post-empty-body.raml) and define request body when it is used
- Switch acq-models to latest `b0fd771` commit
- Updating News file