### PR TITLE
MODORDERS-145 Unable to create new Purchase Order with PO Line

### DIFF
--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -47,7 +47,6 @@ public class InventoryHelper {
   private static final String ITEMS = "items";
   private static final String LOAN_TYPES = "loantypes";
 
-  private static final String INSTANCE_SOURCE = "FOLIO";
   private static final String DEFAULT_INSTANCE_TYPE_CODE = "zzz";
   private static final String DEFAULT_STATUS_CODE = "temp";
   private static final String DEFAULT_LOAN_TYPE_NAME = "Can circulate";
@@ -200,7 +199,8 @@ public class InventoryHelper {
   private JsonObject buildInstanceRecordJsonObject(PoLine compPOL, Map<String, String> productTypes, JsonObject lookupObj) {
     JsonObject instance = new JsonObject();
 
-    instance.put("source", INSTANCE_SOURCE);
+    // MODORDERS-145 The Source and source code are required by schema
+    instance.put("source", compPOL.getSource().getCode());
     if (compPOL.getTitle() != null) {
       instance.put("title", compPOL.getTitle());
     }

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -206,6 +206,7 @@ public class OrdersImpl implements Orders {
   }
 
   @Override
+  @Validate
   public void getOrdersPoNumber(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     logger.info("Receiving generated po_number ...");
 
@@ -290,6 +291,7 @@ public class OrdersImpl implements Orders {
   }
 
   @Override
+  @Validate
   public void getOrdersCompositeOrders(int offset, int limit, String query, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     final HttpClientInterface httpClient = AbstractHelper.getHttpClient(okapiHeaders);
     GetOrdersHelper helper = new GetOrdersHelper(httpClient, okapiHeaders, asyncResultHandler, vertxContext, lang);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -955,7 +955,7 @@ public class OrdersImplTest {
 
   private void verifyInstanceRecordRequest(JsonObject instance, PoLine line) {
     assertThat(instance.getString("title"), equalTo(line.getTitle()));
-    assertThat(instance.getString("source"), equalTo("FOLIO"));
+    assertThat(instance.getString("source"), equalTo(line.getSource().getCode()));
     assertThat(instance.getString("statusId"), equalTo("daf2681c-25af-4202-a3fa-e58fdf806183"));
     assertThat(instance.getString("instanceTypeId"), equalTo("30fffe0e-e985-4144-b2e2-1e8179bdb41f"));
     assertThat(instance.getJsonArray("publication").getJsonObject(0).getString("publisher"), equalTo(line.getPublisher()));

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -54,6 +55,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.RestVerticle;
@@ -172,12 +174,12 @@ public class OrdersImplTest {
   private static final String COMP_PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeLines/";
   private static final String MOCK_DATA_ROOT_PATH = "src/test/resources/";
   private static final String listedPrintMonographPath = MOCK_DATA_ROOT_PATH + "/po_listed_print_monograph.json";
-  private static final String minimalOrderPath = MOCK_DATA_ROOT_PATH + "/minimal_order.json";
+  private static final String MINIMAL_ORDER_PATH = MOCK_DATA_ROOT_PATH + "/minimal_order.json";
   private static final String poCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_creation_failure.json";
   private static final String poLineCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_line_creation_failure.json";
   private static final String CONFIG_MOCK_PATH = BASE_MOCK_DATA_PATH + "configurations.entries/%s.json";
-
-  private static final String EMPTY_PO_LINE_BUT_WITH_IDS = "{\"id\": \"%s\", \"purchase_order_id\": \"%s\"}";
+  /** The PO Line with minimal required content */
+  private static final String PO_LINE_MIN_CONTENT_PATH = COMP_PO_LINES_MOCK_DATA_PATH + "/minimalContent.json";
 
   private static final String PONUMBER_VALIDATE_PATH = "/orders/po-number/validate";
 
@@ -188,6 +190,7 @@ public class OrdersImplTest {
   private static final String EXISTING_PO_NUMBER = "oldPoNumber";
   private static final String NONEXISTING_PO_NUMBER = "newPoNumber";
 
+  private static final Set<String> REQUIRED_PO_LINE_PROPERTIES = ImmutableSet.of(SOURCE);
 
   private static Vertx vertx;
   private static MockServer mockServer;
@@ -342,7 +345,7 @@ public class OrdersImplTest {
   public void testPlaceOrderMinimal() throws Exception {
     logger.info("=== Test Placement of minimal order ===");
 
-    String body = getMockData(minimalOrderPath);
+    String body = getMockData(MINIMAL_ORDER_PATH);
     JsonObject reqData = new JsonObject(body);
 
     final CompositePurchaseOrder resp = verifyPostResponse(COMPOSITE_ORDERS_PATH, body,
@@ -1063,7 +1066,7 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testValidationOnPost() {
+  public void testValidationOnPost() throws IOException {
     logger.info("=== Test validation Annotation on POST API ===");
 
     logger.info("=== Test validation with no body ===");
@@ -1086,7 +1089,7 @@ public class OrdersImplTest {
         .header(NON_EXIST_CONFIG_X_OKAPI_TENANT)
         .header(X_OKAPI_TOKEN)
         .contentType(APPLICATION_JSON)
-        .body("{}")
+        .body(getMockData(MINIMAL_ORDER_PATH))
       .post(COMPOSITE_ORDERS_PATH +INVALID_LANG)
         .then()
           .statusCode(400)
@@ -1131,7 +1134,7 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testValidationOnPut() {
+  public void testValidationOnPut() throws IOException {
     logger.info("=== Test validation Annotation on PUT API ===");
     String id = "non-existent-po-id";
     logger.info("=== Test validation with no body ===");
@@ -1151,8 +1154,8 @@ public class OrdersImplTest {
          .header(X_OKAPI_URL)
          .header(NON_EXIST_CONFIG_X_OKAPI_TENANT)
          .contentType(APPLICATION_JSON)
-         .body("{}")
-       .put(COMPOSITE_ORDERS_PATH +"/"+id+INVALID_LANG)
+         .body(getMockData(MINIMAL_ORDER_PATH))
+       .put(String.format(COMPOSITE_ORDERS_BY_ID_PATH, id) + INVALID_LANG)
          .then()
            .statusCode(400)
            .body(containsString(INCORRECT_LANG_PARAMETER));
@@ -1162,8 +1165,8 @@ public class OrdersImplTest {
        .with()
          .header(X_OKAPI_URL)
          .header(NON_EXIST_CONFIG_X_OKAPI_TENANT)
-         .body("{}")
-       .put(COMPOSITE_ORDERS_PATH +"/"+id+INVALID_LANG)
+         .body(getMockData(MINIMAL_ORDER_PATH))
+       .put(String.format(COMPOSITE_ORDERS_BY_ID_PATH, id) + INVALID_LANG)
          .then()
            .statusCode(400)
            .body(containsString("Content-type"));
@@ -1346,10 +1349,10 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPostOrdersLinesByIdPoLineWithoutId(TestContext ctx) {
+  public void testPostOrdersLinesByIdPoLineWithoutId(TestContext ctx) throws IOException {
     logger.info("=== Test Post Order Lines By Id (empty id in body) ===");
 
-    Errors resp = verifyPostResponse(LINES_PATH, "{}",
+    Errors resp = verifyPostResponse(LINES_PATH, getMockData(PO_LINE_MIN_CONTENT_PATH),
       NON_EXIST_CONFIG_X_OKAPI_TENANT, APPLICATION_JSON, 422).as(Errors.class);
 
     ctx.assertEquals(1, resp.getErrors().size());
@@ -1369,14 +1372,14 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testValidationOnPutWithIncorrectLang() {
+  public void testValidationOnPutWithIncorrectLang() throws IOException {
     logger.info("=== Test validation on PUT line with invalid lang query parameter ===");
     RestAssured
       .with()
         .header(X_OKAPI_URL)
         .header(NON_EXIST_CONFIG_X_OKAPI_TENANT)
         .contentType(APPLICATION_JSON)
-        .body("{}")
+        .body(getMockData(PO_LINE_MIN_CONTENT_PATH))
       .put(String.format(LINE_BY_ID_PATH, ID_DOES_NOT_EXIST) + INVALID_LANG)
         .then()
           .statusCode(400)
@@ -1384,14 +1387,14 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testValidationOnPutWithIncorrectLineId() {
+  public void testValidationOnPutWithIncorrectLineId() throws IOException {
     logger.info("=== Test validation on PUT line with invalid line ID path parameter ===");
     RestAssured
       .with()
         .header(X_OKAPI_URL)
         .header(NON_EXIST_CONFIG_X_OKAPI_TENANT)
         .contentType(APPLICATION_JSON)
-        .body("{}")
+        .body(getMockData(PO_LINE_MIN_CONTENT_PATH))
       .put(String.format(LINE_BY_ID_PATH, ID_BAD_FORMAT))
         .then()
           .statusCode(400)
@@ -1399,12 +1402,12 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPutOrderLineByIdWithEmptyBody() {
+  public void testPutOrderLineByIdWithEmptyBody() throws IOException {
     logger.info("=== Test PUT Order Line By Id With Empty Json - validation error because of required properties like PO ID ===");
 
     String url = String.format(LINE_BY_ID_PATH, PO_LINE_ID_FOR_SUCCESS_CASE);
 
-    Errors resp = verifyPut(url, "{}", "", 422).as(Errors.class);
+    Errors resp = verifyPut(url, getMockData(PO_LINE_MIN_CONTENT_PATH), "", 422).as(Errors.class);
 
     assertEquals(1, resp.getErrors().size());
   }
@@ -1512,13 +1515,13 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPutOrderLineByIdWithoutOkapiUrlHeader() {
+  public void testPutOrderLineByIdWithoutOkapiUrlHeader() throws IOException {
     logger.info("=== Test PUT Order Line By Id - 500 due to missing Okapi URL header ===");
 
     String lineId = ID_DOES_NOT_EXIST;
 
     String url = String.format(LINE_BY_ID_PATH, lineId);
-    String body = String.format(EMPTY_PO_LINE_BUT_WITH_IDS, lineId, ID_DOES_NOT_EXIST);
+    String body = getPoLineWithMinContentAndIds(lineId, ID_DOES_NOT_EXIST);
 
     RestAssured
       .with()
@@ -1536,12 +1539,12 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPutOrderLineByIdNotFound() {
+  public void testPutOrderLineByIdNotFound() throws IOException {
     logger.info("=== Test PUT Order Line By Id - Not Found ===");
 
     String lineId = ID_DOES_NOT_EXIST;
     String url = String.format(LINE_BY_ID_PATH, lineId);
-    String body = String.format(EMPTY_PO_LINE_BUT_WITH_IDS, lineId, PO_ID);
+    String body = getPoLineWithMinContentAndIds(lineId, PO_ID);
 
     Response actual = verifyPut(url, body, TEXT_PLAIN, 404);
 
@@ -1562,11 +1565,11 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPutOrderLineByIdWithInvalidContentInBody() {
+  public void testPutOrderLineByIdWithInvalidContentInBody() throws IOException {
     logger.info("=== Test PUT Order Line By Id - Body Validation Error ===");
 
     String url = String.format(LINE_BY_ID_PATH, ID_DOES_NOT_EXIST);
-    String body = String.format(EMPTY_PO_LINE_BUT_WITH_IDS, ID_BAD_FORMAT, PO_ID);
+    String body = getPoLineWithMinContentAndIds(ID_BAD_FORMAT, PO_ID);
 
     Response resp = verifyPut(url, body, APPLICATION_JSON, 422);
 
@@ -1578,11 +1581,11 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPutOrderLineByIdWithIdMismatch() {
+  public void testPutOrderLineByIdWithIdMismatch() throws IOException {
     logger.info("=== Test PUT Order Line By Id - Ids mismatch ===");
 
     String url = String.format(LINE_BY_ID_PATH, ID_DOES_NOT_EXIST);
-    String body = String.format(EMPTY_PO_LINE_BUT_WITH_IDS, PO_LINE_ID_FOR_SUCCESS_CASE, PO_ID);
+    String body = getPoLineWithMinContentAndIds(PO_LINE_ID_FOR_SUCCESS_CASE, PO_ID);
 
     Response resp = verifyPut(url, body, APPLICATION_JSON, 422);
 
@@ -1594,13 +1597,13 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPutOrderLineById500FromStorageOnGetPoLine() {
+  public void testPutOrderLineById500FromStorageOnGetPoLine() throws IOException {
     logger.info("=== Test PUT Order Line By Id - 500 From Storage On Get PO Line ===");
 
     String lineId = ID_FOR_INTERNAL_SERVER_ERROR;
 
     String url = String.format(LINE_BY_ID_PATH, lineId);
-    String body = String.format(EMPTY_PO_LINE_BUT_WITH_IDS, lineId, PO_ID);
+    String body = getPoLineWithMinContentAndIds(lineId, PO_ID);
 
     Response actual = verifyPut(url, body, TEXT_PLAIN, 500);
 
@@ -1621,7 +1624,7 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testPutOrderLineById500FromStorageOnSubObjectDeletion() {
+  public void testPutOrderLineById500FromStorageOnSubObjectDeletion() throws IOException {
     logger.info("=== Test PUT Order Line By Id - 500 From Storage On Sub-Object deletion ===");
 
     String lineId = PO_LINE_ID_WITH_SUB_OBJECT_OPERATION_500_CODE;
@@ -1630,7 +1633,7 @@ public class OrdersImplTest {
     String poLineNumber = line.getPoLineNumber();
 
     String url = String.format(LINE_BY_ID_PATH, lineId);
-    String body = String.format(EMPTY_PO_LINE_BUT_WITH_IDS, lineId, orderId);
+    String body = getPoLineWithMinContentAndIds(lineId, orderId);
     Response actual = verifyPut(url, body, APPLICATION_JSON, 500);
 
     assertEquals(2, actual.as(Errors.class).getErrors().size());
@@ -1646,7 +1649,7 @@ public class OrdersImplTest {
     assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, COST, DETAILS, ERESOURCE, LOCATION, PHYSICAL, VENDOR_DETAIL));
 
     column = MockServer.serverRqRs.column(HttpMethod.PUT);
-    assertThat(column.keySet(), containsInAnyOrder(PO_LINES));
+    assertThat(column.keySet(), containsInAnyOrder(PO_LINES, SOURCE));
 
     JsonObject lineWithIds = column.get(PO_LINES).get(0);
 
@@ -1656,8 +1659,20 @@ public class OrdersImplTest {
     assertEquals(poLineNumber, lineWithIds.remove(PO_LINE_NUMBER));
     lineWithIds.stream().forEach(entry -> {
       Object value = entry.getValue();
-      assertTrue(Objects.isNull(value) || (value instanceof Iterable && !((Iterable) value).iterator().hasNext()));
+      // Required properties
+      if (REQUIRED_PO_LINE_PROPERTIES.contains(entry.getKey())) {
+        assertThat(value, is(notNullValue()));
+      } else {
+        assertTrue(Objects.isNull(value) || (value instanceof Iterable && !((Iterable) value).iterator().hasNext()));
+      }
     });
+  }
+
+  private String getPoLineWithMinContentAndIds(String lineId, String orderId) throws IOException {
+    PoLine poLine = new JsonObject(getMockData(PO_LINE_MIN_CONTENT_PATH)).mapTo(PoLine.class);
+    poLine.setId(lineId);
+    poLine.setPurchaseOrderId(orderId);
+    return JsonObject.mapFrom(poLine).encode();
   }
 
   @Test
@@ -2208,7 +2223,7 @@ public class OrdersImplTest {
     }
 
     private void handlePutGenericSubObj(RoutingContext ctx, String subObj) {
-      logger.info("got: " + ctx.request().path());
+      logger.info("handlePutGenericSubObj got: PUT " + ctx.request().path());
       String id = ctx.request().getParam(ID);
 
       JsonObject body = ctx.getBodyAsJson();

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -315,6 +315,23 @@ public class OrdersImplTest {
   }
 
   @Test
+  public void testOrderWithPoLinesWithoutSource() throws Exception {
+    logger.info("=== Test Listed Print Monograph with POL without source ===");
+
+    CompositePurchaseOrder reqData = new JsonObject(getMockData(listedPrintMonographPath)).mapTo(CompositePurchaseOrder.class);
+    // Assert that there are 2 lines
+    assertEquals(2, reqData.getPoLines().size());
+    // remove source to verify validation for first POL
+    reqData.getPoLines().get(0).setSource(null);
+    // Set source code to null to verify validation for second POL
+    reqData.getPoLines().get(1).getSource().setCode(null);
+
+    final Errors errors = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
+      NON_EXIST_CONFIG_X_OKAPI_TENANT, APPLICATION_JSON, 422).as(Errors.class);
+    assertEquals(reqData.getPoLines().size(), errors.getErrors().size());
+  }
+
+  @Test
   public void testPostOpenOrderInventoryUpdateOnlyForFirstPOL() throws Exception {
     logger.info("=== Test Put Order By Id to change status of Order to Open - inventory interaction required only for first POL ===");
 

--- a/src/test/resources/README
+++ b/src/test/resources/README
@@ -16,3 +16,4 @@ c0d08448-347b-418a-8c2f-5fb50248d67e.json - PO line. Considered to be valid
 0009662b-8b80-4001-b704-ca10971f175d.json - PO line. 'cost' and 'details' refer to d25498e7-3ae6-45fe-9612-ec99e2700d2f used for 404 to be returned by storage
 c2755a78-2f8d-47d0-a218-059a9b7391b4.json - PO line. 'details' refer to 168f8a86-d26c-406e-813f-c7527f241ac3 used for 500 to be returned by storage; 'cost' refers to d25498e7-3ae6-45fe-9612-ec99e2700d2f used for 404 to be returned by storage.
 f7223ce8-9e92-4c28-8fd9-097596053b7c.json - PO line. One of 'fund_distribution' elements refer to 168f8a86-d26c-406e-813f-c7527f241ac3 used for 500 to be returned by storage.
+minimalContent.json - - PO line with only minimal required content.

--- a/src/test/resources/minimal_order.json
+++ b/src/test/resources/minimal_order.json
@@ -15,6 +15,7 @@
       "description": "ABCDEFGH",
       "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
       "po_line_number": "268758-03",
+      "source": { "code": "FOLIO" },
       "title": "Kayak Fishing in the Northern Gulf Coast",
       "metadata": {
         "createdDate": "2010-10-08T03:53:00.000",

--- a/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -112,7 +112,7 @@
   "selector": "",
   "source": {
     "id": "530853f3-29f1-4af2-8282-08cc835d103e",
-    "code": "",
+    "code": "FOLIO",
     "description": "Manually entered"
   },
   "tags": [],

--- a/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -103,7 +103,7 @@
   "po_line_number": "268758-03",
   "publication_date": "2017",
   "publisher": "John Wiley & Sons, Inc.",
-  "purchase_order_id": "96a07b68-3cb5-4452-b957-f55479005e69",
+  "purchase_order_id": "3419ed01-a339-4448-9539-9815f231d405",
   "receipt_date": null,
   "receipt_status": "Fully Received",
   "reporting_codes": [],
@@ -112,7 +112,7 @@
   "selector": "Woods",
   "source": {
     "id": "ecb05974-8cc8-481d-a3ce-f20af51110c1",
-    "code": "",
+    "code": "FOLIO",
     "description": "Manually entered"
   },
   "tags": [""],

--- a/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
+++ b/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
@@ -130,7 +130,7 @@
   "selector": "Stevens",
   "source": {
     "id": "024b6f40-c5c6-4280-858e-33fba452a334",
-    "code": "",
+    "code": "FOLIO",
     "description": "Manually entered"
   },
   "tags": [],

--- a/src/test/resources/mockdata/compositeLines/minimalContent.json
+++ b/src/test/resources/mockdata/compositeLines/minimalContent.json
@@ -1,0 +1,3 @@
+{
+  "source": { "code": "FOLIO" }
+}

--- a/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -146,7 +146,7 @@
       "selector": "Buchanan",
       "source": {
         "id": "d25498e7-3ae6-45fe-9612-ec99e2700d2f",
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],

--- a/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
+++ b/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
@@ -142,7 +142,7 @@
       "selector": "Stevens",
       "source": {
         "id": "024b6f40-c5c6-4280-858e-33fba452a334",
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],
@@ -275,7 +275,7 @@
       "selector": "Brown",
       "source": {
         "id": "02dbff41-c5c6-4280-858e-33fba452a334",
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],
@@ -408,7 +408,7 @@
       "selector": "Brown",
       "source": {
         "id": "0b4b6f41-c5c6-4280-858e-33fba452a334",
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],

--- a/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
+++ b/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
@@ -125,7 +125,7 @@
       "selector": "Woods",
       "source": {
         "id": "ecb05974-8cc8-481d-a3ce-f20af51110c1",
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [""],

--- a/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -140,7 +140,7 @@
       "selector": "Woods",
       "source": {
         "id": "ecb05974-8cc8-481d-a3ce-f20af51110c1",
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [""],

--- a/src/test/resources/mockdata/lines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/lines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -33,6 +33,7 @@
   "requester" : "Leo Bulero",
   "rush" : true,
   "selector" : "ABCD",
+  "source": "ecb05974-8cc8-481d-a3ce-f20af51110c1",
   "tags" : [ "ABCDEFGHIJKLMNOPQRSTU", "ABCDEFG", "ABCDEFGHIJKLMNOPQRSTU", "ABCDEFGHIJKLMNO" ],
   "title" : "Kayak Fishing in the Northern Gulf Coast",
   "vendor_detail" : "a53d30b7-0f3f-446b-aee7-8d4134cd54a3",

--- a/src/test/resources/po_creation_failure.json
+++ b/src/test/resources/po_creation_failure.json
@@ -2,16 +2,20 @@
   "po_number": "123",
   "po_lines": [
     {
-      "po_line_number": "12345-1"
+      "po_line_number": "12345-1",
+      "source": { "code": "FOLIO" }
     },
     {
-      "po_line_number": "12345-2"
+      "po_line_number": "12345-2",
+      "source": { "code": "FOLIO" }
     },
     {
-      "po_line_number": "12345-3"
+      "po_line_number": "12345-3",
+      "source": { "code": "FOLIO" }
     },
     {
-      "po_line_number": "12345-4"
+      "po_line_number": "12345-4",
+      "source": { "code": "FOLIO" }
     }
   ]
 }

--- a/src/test/resources/po_line_creation_failure.json
+++ b/src/test/resources/po_line_creation_failure.json
@@ -2,10 +2,12 @@
   "po_number": "TESTDATA0123",
   "po_lines": [
     {
-      "po_line_number": "8675309-1"
+      "po_line_number": "8675309-1",
+      "source": { "code": "FOLIO" }
     },
     {
-      "po_line_number": "invalid"
+      "po_line_number": "invalid",
+      "source": { "code": "FOLIO" }
     }
   ]
 }

--- a/src/test/resources/po_listed_print_monograph.json
+++ b/src/test/resources/po_listed_print_monograph.json
@@ -255,7 +255,7 @@
       "rush": false,
       "selector": "Woods",
       "source": {
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [""],

--- a/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
+++ b/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
@@ -93,7 +93,7 @@
       "rush": false,
       "selector": "Stevens",
       "source": {
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],
@@ -203,7 +203,7 @@
       "rush": false,
       "selector": "Brown",
       "source": {
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],
@@ -437,7 +437,7 @@
       "rush": false,
       "selector": "Woods",
       "source": {
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [""],

--- a/src/test/resources/put_order_with_po_lines.json
+++ b/src/test/resources/put_order_with_po_lines.json
@@ -93,7 +93,7 @@
       "rush": false,
       "selector": "Stevens",
       "source": {
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],
@@ -203,7 +203,7 @@
       "rush": false,
       "selector": "Brown",
       "source": {
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [],
@@ -436,7 +436,7 @@
       "rush": false,
       "selector": "Woods",
       "source": {
-        "code": "",
+        "code": "FOLIO",
         "description": "Manually entered"
       },
       "tags": [""],


### PR DESCRIPTION
## Purpose
[MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145) - make `po_line.source` to be required because this is required by Inventory services
This also fixes [MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) where the Order is created without status and any update of such order fails

## Approach
- Use latest acq-models schemas where `po_line.source` is required property and default value for `workflow_status` set to `Pending`
- Updating mock-data with required `source` data
