### PR TITLE
Modorders 126 fix empty query

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -5,6 +5,8 @@ import static org.folio.orders.utils.SubObjects.*;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -300,6 +302,20 @@ public class HelperUtils {
     }
 
     return future;
+  }
+
+  /**
+   * @param query string representing CQL query
+   * @param logger {@link Logger} to log error if any
+   * @return URL encoded string
+   */
+  public static String encodeQuery(String query, Logger logger) {
+    try {
+      return URLEncoder.encode(query, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      logger.error("Error happened while attempting to encode '{}'", e, query);
+      throw new CompletionException(e);
+    }
   }
 
   public static CompletableFuture<JsonObject> handleGetRequest(String endpoint, HttpClientInterface

--- a/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
@@ -33,15 +33,19 @@ public class GetOrdersHelper extends AbstractHelper {
   public CompletableFuture<PurchaseOrders> getPurchaseOrders(int limit, int offset, String query) {
     CompletableFuture<PurchaseOrders> future = new VertxCompletableFuture<>(ctx);
 
-    String queryParam = isEmpty(query) ? EMPTY : "&query=" + encodeQuery(query, logger);
-    String endpoint = String.format(GET_PURCHASE_ORDERS_BY_QUERY, limit, offset, queryParam, lang);
-    HelperUtils.handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
-      .thenAccept(jsonOrders -> future.complete(jsonOrders.mapTo(PurchaseOrders.class)))
-      .exceptionally(t -> {
-        logger.error("Error getting orders", t);
-        future.completeExceptionally(t.getCause());
-        return null;
-      });
+    try {
+      String queryParam = isEmpty(query) ? EMPTY : "&query=" + encodeQuery(query, logger);
+      String endpoint = String.format(GET_PURCHASE_ORDERS_BY_QUERY, limit, offset, queryParam, lang);
+      HelperUtils.handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+        .thenAccept(jsonOrders -> future.complete(jsonOrders.mapTo(PurchaseOrders.class)))
+        .exceptionally(t -> {
+          logger.error("Error getting orders", t);
+          future.completeExceptionally(t.getCause());
+          return null;
+        });
+    } catch (Exception e) {
+      future.completeExceptionally(e);
+    }
 
     return future;
   }

--- a/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersHelper.java
@@ -4,7 +4,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
-import org.apache.commons.lang3.StringUtils;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.PurchaseOrders;
@@ -15,6 +14,9 @@ import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.folio.orders.utils.HelperUtils.encodeQuery;
 import static org.folio.orders.utils.SubObjects.PURCHASE_ORDER;
 import static org.folio.orders.utils.SubObjects.resourcesPath;
 
@@ -31,7 +33,7 @@ public class GetOrdersHelper extends AbstractHelper {
   public CompletableFuture<PurchaseOrders> getPurchaseOrders(int limit, int offset, String query) {
     CompletableFuture<PurchaseOrders> future = new VertxCompletableFuture<>(ctx);
 
-    String queryParam = StringUtils.isEmpty(query) ? StringUtils.EMPTY : "&query=" + query;
+    String queryParam = isEmpty(query) ? EMPTY : "&query=" + encodeQuery(query, logger);
     String endpoint = String.format(GET_PURCHASE_ORDERS_BY_QUERY, limit, offset, queryParam, lang);
     HelperUtils.handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
       .thenAccept(jsonOrders -> future.complete(jsonOrders.mapTo(PurchaseOrders.class)))


### PR DESCRIPTION
## Purpose
[MODORDERS-126](https://issues.folio.org/browse/MODORDERS-126): Fixing case when query parameter has symbols required to be encoded (the value which comes to business logic is already decoded).

## Approach
Encoding query value using `URLEncoder.encode(query, "UTF-8")`
