### PR TITLE
Modorders 89- /orders/po_number/validate endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
  * [MODORDERS-78](https://issues.folio.org/browse/MODORDERS-78) - Implemented GET order line logic
  * [MODORDERS-77](https://issues.folio.org/browse/MODORDERS-77) - Implemented PUT order line logic
  * [MODORDERS-76](https://issues.folio.org/browse/MODORDERS-76) - Implemented POST order line logic
+ * [MODORDERS-89](https://issues.folio.org/browse/MODORDERS-89) - New API to validate PO Number
 ## 1.0.2
  * [MODORDERS-79](https://issues.folio.org/browse/MODORDERS-79) - Implemented delete order line logic
  * [MODORDERS-75](https://issues.folio.org/browse/MODORDERS-75) - Define order line endpoints

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -231,6 +231,14 @@
             "orders-storage.sources.item.delete",
             "orders-storage.vendor_details.item.delete"
           ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/orders/po_number/validate",
+          "permissionsRequired": ["orders.po_number.item.post"],
+          "modulePermissions": [
+            "orders-storage.purchase_orders.item.get"
+          ]
         }
       ]
     }
@@ -351,6 +359,11 @@
       "description": "Delete an existing PO line"
     },
     {
+      "permissionName": "orders.po_number.item.post",
+      "displayName": "Orders - validate a PO Number",
+      "description": "Validate a PO Number"
+    },
+    {
       "permissionName": "orders.all",
       "displayName": "orders - all permissions",
       "description": "Entire set of permissions needed to use orders",
@@ -362,7 +375,8 @@
         "orders.po_lines.item.post",
         "orders.po_lines.item.get",
         "orders.po_lines.item.put",
-        "orders.po_lines.item.delete"
+        "orders.po_lines.item.delete",
+        "orders.po_number.item.post"
       ]
     }
   ],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -234,8 +234,8 @@
         },
         {
           "methods": ["POST"],
-          "pathPattern": "/orders/po_number/validate",
-          "permissionsRequired": ["orders.po_number.item.post"],
+          "pathPattern": "/orders/po-number/validate",
+          "permissionsRequired": ["orders.po-number.item.post"],
           "modulePermissions": [
             "orders-storage.purchase_orders.item.get"
           ]
@@ -359,7 +359,7 @@
       "description": "Delete an existing PO line"
     },
     {
-      "permissionName": "orders.po_number.item.post",
+      "permissionName": "orders.po-number.item.post",
       "displayName": "Orders - validate a PO Number",
       "description": "Validate a PO Number"
     },
@@ -376,7 +376,7 @@
         "orders.po_lines.item.get",
         "orders.po_lines.item.put",
         "orders.po_lines.item.delete",
-        "orders.po_number.item.post"
+        "orders.po-number.item.post"
       ]
     }
   ],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -237,7 +237,7 @@
           "pathPattern": "/orders/po-number/validate",
           "permissionsRequired": ["orders.po-number.item.post"],
           "modulePermissions": [
-            "orders-storage.purchase_orders.item.get"
+            "orders-storage.purchase_orders.collection.get"
           ]
         }
       ]

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -53,15 +53,11 @@ resourceTypes:
           strict: false
           value: !include acq-models/examples/composite_purchase_order.sample
   /po_number/validate:
-     type:
-        post-item:
-          exampleItem: !include acq-models/mod-orders-storage/examples/po_number_get.sample
-          schema: po_number
       
      displayName: PO Number Validation
      post:
         description: validate if the PO Number is unique and matches the pattern specified
-        is: [validate, auth]
+        is: [validate, auth , language]
         body:
           application/json:
             type: po_number

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -13,6 +13,7 @@ types:
   composite_purchase_order: !include acq-models/composite_purchase_order.json
   po_line: !include acq-models/composite_po_line.json
   errors: !include raml-util/schemas/errors.schema
+  po_number: !include acq-models/mod-orders-storage/schemas/po_number.json
   UUID:
     type: string
     pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
@@ -51,7 +52,33 @@ resourceTypes:
         example:
           strict: false
           value: !include acq-models/examples/composite_purchase_order.sample
-
+  /po_number/validate:
+     type:
+        post-item:
+          exampleItem: !include acq-models/examples/composite_purchase_order.sample
+          schema: po_number
+      
+     displayName: PO Number Validation
+     post:
+        description: validate a PO Number to be valid and unique
+        is: [validate, auth]
+        body:
+          application/json:
+            type: po_number
+        responses:
+          204:
+            description: "Valid PO_Number"
+          400:
+            description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+            body:
+              text/plain:
+                example: |
+                  "unable to add <<resourcePathName|!singularize>> -- malformed JSON at 13:3"
+          500:
+            description: "Internal server error, e.g. due to misconfiguration"
+            body:
+              text/plain:
+                example: "Internal server error, contact administrator"
   /{id}:
     uriParameters:
       id:
@@ -65,7 +92,7 @@ resourceTypes:
       description: Update an order by id
       is: [validate]
     /lines:
-      displayName: Purchace Order Lines
+      displayName: Purchase Order Lines
       description: Manage purchase order (PO) lines
       type:
         # Using `post-item` resource type because at the moment only POST is required. In case GET becomes also required, the `collection` resource type should be used instead

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -13,7 +13,7 @@ types:
   composite_purchase_order: !include acq-models/composite_purchase_order.json
   po_line: !include acq-models/composite_po_line.json
   errors: !include raml-util/schemas/errors.schema
-  po_number: !include acq-models/mod-orders-storage/schemas/po_number.json
+  po-number: !include acq-models/mod-orders-storage/schemas/po_number.json
   UUID:
     type: string
     pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
@@ -52,7 +52,7 @@ resourceTypes:
         example:
           strict: false
           value: !include acq-models/examples/composite_purchase_order.sample
-  /po_number/validate:
+  /po-number/validate:
       
      displayName: PO Number Validation
      post:
@@ -60,10 +60,10 @@ resourceTypes:
         is: [validate, auth , language]
         body:
           application/json:
-            type: po_number
+            type: po-number
         responses:
           204:
-            description: "Valid PO_Number"
+            description: "Valid PO Number"
           400:
             description: "Bad request, e.g. existing PO Number. Details of the error provided in the response."
             body:

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -69,7 +69,7 @@ resourceTypes:
           204:
             description: "Valid PO_Number"
           400:
-            description: "Bad request, e.g. malformed request body or query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+            description: "Bad request, e.g. existing PO Number. Details of the error provided in the response."
             body:
               text/plain:
                 example: |

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -60,7 +60,7 @@ resourceTypes:
       
      displayName: PO Number Validation
      post:
-        description: validate if the PO Number is unique and macthes the pattern specified
+        description: validate if the PO Number is unique and matches the pattern specified
         is: [validate, auth]
         body:
           application/json:

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -55,12 +55,12 @@ resourceTypes:
   /po_number/validate:
      type:
         post-item:
-          exampleItem: !include acq-models/examples/composite_purchase_order.sample
+          exampleItem: !include acq-models/mod-orders-storage/examples/po_number_get.sample
           schema: po_number
       
      displayName: PO Number Validation
      post:
-        description: validate a PO Number to be valid and unique
+        description: validate if the PO Number is unique and macthes the pattern specified
         is: [validate, auth]
         body:
           application/json:

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -385,7 +385,7 @@ public class HelperUtils {
   }
 
   public static boolean isPOValid(PoNumber entity) {
-    return PONUMBER_PATTERN.matcher(entity.getId()).matches();
+    return PONUMBER_PATTERN.matcher(entity.getPoNumber()).matches();
   }
 
 }

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -11,6 +11,7 @@ import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.rest.client.ConfigurationsClient;
 import org.folio.rest.jaxrs.model.Adjustment;
 import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.PoNumber;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
@@ -29,12 +30,14 @@ import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 
 public class HelperUtils {
 
+  private static final Pattern PONUMBER_PATTERN = Pattern.compile("^[a-zA-Z0-9]{5,16}$");
   public static final String DEFAULT_POLINE_LIMIT = "500";
   public static final String OKAPI_URL = "X-Okapi-Url";
   public static final String PO_LINES_LIMIT_PROPERTY = "poLines-limit";
   public static final String URL_WITH_LANG_PARAM = "%s?lang=%s";
   public static final String GET_ALL_POLINES_QUERY_WITH_LIMIT = resourcesPath(PO_LINES)+"?limit=%s&query=purchase_order_id==%s&lang=%s";
-  public static final String GET_ALL_PURCHASE_ORDER_QUERY = resourceByIdPath(PURCHASE_ORDER)+URL_WITH_LANG_PARAM;
+  public static final String GET_PURCHASE_ORDER_BYID = resourceByIdPath(PURCHASE_ORDER)+URL_WITH_LANG_PARAM;
+  public static final String GET_PURCHASE_ORDER_BYPONUMBER_QUERY = resourcesPath(PURCHASE_ORDER)+"?query=po_number==%s&lang=%s";
 
 
   private static final int DEFAULT_PORT = 9130;
@@ -87,11 +90,18 @@ public class HelperUtils {
     return (a + b);
   }
 
-  public static CompletableFuture<JsonObject> getPurchaseOrder(String id, String lang, HttpClientInterface httpClient, Context ctx,
+  public static CompletableFuture<JsonObject> getPurchaseOrderById(String id, String lang, HttpClientInterface httpClient, Context ctx,
                                                                Map<String, String> okapiHeaders, Logger logger) {
-    String endpoint = String.format(GET_ALL_PURCHASE_ORDER_QUERY, id, lang);
+    String endpoint = String.format(GET_PURCHASE_ORDER_BYID, id, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger);
   }
+
+  public static CompletableFuture<JsonObject> getPurchaseOrderByPONumber(String poNumber, String lang, HttpClientInterface httpClient, Context ctx,
+      Map<String, String> okapiHeaders, Logger logger) {
+      String endpoint = String.format(GET_PURCHASE_ORDER_BYPONUMBER_QUERY, poNumber, lang);
+      return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger);
+  }
+
 
   /**
    *  Retrieves PO lines from storage by PO id as JsonObject with array of po_lines (/acq-models/mod-orders-storage/schemas/po_line.json objects)
@@ -373,4 +383,9 @@ public class HelperUtils {
     }
     return future;
   }
+
+  public static boolean isPOValid(PoNumber entity) {
+    return PONUMBER_PATTERN.matcher(entity.getId()).matches();
+  }
+
 }

--- a/src/main/java/org/folio/rest/impl/GetOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersByIdHelper.java
@@ -57,7 +57,7 @@ public class GetOrdersByIdHelper {
   private CompletableFuture<CompositePurchaseOrder> getCompositePurchaseOrderById(String id, String lang) {
     CompletableFuture<CompositePurchaseOrder> future = new VertxCompletableFuture<>(ctx);
 
-    HelperUtils.getPurchaseOrder(id, lang, httpClient, ctx, okapiHeaders, logger)
+    HelperUtils.getPurchaseOrderById(id, lang, httpClient, ctx, okapiHeaders, logger)
       .thenAccept(po -> {
         logger.info("got: " + po.encodePrettily());
         po.remove("adjustment");

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -30,8 +30,6 @@ import static org.folio.orders.utils.HelperUtils.OKAPI_URL;
 import static org.folio.orders.utils.HelperUtils.PO_LINES_LIMIT_PROPERTY;
 import static org.folio.orders.utils.HelperUtils.handleGetRequest;
 import static org.folio.orders.utils.HelperUtils.loadConfiguration;
-import static org.folio.orders.utils.HelperUtils.isPOValid;
-import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 import static io.vertx.core.Future.succeededFuture;
@@ -251,5 +249,6 @@ public class OrdersImpl implements Orders {
       throw new CompletionException("Invalid limit value in configuration.", e);
     }
   }
+
 }
 

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -226,15 +226,15 @@ public class OrdersImpl implements Orders {
   }
 
   @Override
+  @Validate
   public void postOrdersPoNumberValidate(String lang, PoNumber entity, Map<String, String> okapiHeaders,
      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
     ValidationHelper helper=new ValidationHelper(httpClient, okapiHeaders, asyncResultHandler, vertxContext);
     logger.info("Validating a PO Number");
-    if(isPOValid(entity))
+    //@Validate asserts the pattern of a PO Number, the below method is used to check for uniqueness
      helper.checkPONumberUnique(entity, lang);
-    else
-     asyncResultHandler.handle(succeededFuture(PostOrdersPoNumberValidateResponse.respond400WithTextPlain("PO Number must match the pattern")));
+
   }
 
   public static HttpClientInterface getHttpClient(Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -251,9 +251,5 @@ public class OrdersImpl implements Orders {
       throw new CompletionException("Invalid limit value in configuration.", e);
     }
   }
-
-
-
-
 }
 

--- a/src/main/java/org/folio/rest/impl/ValidationHelper.java
+++ b/src/main/java/org/folio/rest/impl/ValidationHelper.java
@@ -24,6 +24,8 @@ import io.vertx.core.logging.LoggerFactory;
 
 public class ValidationHelper {
 
+  private static final String PO_NUMBER_MUST_BE_UNIQUE = "PO Number must be unique";
+
   private static final Logger logger = LoggerFactory.getLogger(ValidationHelper.class);
 
   private final HttpClientInterface httpClient;
@@ -41,14 +43,15 @@ public class ValidationHelper {
 
   void checkPONumberUnique(PoNumber poNumber,String lang)
   {
-    getPurchaseOrderByPONumber(poNumber.getPoNumber(), lang, httpClient, ctx, okapiHeaders, logger).thenAccept(po->{
-    if(po.getInteger("total_records")==0)
-      asyncResultHandler.handle(succeededFuture(respond204()));
-    else
-      asyncResultHandler.handle(succeededFuture(respond400WithTextPlain("PO Number must be unique")));
-    httpClient.closeClient();
-  })
-  .exceptionally(this::handleResponse);
+    getPurchaseOrderByPONumber(poNumber.getPoNumber(), lang, httpClient, ctx, okapiHeaders, logger)
+    .thenAccept(po->{
+       if(po.getInteger("total_records")==0)
+         asyncResultHandler.handle(succeededFuture(respond204()));
+       else
+         asyncResultHandler.handle(succeededFuture(respond400WithTextPlain(PO_NUMBER_MUST_BE_UNIQUE)));
+      httpClient.closeClient();
+     })
+    .exceptionally(this::handleResponse);
   }
 
   public Void handleResponse(Throwable throwable) {

--- a/src/main/java/org/folio/rest/impl/ValidationHelper.java
+++ b/src/main/java/org/folio/rest/impl/ValidationHelper.java
@@ -1,0 +1,80 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.orders.utils.HelperUtils.getPurchaseOrderByPONumber;
+import static org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse.*;
+
+import java.util.Map;
+
+import org.folio.orders.rest.exceptions.HttpException;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.PoNumber;
+import org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class ValidationHelper {
+
+  private static final Logger logger = LoggerFactory.getLogger(ValidationHelper.class);
+
+  private final HttpClientInterface httpClient;
+  private final Context ctx;
+  private final Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler;
+  private final Map<String, String> okapiHeaders;
+
+  public ValidationHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context ctx) {
+    this.httpClient = httpClient;
+    this.okapiHeaders = okapiHeaders;
+    this.ctx = ctx;
+    this.asyncResultHandler = asyncResultHandler;
+  }
+
+  void checkPONumberUnique(PoNumber poNumber,String lang)
+  {
+    getPurchaseOrderByPONumber(poNumber.getId(), lang, httpClient, ctx, okapiHeaders, logger).thenAccept(po->{
+    if(po.getInteger("total_records")==0)
+      asyncResultHandler.handle(succeededFuture(respond204()));
+    else
+      asyncResultHandler.handle(succeededFuture(respond400WithTextPlain("PO Number already exists")));
+    httpClient.closeClient();
+  })
+  .exceptionally(this::handleResponse);
+  }
+
+  public Void handleResponse(Throwable throwable) {
+    final Future<javax.ws.rs.core.Response> result;
+
+    final Throwable t = throwable.getCause();
+    if (t instanceof HttpException) {
+      final int code = ((HttpException) t).getCode();
+      final String message = t.getMessage();
+      switch (code) {
+      case 400:
+        result = Future.succeededFuture(respond400WithTextPlain(message));
+        break;
+      case 422:
+        Errors errors = new Errors();
+        errors.getErrors().add(new Error().withMessage(message));
+        result = Future.succeededFuture(respond422WithApplicationJson(errors));
+        break;
+      default:
+        result = Future.succeededFuture(respond500WithTextPlain(message));
+      }
+    } else {
+      result = Future.succeededFuture(respond500WithTextPlain(throwable.getMessage()));
+    }
+
+    httpClient.closeClient();
+    asyncResultHandler.handle(result);
+
+    return null;
+  }
+}

--- a/src/main/java/org/folio/rest/impl/ValidationHelper.java
+++ b/src/main/java/org/folio/rest/impl/ValidationHelper.java
@@ -2,7 +2,10 @@ package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.orders.utils.HelperUtils.getPurchaseOrderByPONumber;
-import static org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse.*;
+import static org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse.respond204;
+import static org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse.respond400WithTextPlain;
+import static org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse.respond422WithApplicationJson;
+import static org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse.respond500WithTextPlain;
 
 import java.util.Map;
 
@@ -10,7 +13,6 @@ import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.PoNumber;
-import org.folio.rest.jaxrs.resource.Orders.PostOrdersPoNumberValidateResponse;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.AsyncResult;

--- a/src/main/java/org/folio/rest/impl/ValidationHelper.java
+++ b/src/main/java/org/folio/rest/impl/ValidationHelper.java
@@ -41,11 +41,11 @@ public class ValidationHelper {
 
   void checkPONumberUnique(PoNumber poNumber,String lang)
   {
-    getPurchaseOrderByPONumber(poNumber.getId(), lang, httpClient, ctx, okapiHeaders, logger).thenAccept(po->{
+    getPurchaseOrderByPONumber(poNumber.getPoNumber(), lang, httpClient, ctx, okapiHeaders, logger).thenAccept(po->{
     if(po.getInteger("total_records")==0)
       asyncResultHandler.handle(succeededFuture(respond204()));
     else
-      asyncResultHandler.handle(succeededFuture(respond400WithTextPlain("PO Number already exists")));
+      asyncResultHandler.handle(succeededFuture(respond400WithTextPlain("PO Number must be unique")));
     httpClient.closeClient();
   })
   .exceptionally(this::handleResponse);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1316,8 +1316,7 @@ public class OrdersImplTest {
   public void testPoNumberValidate()
   {
     JsonObject poNumber=new JsonObject("{\"id\": \"dasdas\"}");
-
-    verifyPostResponse(PONUMBER_VALIDATE_PATH, poNumber.encodePrettily(), EXIST_CONFIG_X_OKAPI_TENANT, "PO Number must match the pattern", 400);
+    verifyPostResponse(PONUMBER_VALIDATE_PATH, poNumber.encodePrettily(), EXIST_CONFIG_X_OKAPI_TENANT, "", 204);
   }
 
   private org.folio.rest.acq.model.PoLine getMockLine(String id) {
@@ -1427,6 +1426,7 @@ public class OrdersImplTest {
       router.route(HttpMethod.POST, resourcesPath(VENDOR_DETAIL)).handler(ctx -> handlePostGenericSubObj(ctx, VENDOR_DETAIL));
 
       router.route(HttpMethod.GET, resourcesPath(PURCHASE_ORDER)+"/:id").handler(this::handleGetPurchaseOrderById);
+      router.route(HttpMethod.GET, resourcesPath(PURCHASE_ORDER)+"?query=po_number==dasdas&lang=en").handler(this::handleGetPurchaseOrderById);
       router.route(HttpMethod.GET, "/instance-types").handler(ctx -> handleGetInstanceType(ctx));
       router.route(HttpMethod.GET, "/instance-statuses").handler(ctx -> handleGetInstanceStatus(ctx));
       router.route(HttpMethod.GET, "/identifier-types").handler(ctx -> handleGetIdentifierType(ctx));
@@ -1478,6 +1478,7 @@ public class OrdersImplTest {
 
       router.get("/configurations/entries").handler(this::handleConfigurationModuleResponse);
 
+        router.getRoutes().stream().forEach(System.out::println);
       return router;
     }
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -29,15 +29,12 @@ import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.PoLine;
-import org.folio.rest.jaxrs.model.PoNumber;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.raml.v2.api.model.v08.bodies.JSONBody;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -1810,6 +1807,7 @@ public class OrdersImplTest {
         po.put(TOTAL_RECORDS, 0);
         break;
       default:
+         //modify later as needed
          po.put(TOTAL_RECORDS, 0);
       }
       addServerRqRsData(HttpMethod.GET, PURCHASE_ORDER, po);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -150,6 +150,9 @@ public class OrdersImplTest {
   private static final String PURCHASE_ORDER_ID = "purchase_order_id";
   private static final String INCORRECT_LANG_PARAMETER = "'lang' parameter is incorrect. parameter value {english} is not valid: must match \"[a-zA-Z]{2}\"";
   private static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
+  private static final String EXISTING_PO_NUMBER = "oldPoNumber";
+  private static final String NONEXISTING_PO_NUMBER = "newPoNumber";
+
 
   private static Vertx vertx;
   private static MockServer mockServer;
@@ -1313,10 +1316,28 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPoNumberValidate()
+  public void testPoNumberValidatewithExistingPONumber()
   {
-    JsonObject poNumber=new JsonObject("{\"id\": \"dasdas\"}");
+    JsonObject poNumber=new JsonObject();
+    poNumber.put("po_number", EXISTING_PO_NUMBER);
+    verifyPostResponse(PONUMBER_VALIDATE_PATH, poNumber.encodePrettily(), EXIST_CONFIG_X_OKAPI_TENANT, TEXT_PLAIN, 400);
+  }
+
+
+  @Test
+  public void testPoNumberValidatewithUniquePONumber()
+  {
+    JsonObject poNumber=new JsonObject();
+    poNumber.put("po_number", NONEXISTING_PO_NUMBER);
     verifyPostResponse(PONUMBER_VALIDATE_PATH, poNumber.encodePrettily(), EXIST_CONFIG_X_OKAPI_TENANT, "", 204);
+  }
+
+  @Test
+  public void testPoNumberValidatewithInvalidPattern()
+  {
+    JsonObject poNumber=new JsonObject();
+    poNumber.put("po_number", "11");
+    verifyPostResponse(PONUMBER_VALIDATE_PATH, poNumber.encodePrettily(), EXIST_CONFIG_X_OKAPI_TENANT, APPLICATION_JSON, 422);
   }
 
   private org.folio.rest.acq.model.PoLine getMockLine(String id) {
@@ -1383,6 +1404,7 @@ public class OrdersImplTest {
 
   public static class MockServer {
 
+    private static final String TOTAL_RECORDS = "total_records";
     static Table<String, HttpMethod, List<JsonObject>> serverRqRs = HashBasedTable.create();
     private static final Logger logger = LoggerFactory.getLogger(MockServer.class);
 
@@ -1426,7 +1448,7 @@ public class OrdersImplTest {
       router.route(HttpMethod.POST, resourcesPath(VENDOR_DETAIL)).handler(ctx -> handlePostGenericSubObj(ctx, VENDOR_DETAIL));
 
       router.route(HttpMethod.GET, resourcesPath(PURCHASE_ORDER)+"/:id").handler(this::handleGetPurchaseOrderById);
-      router.route(HttpMethod.GET, resourcesPath(PURCHASE_ORDER)+"?query=po_number==dasdas&lang=en").handler(this::handleGetPurchaseOrderById);
+      router.route(HttpMethod.GET, resourcesPath(PURCHASE_ORDER)).handler(this::handleGetPurchaseOrderByQuery);
       router.route(HttpMethod.GET, "/instance-types").handler(ctx -> handleGetInstanceType(ctx));
       router.route(HttpMethod.GET, "/instance-statuses").handler(ctx -> handleGetInstanceStatus(ctx));
       router.route(HttpMethod.GET, "/identifier-types").handler(ctx -> handleGetIdentifierType(ctx));
@@ -1477,8 +1499,6 @@ public class OrdersImplTest {
       router.route(HttpMethod.DELETE, resourcePath(FUND_DISTRIBUTION)).handler(ctx -> handleDeleteGenericSubObj(ctx, FUND_DISTRIBUTION));
 
       router.get("/configurations/entries").handler(this::handleConfigurationModuleResponse);
-
-        router.getRoutes().stream().forEach(System.out::println);
       return router;
     }
 
@@ -1639,9 +1659,9 @@ public class OrdersImplTest {
             .put("first", 0)
             .put("last", lines.size());
           if (EMPTY_CONFIG_TENANT.equals(tenant)) {
-            po_lines.put("total_records", Integer.parseInt(DEFAULT_POLINE_LIMIT));
+            po_lines.put(TOTAL_RECORDS, Integer.parseInt(DEFAULT_POLINE_LIMIT));
           } else {
-            po_lines.put("total_records", lines.size());
+            po_lines.put(TOTAL_RECORDS, lines.size());
           }
 
 
@@ -1773,6 +1793,27 @@ public class OrdersImplTest {
           .setStatusCode(404)
           .end(id);
       }
+    }
+
+    private void handleGetPurchaseOrderByQuery(RoutingContext ctx) {
+
+      JsonObject po;
+      po = new JsonObject();
+      String queryParam = ctx.request().getParam("query");
+      addServerRqRsData(HttpMethod.GET, PURCHASE_ORDER, po);
+      final String PO_NUMBER_QUERY = "po_number==";
+      switch (queryParam) {
+      case PO_NUMBER_QUERY+EXISTING_PO_NUMBER:
+        po.put(TOTAL_RECORDS, 1);
+        break;
+      case PO_NUMBER_QUERY+NONEXISTING_PO_NUMBER:
+        po.put(TOTAL_RECORDS, 0);
+        break;
+      default:
+         po.put(TOTAL_RECORDS, 0);
+      }
+      addServerRqRsData(HttpMethod.GET, PURCHASE_ORDER, po);
+      serverResponse(ctx, 200, APPLICATION_JSON, po.encodePrettily());
     }
 
     private void handlePostPurchaseOrder(RoutingContext ctx) {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -29,12 +29,14 @@ import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.PoNumber;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.raml.v2.api.model.v08.bodies.JSONBody;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -119,7 +121,7 @@ public class OrdersImplTest {
   private static final String PO_LINE_ID_WITH_FUND_DISTRIBUTION_404_CODE = "f7223ce8-9e92-4c28-8fd9-097596053b7c";
 
   // API paths
-  private final String rootPath = "/orders";
+  private final static String rootPath = "/orders";
   private final static String LINES_PATH = "/orders/%s/lines";
   private final static String LINE_BY_ID_PATH = "/orders/%s/lines/%s";
 
@@ -141,6 +143,8 @@ public class OrdersImplTest {
   private static final String CONFIG_MOCK_PATH = BASE_MOCK_DATA_PATH + "configurations.entries/%s.json";
 
   private static final String EMPTY_PO_LINE_BUT_WITH_IDS = "{\"id\": \"%s\", \"purchase_order_id\": \"%s\"}";
+
+  private static final String PONUMBER_VALIDATE_PATH=rootPath+"/po_number/validate";
 
   private static final String ID = "id";
   private static final String PURCHASE_ORDER_ID = "purchase_order_id";
@@ -1306,6 +1310,14 @@ public class OrdersImplTest {
       Object value = entry.getValue();
       assertTrue(Objects.isNull(value) || (value instanceof Iterable && !((Iterable) value).iterator().hasNext()));
     });
+  }
+
+  @Test
+  public void testPoNumberValidate()
+  {
+    JsonObject poNumber=new JsonObject("{\"id\": \"dasdas\"}");
+
+    verifyPostResponse(PONUMBER_VALIDATE_PATH, poNumber.encodePrettily(), EXIST_CONFIG_X_OKAPI_TENANT, "PO Number must match the pattern", 400);
   }
 
   private org.folio.rest.acq.model.PoLine getMockLine(String id) {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -141,7 +141,7 @@ public class OrdersImplTest {
 
   private static final String EMPTY_PO_LINE_BUT_WITH_IDS = "{\"id\": \"%s\", \"purchase_order_id\": \"%s\"}";
 
-  private static final String PONUMBER_VALIDATE_PATH=rootPath+"/po_number/validate";
+  private static final String PONUMBER_VALIDATE_PATH=rootPath+"/po-number/validate";
 
   private static final String ID = "id";
   private static final String PURCHASE_ORDER_ID = "purchase_order_id";


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDERS-89
## Purpose
Adding a new end point to validate a PO Number to ensure a user entered PO Number is unique and matches the pattern 5-16 alphanumeric characters

## Approach
Using the RMB specified @validate annotation to ensure it follows the pattern specified in the acq models
A call to the /orders-storage/purchase-orders endpoint to check if the entered PO number is distinct. 