### PR TITLE
Modorders 128 put orders handle empty array of the po lines

### DIFF
--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -247,7 +247,7 @@ public class OrdersImpl implements Orders {
 
   private void validatePoLinesQuantity(CompositePurchaseOrder compPO, JsonObject config) {
     int limit = getPoLineLimit(config);
-    if (compPO.getPoLines().size() > limit) {
+    if (compPO.getPoLines() != null && compPO.getPoLines().size() > limit) {
       throw new ValidationException(String.format(OVER_LIMIT_ERROR_MESSAGE, limit), LINES_LIMIT_ERROR_CODE);
     }
   }

--- a/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
@@ -33,7 +33,7 @@ public class PostOrdersHelper extends AbstractHelper {
   private static final long PO_NUMBER_EPOCH = 1535774400000L;
 
   private final ValidationHelper validationHelper;
-  private PostOrderLineHelper postOrderLineHelper;
+  private final PostOrderLineHelper postOrderLineHelper;
 
   public PostOrdersHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context ctx, String lang) {
@@ -82,7 +82,6 @@ public class PostOrdersHelper extends AbstractHelper {
           if (CollectionUtils.isEmpty(compPO.getPoLines())) {
             future.complete(compPO);
           } else {
-
             String poNumber = po.getPoNumber();
             List<PoLine> lines = new ArrayList<>(compPO.getPoLines().size());
             List<CompletableFuture<Void>> futures = new ArrayList<>();

--- a/src/test/resources/order_with_empty_array_in_po_lines.json
+++ b/src/test/resources/order_with_empty_array_in_po_lines.json
@@ -1,0 +1,14 @@
+{
+  "approved": false,
+  "assigned_to": "28d0f99c-d137-11e8-a8d5-f2801f1b9fd1",
+  "manual_po": false,
+  "notes": [],
+  "po_number": "268758",
+  "order_type": "One-Time",
+  "re_encumber": false,
+  "total_estimated_price": 127.94,
+  "total_items": 3,
+  "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflow_status": "Pending",
+  "po_lines": []
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-128](https://issues.folio.org/browse/MODORDERS-128)  In case a request that contains an empty po_lines array, all the PO Lines should be removed... e.g. per the "if the po_line exists in the database but not in the request, remove the po_line" rule.

## Approach
Added logic that:
- remove all the PO Lines in case a request that contains an empty po_lines array
- In this case if the request does not include po_lines or includes "po_lines": null don't remove lines