### PR TITLE
MODORDERS-124 - orders interface upgrade to v3.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "orders",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: Orders
 baseUri: https://github.com/folio-org/mod-orders
-version: v2
+version: v3
 protocols: [ HTTP, HTTPS ]
 
 documentation:


### PR DESCRIPTION
## Purpose
Increment order interface according to new implemented features
## Approach
Upgrade order interface to v3.0 after temporary downgrade https://github.com/folio-org/mod-orders/pull/71
#### TODOS and Open Questions
Should be merged together with
* https://github.com/folio-org/mod-gobi/pull/36
* https://github.com/folio-org/ui-orders/pull/174
