### PR TITLE
MODORDERS-69 fix how location header is parsed and unit test

### DIFF
--- a/src/main/java/org/folio/rest/impl/PostOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrderLineHelper.java
@@ -192,7 +192,7 @@ public class PostOrderLineHelper extends AbstractOrderLineHelper  {
             })
             .thenApply(response -> {
               String location = response.getHeaders().get(LOCATION_HEADER);
-              return location.substring(location.lastIndexOf('/'));
+              return location.substring(location.lastIndexOf('/')+1);
             });
         } catch (Exception e) {
           throw new CompletionException(e);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -603,8 +603,23 @@ public class OrdersImplTest {
 
     CompositePurchaseOrder orderRq = reqData.mapTo(CompositePurchaseOrder.class);
     for (int i = 0; i < orderRq.getPoLines().size(); i++) {
-      JsonObject instance = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.POST).get(i);
-      verifyInstanceRecordRequest(instance, orderRq.getPoLines().get(i));
+      PoLine pol = orderRq.getPoLines().get(i);
+
+      boolean verified = false;
+      // note we can't rely on the order being the same!
+      for (int j = 0; j < MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.POST).size(); j++) {
+        JsonObject instance = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.POST).get(j);
+
+        if (pol.getTitle().equals(instance.getString("title"))) {
+          verifyInstanceRecordRequest(instance, pol);
+          verified = true;
+          break;
+        }
+      }
+
+      if (!verified) {
+        fail("No matching instance for POL: " + JsonObject.mapFrom(pol).encodePrettily());
+      }
     }
   }
 
@@ -1477,7 +1492,7 @@ public class OrdersImplTest {
       ctx.response()
         .setStatusCode(201)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .putHeader(HttpHeaders.LOCATION, ctx.request().absoluteURI() + "/11111-22222-33333-44444")
+        .putHeader(HttpHeaders.LOCATION, ctx.request().absoluteURI() + "/" + UUID.randomUUID().toString())
         .end();
     }
 


### PR DESCRIPTION
## Purpose
Calling POST /orders with an open purchase order (single POL for something that didn't exist in inventory) we currently get a 422:

```
{
  "errors" : [ {
    "message" : "{\"errors\":[{\"message\":\"must match \\\"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$\\\"\",\"type\":\"1\",\"code\":\"-1\",\"parameters\":[{\"key\":\"instanceId\",\"value\":\"/88f80ba8-7d68-4c0f-a7bd-c820123065c9\"}]}]}",
    "parameters" : [ ]
  } ]
}
```
However, it appears the instance is created. Repeating the exact same call yields a 201 created. As expected, a duplicate instance is NOT created.

The problem is that there's a leading '/' in the instanceId value (from the error message). This would cause the UUID regex pattern check to fail.

See recent comments in [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) comments for details.

## Approach
The leading slash is a product of how we're parsing the Location header of to obtain the instanceId.  Adjusting the substring offset by 1 solves the problem.

## Notes
While working on this I noticed intermittent unit test failures due to reliance on the order in which the instance records are added to the `serverRqRs` table being consistent.  This assumption is flawed given the asynchronous nature of how the instance records are created.  I added logic to the offending test that identifies the appropriate instance before verifying it against the pol fields.