### PR TITLE
MODORDERS-124 interface version downgrade

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "orders",
-      "version": "3.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: Orders
 baseUri: https://github.com/folio-org/mod-orders
-version: v3
+version: v2
 protocols: [ HTTP, HTTPS ]
 
 documentation:


### PR DESCRIPTION
## Purpose
The purpose is to downgrade orders interface version to v2.0 just to be compatible with existing mod-gobi module and to have successful daily build
## Approach
orders interface version temporary reverted to v2.0
#### TODOS and Open Questions
Upgrade orders interface version to 3.0 after merging https://github.com/folio-org/mod-gobi/pull/36
