### PR TITLE
MODORDERS-131 - Release 2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,37 @@
-## 1.1.0 - unreleased
+## 2.0.0 - Released
+
+This primary focus of this release was to implement backend logic necessary for ui-orders to manage (Create, Read, Update, Delete) purchase orders and purchase order lines.
+
+NOTE: This was originally slated to be v1.1.0, but given the amount of changes made to the API, the major version number was bumped.
+
+### Stories
  * [MODORDERS-95](https://issues.folio.org/browse/MODORDERS-95) - Upgrade to RMB v23.3.0 to enable path parameters pattern validation
+ * [MODORDERS-94](https://issues.folio.org/browse/MODORDERS-94) - Improved implementation of PUT /orders/id
+ * [MODORDERS-92](https://issues.folio.org/browse/MODORDERS-92) - Add the ability to specify a reason for closure
+ * [MODORDERS-91](https://issues.folio.org/browse/MODORDERS-91) - Limit number of po_lines per purchase_order
+ * [MODORDERS-90](https://issues.folio.org/browse/MODORDERS-90) - Update receiving and check-in schemas
+ * [MODORDERS-89](https://issues.folio.org/browse/MODORDERS-89) - New API to validate PO Number
+ * [MODORDERS-88](https://issues.folio.org/browse/MODORDERS-88) - Honor 'po_number' if passed in during order placement
+ * [MODORDERS-85](https://issues.folio.org/browse/MODORDERS-85) - Move 'renewals' to purchase_order
+ * [MODORDERS-83](https://issues.folio.org/browse/MODORDERS-83) - Set the 'created_on' field automatically
+ * [MODORDERS-79](https://issues.folio.org/browse/MODORDERS-79) - Implemented GET order line logic
  * [MODORDERS-78](https://issues.folio.org/browse/MODORDERS-78) - Implemented GET order line logic
  * [MODORDERS-77](https://issues.folio.org/browse/MODORDERS-77) - Implemented PUT order line logic
  * [MODORDERS-76](https://issues.folio.org/browse/MODORDERS-76) - Implemented POST order line logic
- * [MODORDERS-89](https://issues.folio.org/browse/MODORDERS-89) - New API to validate PO Number
-## 1.0.2
+ * [MODORDERS-70](https://issues.folio.org/browse/MODORDERS-70) - Various po_line schema updates
+ * [MODORDERS-69](https://issues.folio.org/browse/MODORDERS-69) - Create instance record in inventory when order transitions to OPEN status
+ * [MODORDERS-32](https://issues.folio.org/browse/MODORDERS-32) & [MODORDERS-33](https://issues.folio.org/browse/MODORDERS-33) - Create po_line sub-objects on order creation
+
+### Bug Fixes
+ * [MODORDERS-120](https://issues.folio.org/browse/MODORDERS-120)
+ * [MODORDERS-116](https://issues.folio.org/browse/MODORDERS-116)
+ * [MODORDERS-114](https://issues.folio.org/browse/MODORDERS-114)
+ * [MODORDERS-113](https://issues.folio.org/browse/MODORDERS-113)
+ * [MODORDERS-112](https://issues.folio.org/browse/MODORDERS-112)
+ * [MODORDERS-102](https://issues.folio.org/browse/MODORDERS-102)
+
+
+## 1.0.2 - Released
  * [MODORDERS-79](https://issues.folio.org/browse/MODORDERS-79) - Implemented delete order line logic
  * [MODORDERS-75](https://issues.folio.org/browse/MODORDERS-75) - Define order line endpoints
  * [MODORDERS-62](https://issues.folio.org/browse/MODORDERS-62) - Migrate to RAML1.0 and RMB 23

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 This primary focus of this release was to implement backend logic necessary for ui-orders to manage (Create, Read, Update, Delete) purchase orders and purchase order lines.
 
-NOTE: This was originally slated to be v1.1.0, but given the amount of changes made to the API, the major version number was bumped.
+NOTE: This was originally slated to be v1.1.0, but given the amount of changes made to API, schemas and interface permissions, the major version number was bumped.
+
+NOTE: Validation is enabled for all endpoints in this release.
 
 ### Stories
  * [MODORDERS-95](https://issues.folio.org/browse/MODORDERS-95) - Upgrade to RMB v23.3.0 to enable path parameters pattern validation

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "orders",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -196,59 +196,59 @@
   "requires": [
     {
       "id": "orders-storage.purchase_orders",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.adjustments",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.alerts",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.claims",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.costs",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.details",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.eresources",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.fund-distributions",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.locations",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.physicals",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.reporting_codes",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.sources",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.vendor_details",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.po_lines",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "identifier-types",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>2.0.0</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v1.0.1</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>v1.0.1</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
See [MODORDERS-131](https://issues.folio.org/browse/MODORDERS-131)

## Purpose
Changes required for release 2.0.0

## Approach
See https://dev.folio.org/guidelines/release-procedures/#maven-based-modules for release procedure documentation
