### PR TITLE
MODORDERS-145 Unable to create new Purchase Order with PO Line

### DIFF
--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -47,6 +47,7 @@ public class InventoryHelper {
   private static final String ITEMS = "items";
   private static final String LOAN_TYPES = "loantypes";
 
+  private static final String INSTANCE_SOURCE = "FOLIO";
   private static final String DEFAULT_INSTANCE_TYPE_CODE = "zzz";
   private static final String DEFAULT_STATUS_CODE = "temp";
   private static final String DEFAULT_LOAN_TYPE_NAME = "Can circulate";
@@ -198,9 +199,8 @@ public class InventoryHelper {
 
   private JsonObject buildInstanceRecordJsonObject(PoLine compPOL, Map<String, String> productTypes, JsonObject lookupObj) {
     JsonObject instance = new JsonObject();
-    if (compPOL.getSource() != null) {
-      instance.put("source", compPOL.getSource().getCode());
-    }
+
+    instance.put("source", INSTANCE_SOURCE);
     if (compPOL.getTitle() != null) {
       instance.put("title", compPOL.getTitle());
     }

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -56,7 +56,6 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class PutOrderLineByIdHelper extends AbstractHelper {
 
-  private static final String INSTANCE_SOURCE = "FOLIO";
   private final InventoryHelper inventoryHelper;
   private final Errors processingErrors = new Errors();
 

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -67,6 +67,7 @@ import static org.folio.rest.tools.client.Response.isSuccess;
 
 public class PutOrderLineByIdHelper extends AbstractHelper {
 
+  private static final String INSTANCE_SOURCE = "FOLIO";
   private static final String DEFAULT_INSTANCE_TYPE_CODE = "zzz";
   private static final String DEFAULT_STATUS_CODE = "temp";
   private static final String LOCATION_HEADER = "Location";
@@ -287,9 +288,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
 
   private JsonObject buildInstanceRecordJsonObject(PoLine compPOL, Map<String, String> productTypes, JsonObject lookupObj) {
     JsonObject instance = new JsonObject();
-    if (compPOL.getSource() != null) {
-      instance.put("source", compPOL.getSource().getCode());
-    }
+    instance.put("source", INSTANCE_SOURCE);
     if (compPOL.getTitle() != null) {
       instance.put("title", compPOL.getTitle());
     }

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1583,7 +1583,7 @@ public class OrdersImplTest {
 
   private void verifyInstanceRecordRequest(JsonObject instance, PoLine line) {
     assertThat(instance.getString("title"), equalTo(line.getTitle()));
-    assertThat(instance.getString("source"), equalTo(line.getSource().getCode()));
+    assertThat(instance.getString("source"), equalTo("FOLIO"));
     assertThat(instance.getString("statusId"), equalTo("daf2681c-25af-4202-a3fa-e58fdf806183"));
     assertThat(instance.getString("instanceTypeId"), equalTo("30fffe0e-e985-4144-b2e2-1e8179bdb41f"));
     assertThat(instance.getJsonArray("publication").getJsonObject(0).getString("publisher"), equalTo(line.getPublisher()));


### PR DESCRIPTION
## Purpose
since `po_line.source` and `instance.source` are not the same thing, we should set `instance.source` to hardcoded value `FOLIO` instead of mapping it from `po_line.source`

## Approach
Change "update inventory" logic in PutOrderLineByIdHelper to populate Instance Record source with hardcoded value.