### PR TITLE
Modorders 70 orders schema updates

### DIFF
--- a/src/main/resources/mockdata/00ed10af-fac2-46ad-9f94-a298358646a2.json
+++ b/src/main/resources/mockdata/00ed10af-fac2-46ad-9f94-a298358646a2.json
@@ -122,7 +122,7 @@
         "id": "50fb6de2-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",
@@ -259,7 +259,7 @@
         "id": "50fb6ca2-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb4a7e-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33.json
+++ b/src/main/resources/mockdata/05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33.json
@@ -122,7 +122,9 @@
         "id": "50fb71e8-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "Ro*Co films",
         "receipt_due": "2018-08-19T00:00:00.000Z",
-        "volumes": 1,
+        "volumes": [
+          "vol.1"
+        ],
         "po_line_id": "50fb53f2-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/0610be6d-0ddd-494b-b867-19f63d8b5d6d.json
+++ b/src/main/resources/mockdata/0610be6d-0ddd-494b-b867-19f63d8b5d6d.json
@@ -122,7 +122,9 @@
         "id": "50fb7be8-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "",
         "receipt_due": null,
-        "volumes": 1,
+        "volumes": [
+          "vol.1"
+        ],
         "po_line_id": "50fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/main/resources/mockdata/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -122,7 +122,7 @@
         "id": "50fb7332-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
+++ b/src/main/resources/mockdata/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
@@ -122,7 +122,9 @@
         "id": "5ee243f9-72e5-4464-bdbc-43a21873d648",
         "material_supplier": "",
         "receipt_due": "2018-09-29T00:00:00.000Z",
-        "volumes": 1,
+        "volumes": [
+          "vol. 1"
+        ],
         "po_line_id": "50fb4bfa-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",
@@ -250,7 +252,9 @@
         "id": "5ee243f9-72e5-4464-bd6c-43a21873d648",
         "material_supplier": "",
         "receipt_due": "2018-09-29T00:00:00.000Z",
-        "volumes": 1,
+        "volumes": [
+          "vol. 1"
+        ],
         "po_line_id": "50fb4e66-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",
@@ -378,7 +382,9 @@
         "id": "5ee243f9-72e5-b464-bdbc-43a21873d648",
         "material_supplier": "",
         "receipt_due": "2018-09-29T00:00:00.000Z",
-        "volumes": 1,
+        "volumes": [
+          "vol. 1"
+        ],
         "po_line_id": "50fb5168-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
+++ b/src/main/resources/mockdata/1d6a455f-29c5-4e51-84d9-e28450ef86ad.json
@@ -122,7 +122,12 @@
         "id": "50fb6f0e-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "Amazon.com",
         "receipt_due": "2018-06-01T00:00:00.000Z",
-        "volumes": 4,
+        "volumes": [
+          "vol.1",
+          "vol.2",
+          "vol.3",
+          "vol.4"
+        ],
         "po_line_id": "50fb52bc-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/55b97a4a-6601-4488-84e1-8b0d47a3f523.json
+++ b/src/main/resources/mockdata/55b97a4a-6601-4488-84e1-8b0d47a3f523.json
@@ -122,7 +122,14 @@
         "id": "50fb765c-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "Otto Harrassowitz GmbH & Co. KG",
         "receipt_due": "2018-08-31T00:00:00.000Z",
-        "volumes": 6,
+        "volumes": [
+          "vol.1",
+          "vol.2",
+          "vol.3",
+          "vol.4",
+          "vol.5",
+          "vol.6"
+        ],
         "po_line_id": "50fb5956-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/589a6016-3463-49f6-8aa2-dc315d0665fd.json
+++ b/src/main/resources/mockdata/589a6016-3463-49f6-8aa2-dc315d0665fd.json
@@ -122,7 +122,7 @@
         "id": "50fb78be-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "EBSCO SUBSCRIPTION SERVICES",
         "receipt_due": "2018-07-31T00:00:00.000Z",
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/8c328a18-5761-4329-95f6-599412c32310.json
+++ b/src/main/resources/mockdata/8c328a18-5761-4329-95f6-599412c32310.json
@@ -122,7 +122,7 @@
         "id": "50fb745e-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "Otto Harrassowitz GmbH & Co. KG",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb580c-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/9447d062-89ec-486e-a14b-572f3efb9f8c.json
+++ b/src/main/resources/mockdata/9447d062-89ec-486e-a14b-572f3efb9f8c.json
@@ -122,7 +122,7 @@
         "id": "50fb7d28-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "Amazon.com",
         "receipt_due": "2018-07-31T00:00:00.000Z",
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb6130-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/c27e60f9-6361-44c1-976e-0c4821a33a7d.json
+++ b/src/main/resources/mockdata/c27e60f9-6361-44c1-976e-0c4821a33a7d.json
@@ -122,7 +122,7 @@
         "id": "50fb7f80-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "GOBI Library Solutions",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb627a-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/e20af8c8-b07d-47a1-9ebd-f1187e9335bd.json
+++ b/src/main/resources/mockdata/e20af8c8-b07d-47a1-9ebd-f1187e9335bd.json
@@ -124,7 +124,7 @@
         "id": "50fb832c-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb64dc-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/e41e0161-2bc6-41f3-a6e7-34fc13250bf1.json
+++ b/src/main/resources/mockdata/e41e0161-2bc6-41f3-a6e7-34fc13250bf1.json
@@ -124,7 +124,7 @@
         "id": "50fb8458-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "EBSCO SUBSCRIPTION SERVICES",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb6608-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/main/resources/mockdata/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -122,7 +122,7 @@
         "id": "50fb81ec-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "GOBI Library Solutions",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb63b0-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/main/resources/mockdata/f4dc647c-ec82-442e-b13d-f9505b7ce8e9.json
+++ b/src/main/resources/mockdata/f4dc647c-ec82-442e-b13d-f9505b7ce8e9.json
@@ -122,7 +122,7 @@
         "id": "50fb857a-cdf1-11e8-a8d5-f2801f1b9fd1",
         "material_supplier": "",
         "receipt_due": null,
-        "volumes": 0,
+        "volumes": [],
         "po_line_id": "50fb695a-cdf1-11e8-a8d5-f2801f1b9fd1"
       },
       "po_line_description": "",

--- a/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -96,7 +96,7 @@
     "id": "617f33a4-40dd-48fc-86e0-648cd5b5c1bc",
     "material_supplier": "6828d7cb-d84e-41e5-9db5-fc2e162f9ffb",
     "receipt_due": "2018-07-31T00:00:00.000Z",
-    "volumes": 0,
+    "volumes": [],
     "po_line_id": "0009662b-8b80-4001-b704-ca10971f175d"
   },
   "po_line_description": "",

--- a/src/test/resources/mockdata/compositeLines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
+++ b/src/test/resources/mockdata/compositeLines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
@@ -107,7 +107,9 @@
   "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "payment_status": "Awaiting Payment",
   "physical": {
-    "volumes": 1,
+    "volumes": [
+      "vol. 1"
+    ],
     "id": "5ee243f9-72e5-4464-bdbc-43a21873d648",
     "material_supplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
     "receipt_due": "2018-10-10T00:00:00.000Z",

--- a/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -96,7 +96,7 @@
     "id": "50fb81ec-cdf1-11e8-a8d5-f2801f1b9fd1",
     "material_supplier": "GOBI Library Solutions",
     "receipt_due": null,
-    "volumes": 0,
+    "volumes": [],
     "po_line_id": "c2755a78-2f8d-47d0-a218-059a9b7391b4"
   },
   "po_line_description": "",

--- a/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
+++ b/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
@@ -96,7 +96,9 @@
     "id": "2f8ad479-1137-45d8-aee8-4b79e9a8e7ff",
     "material_supplier": "1c9a6406-dc14-46cc-8777-5199d791c21f",
     "receipt_due": "2018-09-29T00:00:00.000Z",
-    "volumes": 1,
+    "volumes": [
+      "vol. 1"
+    ],
     "po_line_id": "fca5fa9e-15cb-4a3d-ab09-eeea99b97a47"
   },
   "po_line_description": "",

--- a/src/test/resources/po_listed_print_monograph.json
+++ b/src/test/resources/po_listed_print_monograph.json
@@ -105,7 +105,9 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "payment_status": "Awaiting Payment",
       "physical": {
-        "volumes": 1,
+        "volumes": [
+          "vol.1"
+        ],
         "material_supplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
         "receipt_due": "2018-10-10T00:00:00.000Z"
       },

--- a/src/test/resources/po_listed_print_serial.json
+++ b/src/test/resources/po_listed_print_serial.json
@@ -104,7 +104,9 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "payment_status": "Awaiting Payment",
       "physical": {
-        "volumes": 1,
+        "volumes": [
+          "vol.1"
+        ],
         "id": "5ee243f9-72e5-4464-bdbc-43a21873d648",
         "material_supplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
         "receipt_due": "2018-10-10T00:00:00.000Z"
@@ -123,7 +125,7 @@
         "manual_renewal": true,
         "review_period": 30,
         "renewal_date": "2019-04-09T00:00:00.000Z"
-      },      
+      },
       "reporting_codes": [
         {
           "code": "CODE1",


### PR DESCRIPTION
## Purpose
The module needs to be updated to use the latest acquisitions schema in order to be able to proceed with implementation of new features.

## Approach

- update acq-models submodule to point to the latest commit
- update mock data to be consistent with the new schema

#### TODOS and Open Questions

- move mock data to test resources and remove all the samples which are not used in tests