### PR TITLE
Modorders 150 edit po withot status

### DIFF
--- a/src/main/java/org/folio/rest/impl/PutOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrdersByIdHelper.java
@@ -109,13 +109,7 @@ public class PutOrdersByIdHelper extends AbstractHelper {
   }
 
   private boolean isTransitionToOpen(CompositePurchaseOrder compPO, JsonObject poFromStorage) {
-    // MODORDERS-150 Workflow status might be null. Use default as 'Pending' in such case
-    WorkflowStatus currentStatus;
-    if (StringUtils.isNotEmpty(poFromStorage.getString("workflow_status"))) {
-      currentStatus = WorkflowStatus.fromValue(poFromStorage.getString("workflow_status"));
-    } else {
-      currentStatus = PENDING;
-    }
+    WorkflowStatus currentStatus = WorkflowStatus.fromValue(poFromStorage.getString("workflow_status"));
     return currentStatus == PENDING && compPO.getWorkflowStatus() == OPEN;
   }
 

--- a/src/main/java/org/folio/rest/impl/PutOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrdersByIdHelper.java
@@ -8,7 +8,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
@@ -109,7 +109,13 @@ public class PutOrdersByIdHelper extends AbstractHelper {
   }
 
   private boolean isTransitionToOpen(CompositePurchaseOrder compPO, JsonObject poFromStorage) {
-    WorkflowStatus currentStatus = WorkflowStatus.fromValue(poFromStorage.getString("workflow_status"));
+    // MODORDERS-150 Workflow status might be null. Use default as 'Pending' in such case
+    WorkflowStatus currentStatus;
+    if (StringUtils.isNotEmpty(poFromStorage.getString("workflow_status"))) {
+      currentStatus = WorkflowStatus.fromValue(poFromStorage.getString("workflow_status"));
+    } else {
+      currentStatus = PENDING;
+    }
     return currentStatus == PENDING && compPO.getWorkflowStatus() == OPEN;
   }
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -151,6 +151,7 @@ public class OrdersImplTest {
   private static final String PO_LINE_ID_WITH_SUB_OBJECT_OPERATION_500_CODE = "c2755a78-2f8d-47d0-a218-059a9b7391b4";
   private static final String PO_LINE_ID_WITH_FUND_DISTRIBUTION_404_CODE = "f7223ce8-9e92-4c28-8fd9-097596053b7c";
   private static final String ORDER_ID_WITHOUT_PO_LINES = "50fb922c-3fa9-494e-a972-f2801f1b9fd1";
+  private static final String ORDER_WITHOUT_WORKFLOW_STATUS = "41d56e59-46db-4d5e-a1ad-a178228913e5";
 
   // API paths
   private final static String COMPOSITE_ORDERS_PATH = "/orders/composite-orders";
@@ -174,7 +175,7 @@ public class OrdersImplTest {
   private static final String COMP_PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeLines/";
   private static final String MOCK_DATA_ROOT_PATH = "src/test/resources/";
   private static final String listedPrintMonographPath = MOCK_DATA_ROOT_PATH + "/po_listed_print_monograph.json";
-  private static final String minimalOrderPath = MOCK_DATA_ROOT_PATH + "/minimal_order.json";
+  private static final String MINIMAL_ORDER_PATH = MOCK_DATA_ROOT_PATH + "/minimal_order.json";
   private static final String poCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_creation_failure.json";
   private static final String poLineCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_line_creation_failure.json";
   private static final String CONFIG_MOCK_PATH = BASE_MOCK_DATA_PATH + "configurations.entries/%s.json";
@@ -344,7 +345,7 @@ public class OrdersImplTest {
   public void testPlaceOrderMinimal() throws Exception {
     logger.info("=== Test Placement of minimal order ===");
 
-    String body = getMockData(minimalOrderPath);
+    String body = getMockData(MINIMAL_ORDER_PATH);
     JsonObject reqData = new JsonObject(body);
 
     final CompositePurchaseOrder resp = verifyPostResponse(COMPOSITE_ORDERS_PATH, body,
@@ -720,6 +721,21 @@ public class OrdersImplTest {
     assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.DELETE).size(), poLinesFromStorage.size() - sameLinesCount);
     assertNotNull(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT));
     assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT).size(), sameLinesCount);
+  }
+
+  @Test
+  public void testUpdateOrderWithStatus_MODORDERS150() throws Exception {
+    logger.info("=== Test Put Order By Id - MODORDERS-150 ===");
+
+    CompositePurchaseOrder reqData = new JsonObject(getMockData(MINIMAL_ORDER_PATH)).mapTo(CompositePurchaseOrder.class);
+    reqData.setId(ORDER_WITHOUT_WORKFLOW_STATUS);
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.CLOSED);
+
+    String url = COMPOSITE_ORDERS_PATH + "/" + reqData.getId();
+    String body = JsonObject.mapFrom(reqData).encode();
+    verifyPut(url, body, "", 204);
+
+    assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -745,8 +745,8 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testUpdateOrderWithStatus_MODORDERS150() throws Exception {
-    logger.info("=== Test Put Order By Id - MODORDERS-150 ===");
+  public void testUpdateOrderWithDefaultStatus() throws Exception {
+    logger.info("=== Test Put Order By Id - Make sure that default status is used ===");
 
     CompositePurchaseOrder reqData = new JsonObject(getMockData(MINIMAL_ORDER_PATH)).mapTo(CompositePurchaseOrder.class);
     reqData.setId(ORDER_WITHOUT_WORKFLOW_STATUS);
@@ -2356,12 +2356,14 @@ public class OrdersImplTest {
       logger.info("id: " + id);
 
       try {
-        JsonObject po;
-
-        po = new JsonObject(getMockData(String.format("%s%s.json", COMP_ORDER_MOCK_DATA_PATH, id)));
+        JsonObject po = new JsonObject(getMockData(String.format("%s%s.json", COMP_ORDER_MOCK_DATA_PATH, id)));
         po.remove(ADJUSTMENT);
         po.remove(PO_LINES);
         po.put(ADJUSTMENT, UUID.randomUUID().toString());
+
+        // Validate the content against schema
+        org.folio.rest.acq.model.PurchaseOrder order = po.mapTo(org.folio.rest.acq.model.PurchaseOrder.class);
+        po = JsonObject.mapFrom(order);
         addServerRqRsData(HttpMethod.GET, PURCHASE_ORDER, po);
         serverResponse(ctx, 200, APPLICATION_JSON, po.encodePrettily());
       } catch (IOException e) {

--- a/src/test/resources/README
+++ b/src/test/resources/README
@@ -9,6 +9,7 @@ po_listed_print_monograph.json - Pending order with 2 POLs:
 1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json - Pending order with 3 POLs
 bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json - Pending order with 1 POL:
   - c2755a78-2f8d-47d0-a218-059a9b7391b4 - 500 from storage for some of sub-objects (see below)
+41d56e59-46db-4d5e-a1ad-a178228913e5.json - Order with no POL and no workflow status set
 
 # mockdata/compositeLines and lines:
 fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json - PO line. Considered to be valid

--- a/src/test/resources/mockdata/compositeOrders/41d56e59-46db-4d5e-a1ad-a178228913e5.json
+++ b/src/test/resources/mockdata/compositeOrders/41d56e59-46db-4d5e-a1ad-a178228913e5.json
@@ -1,0 +1,5 @@
+{
+  "id": "41d56e59-46db-4d5e-a1ad-a178228913e5",
+  "po_number": "268758",
+  "order_type": "One-Time"
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) - handling the case when the order's workflow status is not set in the storage.

## Approach
- The main issue resolved by [MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145) where latest acq-models schemas added and default value for `workflow_status` set to `Pending` for composite purchase order. In this case if UI does not send workflow status for order, the default one will be always used.
- The second case when some 3rd party service sends requests directly to storage endpoints. In this case there is potentially might happen that workflow status is not defined. Using `Pending` as a default one in the business logic.
- Adding unit test to verify this case