### PR TITLE
MODORDERS-79 Delete PO line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <mojo.java.target>1.8</mojo.java.target>
   </properties>
 
   <repositories>
@@ -260,6 +261,8 @@
           <aspectDirectory>src/main/java/org/folio/rest/annotations</aspectDirectory>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>
+          <!-- Forces re-compilation, regardless of whether the compiler arguments or the sources have changed. Useful for local re-builds. -->
+          <forceAjcCompile>true</forceAjcCompile>
           <aspectLibraries>
             <aspectLibrary>
               <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -79,10 +79,10 @@ public class HelperUtils {
   /**
    * If response http code is {@code 404}, empty {@link JsonObject} is returned. Otherwise verifies if response is successful and extracts body
    * In case there was failed attempt to delete PO or particular PO line, the sub-objects might be already partially deleted.
-   * This check allows user to retry DELETE operation
+   * This check allows user to retrieve order/line again and retry DELETE operation
    *
    * @param response response to verify
-   * @return empty {@link JsonObject} if response http code is {@code 404}, otherwise verifies if response is successful and extracts body
+   * @return empty {@link JsonObject} if response http code is {@code 404}, otherwise calls {@link #verifyAndExtractBody(Response)}
    */
   private static JsonObject verifyAndExtractBodyIfFound(Response response) {
     if (response.getCode() == 404) {

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -133,10 +133,8 @@ public class OrdersImpl implements Orders {
   @Validate
   public void deleteOrdersLinesByIdAndLineId(String orderId, String lineId, String lang, Map<String, String> okapiHeaders,
                                              Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
-    final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
-    DeleteOrderLineByIdHelper helper = new DeleteOrderLineByIdHelper(httpClient, okapiHeaders, asyncResultHandler, vertxContext);
-
-    helper.deleteLine(orderId, lineId, lang);
+    new DeleteOrderLineByIdHelper(okapiHeaders, asyncResultHandler, vertxContext)
+      .deleteLine(orderId, lineId, lang);
   }
 
   @Override


### PR DESCRIPTION
- Closing `HttpClientInterface` on success case in `DeleteOrderLineByIdHelper`
- Setting `forceAjcCompile` to `true` for `aspectj-maven-plugin`. For local re-builds the interface is recompiled each time and in some cases aspectj plugin skipps updating class files with required join points