### PR TITLE
MODORDERS-131 - Release 2.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 3.0.0 - Unreleased
+
+## 2.0.1 - Released
+
+The sole purpose of this release is to bring the interface versions in the RAML file inline with those in the module descriptor.
+
 ## 2.0.0 - Released
 
 This primary focus of this release was to implement backend logic necessary for ui-orders to manage (Create, Read, Update, Delete) purchase orders and purchase order lines.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 The sole purpose of this release is to bring the interface versions in the RAML file inline with those in the module descriptor.
 
+ * [MODORDERS-131](https://issues.folio.org/browse/MODORDERS-131)
+
 ## 2.0.0 - Released
 
 This primary focus of this release was to implement backend logic necessary for ui-orders to manage (Create, Read, Update, Delete) purchase orders and purchase order lines.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>2.0.1</version>
+  <version>3.0.0-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v2.0.1</tag>
+    <tag>v1.0.1</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.0.1</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v1.0.1</tag>
+    <tag>v2.0.1</tag>
   </scm>
 
   <issueManagement>

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: Orders
 baseUri: https://github.com/folio-org/mod-orders
-version: v1
+version: v2
 protocols: [ HTTP, HTTPS ]
 
 documentation:


### PR DESCRIPTION
See [MODORDERS-131](https://issues.folio.org/browse/MODORDERS-131)

## Purpose
This is a follow-on release to fix the RAML so that the API version is consistent with that specified in the module descriptor.

## Approach
Push button, turn crank, voila! New and improved.