### PR TITLE
MODORDERS-126 Implement GET orders by query endpoint

### DIFF
--- a/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
@@ -4,6 +4,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.PurchaseOrders;
@@ -19,7 +20,7 @@ import static org.folio.orders.utils.SubObjects.resourcesPath;
 
 public class GetOrdersHelper extends AbstractHelper {
 
-  public static final String GET_PURCHASE_ORDERS_BY_QUERY = resourcesPath(PURCHASE_ORDER) + "?limit=%s&offset=%s&query=%s&lang=%s";
+  public static final String GET_PURCHASE_ORDERS_BY_QUERY = resourcesPath(PURCHASE_ORDER) + "?limit=%s&offset=%s%s&lang=%s";
 
   GetOrdersHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
                   Handler<AsyncResult<Response>> asyncResultHandler, Context ctx, String lang) {
@@ -30,7 +31,8 @@ public class GetOrdersHelper extends AbstractHelper {
   public CompletableFuture<PurchaseOrders> getPurchaseOrders(int limit, int offset, String query) {
     CompletableFuture<PurchaseOrders> future = new VertxCompletableFuture<>(ctx);
 
-    String endpoint = String.format(GET_PURCHASE_ORDERS_BY_QUERY, limit, offset, query, lang);
+    String queryParam = StringUtils.isEmpty(query) ? StringUtils.EMPTY : "&query=" + query;
+    String endpoint = String.format(GET_PURCHASE_ORDERS_BY_QUERY, limit, offset, queryParam, lang);
     HelperUtils.handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
       .thenAccept(jsonOrders -> future.complete(jsonOrders.mapTo(PurchaseOrders.class)))
       .exceptionally(t -> {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1930,7 +1930,7 @@ public class OrdersImplTest {
 
       JsonObject po;
       po = new JsonObject();
-      String queryParam = ctx.request().getParam("query");
+      String queryParam = StringUtils.trimToEmpty(ctx.request().getParam("query"));
       addServerRqRsData(HttpMethod.GET, PURCHASE_ORDER, po);
       final String PO_NUMBER_QUERY = "po_number==";
       switch (queryParam) {
@@ -1940,7 +1940,7 @@ public class OrdersImplTest {
         case PO_NUMBER_QUERY + NONEXISTING_PO_NUMBER:
           po.put(TOTAL_RECORDS, 0);
           break;
-        case "null":
+        case StringUtils.EMPTY:
           po.put(TOTAL_RECORDS, 3);
           break;
         default:


### PR DESCRIPTION
## Purpose
[MODORDERS-126](https://issues.folio.org/browse/MODORDERS-126): Fixing case when query parameter is not provided or empty. This resulted to `QueryValidationException` on the storage side

## Approach
Do not pass `query` parameter to storage if it is empty in the `/orders/composite-orders` request
