### PR TITLE
MODORDERS-142 GET /orders/order-lines

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -111,6 +111,14 @@
           ]
         },
         {
+          "methods": ["GET"],
+          "pathPattern": "/orders/order-lines",
+          "permissionsRequired": ["orders.po-lines.collection.get"],
+          "modulePermissions": [
+            "orders-storage.po_lines.collection.get"
+          ]
+        },
+        {
           "methods": ["POST"],
           "pathPattern": "/orders/order-lines",
           "permissionsRequired": ["orders.po-lines.item.post"],
@@ -370,6 +378,11 @@
       "description": "Delete an existing order"
     },
     {
+      "permissionName": "orders.po-lines.collection.get",
+      "displayName": "Orders - get collection of PO lines",
+      "description": "Create a new PO line"
+    },
+    {
       "permissionName": "orders.po-lines.item.post",
       "displayName": "Orders - create a new PO line",
       "description": "Create a new PO line"
@@ -424,6 +437,7 @@
         "orders.item.get",
         "orders.item.put",
         "orders.item.delete",
+        "orders.po-lines.collection.get",
         "orders.po-lines.item.post",
         "orders.po-lines.item.get",
         "orders.po-lines.item.put",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -388,7 +388,7 @@
     {
       "permissionName": "orders.po-lines.collection.get",
       "displayName": "Orders - get collection of PO lines",
-      "description": "Create a new PO line"
+      "description": "Get collection of PO lines"
     },
     {
       "permissionName": "orders.po-lines.item.post",

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -9,8 +9,8 @@ documentation:
     content: <b>API for managing purchase orders</b>
 
 types:
-  composite_purchase_order: !include acq-models/composite_purchase_order.json
-  purchase_orders: !include acq-models/mod-orders-storage/schemas/purchase_order_collection.json
+  composite-purchase-order: !include acq-models/composite_purchase_order.json
+  purchase-orders: !include acq-models/mod-orders-storage/schemas/purchase_order_collection.json
   purchase_order: !include acq-models/mod-orders-storage/schemas/purchase_order.json
   composite-po-line: !include acq-models/composite_po_line.json
   po-line-collection: !include acq-models/mod-orders-storage/schemas/po_line_collection.json
@@ -43,8 +43,6 @@ resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
   collection-item: !include raml-util/rtypes/item-collection.raml
   collection-get: !include raml-util/rtypes/collection-get.raml
-  # The post-empty-body.raml does not declare request body but it can be defined when this resource type is used
-  post-item: !include raml-util/rtypes/post-empty-body.raml
   post-with-200: !include rtypes/post-json-body-200.raml
 
 /orders:
@@ -54,8 +52,8 @@ resourceTypes:
       collection:
         exampleCollection: !include acq-models/mod-orders-storage/examples/purchase_order_collection.sample
         exampleItem: !include acq-models/examples/composite_purchase_order.sample
-        schemaCollection: purchase_orders
-        schemaItem: composite_purchase_order
+        schemaCollection: purchase-orders
+        schemaItem: composite-purchase-order
     is: [validate]
     get:
       is: [pageable, searchable: {description: "using CQL (indexes for purchase orders)", example: "workflow_status==\"Pending\""} ]
@@ -70,7 +68,7 @@ resourceTypes:
       type:
         collection-item:
           exampleItem: !include acq-models/examples/composite_purchase_order.sample
-          schema: composite_purchase_order
+          schema: composite-purchase-order
       is: [validate]
       get:
         description: Return a purchase order with given {id}

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -97,7 +97,7 @@ resourceTypes:
         schemaItem: composite-po-line
     is: [validate]
     get:
-      is: [pageable, searchable: {description: "using CQL (indexes for PO lines)", example: "workflow_status==\"Pending\""} ]
+      is: [pageable, searchable: {description: "using CQL (indexes for PO lines)", example: "payment_status==\"Cancelled\""} ]
     post:
       description: Post a PO lines to corresponding PO
       is: [auth]

--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -12,7 +12,9 @@ types:
   composite_purchase_order: !include acq-models/composite_purchase_order.json
   purchase_orders: !include acq-models/mod-orders-storage/schemas/purchase_order_collection.json
   purchase_order: !include acq-models/mod-orders-storage/schemas/purchase_order.json
-  po_line: !include acq-models/composite_po_line.json
+  composite-po-line: !include acq-models/composite_po_line.json
+  po-line-collection: !include acq-models/mod-orders-storage/schemas/po_line_collection.json
+  po-line: !include acq-models/mod-orders-storage/schemas/po_line.json
   checkin-collection: !include acq-models/mod-orders/schemas/checkinCollection.json
   receiving-collection: !include acq-models/mod-orders/schemas/receivingCollection.json
   receiving-results: !include acq-models/mod-orders/schemas/receivingResults.json
@@ -88,20 +90,17 @@ resourceTypes:
     displayName: Purchase Order Lines
     description: Manage purchase order (PO) lines
     type:
-      # Using `post-item` resource type because at the moment only POST is required. In case GET becomes also required, the `collection` resource type should be used instead
-      post-item:
+      collection:
+        exampleCollection: !include acq-models/mod-orders-storage/examples/po_line_collection.sample
         exampleItem: !include acq-models/examples/composite_po_line.sample
-        schema: po_line
+        schemaCollection: po-line-collection
+        schemaItem: composite-po-line
+    is: [validate]
+    get:
+      is: [pageable, searchable: {description: "using CQL (indexes for PO lines)", example: "workflow_status==\"Pending\""} ]
     post:
-      displayName: Create a new purchace order line
-      description: Post a purchase order (PO) line
-      is: [validate, auth]
-      body:
-        application/json:
-          type: po_line
-          example:
-            strict: false
-            value: !include acq-models/examples/composite_po_line.sample
+      description: Post a PO lines to corresponding PO
+      is: [auth]
     /{id}:
       displayName: Purchase Order Line
       description: Manage purchase order line (PO line) by id
@@ -112,7 +111,7 @@ resourceTypes:
       type:
         collection-item:
           exampleItem: !include acq-models/examples/composite_po_line.sample
-          schema: po_line
+          schema: composite-po-line
       is: [validate]
       get:
         description: Return a purchase order line with given {id}

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -35,13 +35,15 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class HelperUtils {
 
+  public static final String COMPOSITE_PO_LINES = "compositePoLines";
+
   public static final String PO_NUMBER_ALREADY_EXISTS = "PO Number already exists";
   public static final String DEFAULT_POLINE_LIMIT = "1";
   private static final String MAX_POLINE_LIMIT = "500";
   public static final String OKAPI_URL = "X-Okapi-Url";
   public static final String PO_LINES_LIMIT_PROPERTY = "poLines-limit";
   public static final String URL_WITH_LANG_PARAM = "%s?lang=%s";
-  public static final String GET_ALL_POLINES_QUERY_WITH_LIMIT = resourcesPath(COMPOSITE_PO_LINES)+"?limit=%s&query=purchase_order_id==%s&lang=%s";
+  public static final String GET_ALL_POLINES_QUERY_WITH_LIMIT = resourcesPath(PO_LINES)+"?limit=%s&query=purchase_order_id==%s&lang=%s";
   public static final String GET_PURCHASE_ORDER_BYID = resourceByIdPath(PURCHASE_ORDER)+URL_WITH_LANG_PARAM;
   public static final String GET_PURCHASE_ORDER_BYPONUMBER_QUERY = resourcesPath(PURCHASE_ORDER)+"?query=po_number==%s&lang=%s";
 
@@ -123,7 +125,7 @@ public class HelperUtils {
    */
   public static CompletableFuture<JsonObject> getPoLineById(String lineId, String lang, HttpClientInterface httpClient, Context ctx,
                                                             Map<String, String> okapiHeaders, Logger logger) {
-    String endpoint = String.format(URL_WITH_LANG_PARAM, resourceByIdPath(COMPOSITE_PO_LINES, lineId), lang);
+    String endpoint = String.format(URL_WITH_LANG_PARAM, resourceByIdPath(PO_LINES, lineId), lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger);
   }
 
@@ -134,8 +136,8 @@ public class HelperUtils {
       .thenCompose(body -> {
         List<CompletableFuture<JsonObject>> futures = new ArrayList<>();
 
-        for (int i = 0; i < body.getJsonArray(COMPOSITE_PO_LINES).size(); i++) {
-          JsonObject line = body.getJsonArray(COMPOSITE_PO_LINES).getJsonObject(i);
+        for (int i = 0; i < body.getJsonArray(PO_LINES).size(); i++) {
+          JsonObject line = body.getJsonArray(PO_LINES).getJsonObject(i);
           futures.add(deletePoLine(line, httpClient, ctx, okapiHeaders, logger));
         }
 
@@ -152,7 +154,7 @@ public class HelperUtils {
     return operateOnPoLine(HttpMethod.DELETE, line, httpClient, ctx, okapiHeaders, logger)
       .thenCompose(poline -> {
         String polineId = poline.getId();
-        return operateOnSubObj(HttpMethod.DELETE, resourceByIdPath(COMPOSITE_PO_LINES, polineId), httpClient, ctx, okapiHeaders, logger);
+        return operateOnSubObj(HttpMethod.DELETE, resourceByIdPath(PO_LINES, polineId), httpClient, ctx, okapiHeaders, logger);
       });
   }
 
@@ -165,8 +167,8 @@ public class HelperUtils {
         List<CompositePoLine> lines = new ArrayList<>();
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-        for (int i = 0; i < body.getJsonArray(COMPOSITE_PO_LINES).size(); i++) {
-          JsonObject line = body.getJsonArray(COMPOSITE_PO_LINES).getJsonObject(i);
+        for (int i = 0; i < body.getJsonArray(PO_LINES).size(); i++) {
+          JsonObject line = body.getJsonArray(PO_LINES).getJsonObject(i);
           futures.add(operateOnPoLine(HttpMethod.GET, line, httpClient, ctx, okapiHeaders, logger)
             .thenAccept(lines::add));
         }
@@ -180,7 +182,8 @@ public class HelperUtils {
       })
       .exceptionally(t -> {
         logger.error("Exception gathering po_line data:", t);
-        throw new CompletionException(t);
+        future.completeExceptionally(t);
+        return null;
       });
     return future;
   }

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -10,7 +10,7 @@ public class ResourcePathResolver {
   private ResourcePathResolver() {
   }
 
-  public static final String PO_LINES = "po_lines";
+  public static final String COMPOSITE_PO_LINES = "compositePoLines";
   public static final String PO_NUMBER = "po_number";
 
   public static final String ADJUSTMENT = "adjustment";
@@ -45,7 +45,7 @@ public class ResourcePathResolver {
     apis.put(REPORTING_CODES, "/orders-storage/reporting_codes");
     apis.put(SOURCE, "/orders-storage/sources");
     apis.put(VENDOR_DETAIL, "/orders-storage/vendor_details");
-    apis.put(PO_LINES, "/orders-storage/po_lines");
+    apis.put(COMPOSITE_PO_LINES, "/orders-storage/po_lines");
     apis.put(PO_NUMBER, "/orders-storage/po_number");
     apis.put(PURCHASE_ORDER, "/orders-storage/purchase_orders");
 

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -10,7 +10,7 @@ public class ResourcePathResolver {
   private ResourcePathResolver() {
   }
 
-  public static final String COMPOSITE_PO_LINES = "compositePoLines";
+  public static final String PO_LINES = "po_lines";
   public static final String PO_NUMBER = "po_number";
 
   public static final String ADJUSTMENT = "adjustment";
@@ -45,7 +45,7 @@ public class ResourcePathResolver {
     apis.put(REPORTING_CODES, "/orders-storage/reporting_codes");
     apis.put(SOURCE, "/orders-storage/sources");
     apis.put(VENDOR_DETAIL, "/orders-storage/vendor_details");
-    apis.put(COMPOSITE_PO_LINES, "/orders-storage/po_lines");
+    apis.put(PO_LINES, "/orders-storage/po_lines");
     apis.put(PO_NUMBER, "/orders-storage/po_number");
     apis.put(PURCHASE_ORDER, "/orders-storage/purchase_orders");
     apis.put(PIECES, "/orders-storage/pieces");

--- a/src/main/java/org/folio/rest/impl/AbstractHelper.java
+++ b/src/main/java/org/folio/rest/impl/AbstractHelper.java
@@ -1,9 +1,9 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
 import static org.folio.orders.utils.HelperUtils.OKAPI_URL;
 import static org.folio.orders.utils.ResourcePathResolver.ADJUSTMENT;
-import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 import io.vertx.core.AsyncResult;

--- a/src/main/java/org/folio/rest/impl/AbstractHelper.java
+++ b/src/main/java/org/folio/rest/impl/AbstractHelper.java
@@ -3,7 +3,7 @@ package org.folio.rest.impl;
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.orders.utils.HelperUtils.OKAPI_URL;
 import static org.folio.orders.utils.ResourcePathResolver.ADJUSTMENT;
-import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 import io.vertx.core.AsyncResult;
@@ -79,8 +79,8 @@ public abstract class AbstractHelper {
     if (purchaseOrder.containsKey(ADJUSTMENT)) {
       purchaseOrder.remove(ADJUSTMENT);
     }
-    if (purchaseOrder.containsKey(PO_LINES)) {
-      purchaseOrder.remove(PO_LINES);
+    if (purchaseOrder.containsKey(COMPOSITE_PO_LINES)) {
+      purchaseOrder.remove(COMPOSITE_PO_LINES);
     }
     return purchaseOrder;
   }

--- a/src/main/java/org/folio/rest/impl/GetOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOrdersByIdHelper.java
@@ -54,7 +54,7 @@ public class GetOrdersByIdHelper extends AbstractHelper {
 
         HelperUtils.getCompositePoLines(id, lang, httpClient, ctx, okapiHeaders, logger)
           .thenAccept(poLines -> {
-            compPO.setPoLines(poLines);
+            compPO.setCompositePoLines(poLines);
             compPO.setAdjustment(HelperUtils.calculateAdjustment(poLines));
             future.complete(compPO);
           })

--- a/src/main/java/org/folio/rest/impl/GetPOLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetPOLineByIdHelper.java
@@ -7,8 +7,8 @@ import java.util.concurrent.CompletionStage;
 import javax.ws.rs.core.Response;
 
 import org.folio.orders.utils.HelperUtils;
+import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.resource.Orders.GetOrdersOrderLinesByIdResponse;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
@@ -26,8 +26,8 @@ public class GetPOLineByIdHelper extends AbstractHelper {
     super(httpClient, okapiHeaders, asyncResultHandler, ctx, lang);
   }
 
-  public CompletableFuture<PoLine> getPOLineByPOLineId(String polineId) {
-    CompletableFuture<PoLine> future = new VertxCompletableFuture<>(ctx);
+  public CompletableFuture<CompositePoLine> getPOLineByPOLineId(String polineId) {
+    CompletableFuture<CompositePoLine> future = new VertxCompletableFuture<>(ctx);
     HelperUtils.getPoLineById(polineId, lang, httpClient,ctx, okapiHeaders, logger)
       .thenCompose(this::populateCompositeLine)
       .thenAccept(future::complete)
@@ -39,7 +39,7 @@ public class GetPOLineByIdHelper extends AbstractHelper {
     return future;
   }
 
-  private CompletionStage<PoLine> populateCompositeLine(JsonObject poline) {
+  private CompletionStage<CompositePoLine> populateCompositeLine(JsonObject poline) {
     return HelperUtils.operateOnPoLine(HttpMethod.GET, poline, httpClient, ctx, okapiHeaders, logger);
   }
 

--- a/src/main/java/org/folio/rest/impl/GetPOLinesHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetPOLinesHelper.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -23,7 +23,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.orders.utils.HelperUtils.encodeQuery;
 
 public class GetPOLinesHelper extends AbstractHelper {
-  public static final String GET_PO_LINES_BY_QUERY = resourcesPath(COMPOSITE_PO_LINES) + "?limit=%s&offset=%s%s&lang=%s";
+  public static final String GET_PO_LINES_BY_QUERY = resourcesPath(PO_LINES) + "?limit=%s&offset=%s%s&lang=%s";
 
   GetPOLinesHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
                    Handler<AsyncResult<Response>> asyncResultHandler, Context ctx, String lang) {

--- a/src/main/java/org/folio/rest/impl/GetPOLinesHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetPOLinesHelper.java
@@ -1,0 +1,72 @@
+package org.folio.rest.impl;
+
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.folio.orders.utils.HelperUtils;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.PoLineCollection;
+import org.folio.rest.jaxrs.resource.Orders.GetOrdersCompositeOrdersResponse;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.folio.orders.utils.HelperUtils.encodeQuery;
+
+public class GetPOLinesHelper extends AbstractHelper {
+  public static final String GET_PO_LINES_BY_QUERY = resourcesPath(COMPOSITE_PO_LINES) + "?limit=%s&offset=%s%s&lang=%s";
+
+  GetPOLinesHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
+                   Handler<AsyncResult<Response>> asyncResultHandler, Context ctx, String lang) {
+    super(httpClient, okapiHeaders, asyncResultHandler, ctx, lang);
+  }
+
+
+  public CompletableFuture<PoLineCollection> getPOLines(int limit, int offset, String query) {
+    CompletableFuture<PoLineCollection> future = new VertxCompletableFuture<>(ctx);
+    try {
+      String queryParam = isEmpty(query) ? EMPTY : "&query=" + encodeQuery(query, logger);
+      String endpoint = String.format(GET_PO_LINES_BY_QUERY, limit, offset, queryParam, lang);
+      HelperUtils.handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+        .thenAccept(jsonOrders -> future.complete(jsonOrders.mapTo(PoLineCollection.class)))
+        .exceptionally(t -> {
+          logger.error("Error getting PO lines", t);
+          future.completeExceptionally(t.getCause());
+          return null;
+        });
+    } catch (Exception e) {
+      future.completeExceptionally(e);
+    }
+
+    return future;
+  }
+
+
+  @Override
+  protected Response buildErrorResponse(int code, Error error) {
+    final Response result;
+    switch (code) {
+      case 400:
+        result = GetOrdersCompositeOrdersResponse.respond400WithTextPlain(error.getMessage());
+        break;
+      case 500:
+        result = GetOrdersCompositeOrdersResponse.respond500WithTextPlain(error.getMessage());
+        break;
+      case 401:
+        result = GetOrdersCompositeOrdersResponse.respond401WithTextPlain(error.getMessage());
+        break;
+      default:
+        result = GetOrdersCompositeOrdersResponse.respond500WithTextPlain(error.getMessage());
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -94,7 +94,7 @@ public class InventoryHelper {
           });
   }
 
-  private CompletableFuture<String> createHoldingsRecord(PoLine compPOL) {
+  private CompletableFuture<String> createHoldingsRecord(CompositePoLine compPOL) {
     JsonObject holdingsRecJson=new JsonObject();
     holdingsRecJson.put("instanceId", compPOL.getInstanceId());
     holdingsRecJson.put("permanentLocationId", compPOL.getLocation().getLocationId());

--- a/src/main/java/org/folio/rest/impl/PostOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrderLineHelper.java
@@ -11,7 +11,7 @@ import static org.folio.orders.utils.ResourcePathResolver.ERESOURCE;
 import static org.folio.orders.utils.ResourcePathResolver.FUND_DISTRIBUTION;
 import static org.folio.orders.utils.ResourcePathResolver.LOCATION;
 import static org.folio.orders.utils.ResourcePathResolver.PHYSICAL;
-import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.REPORTING_CODES;
 import static org.folio.orders.utils.ResourcePathResolver.SOURCE;
 import static org.folio.orders.utils.ResourcePathResolver.VENDOR_DETAIL;
@@ -68,7 +68,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       .thenCompose(v -> {
         try {
           Buffer polBuf = JsonObject.mapFrom(line).toBuffer();
-          return httpClient.request(HttpMethod.POST, polBuf, resourcesPath(COMPOSITE_PO_LINES), okapiHeaders)
+          return httpClient.request(HttpMethod.POST, polBuf, resourcesPath(PO_LINES), okapiHeaders)
             .thenApply(HelperUtils::verifyAndExtractBody)
             .thenApply(body -> {
               logger.info("response from /po_line: " + body.encodePrettily());

--- a/src/main/java/org/folio/rest/impl/PostOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrderLineHelper.java
@@ -11,7 +11,7 @@ import static org.folio.orders.utils.ResourcePathResolver.ERESOURCE;
 import static org.folio.orders.utils.ResourcePathResolver.FUND_DISTRIBUTION;
 import static org.folio.orders.utils.ResourcePathResolver.LOCATION;
 import static org.folio.orders.utils.ResourcePathResolver.PHYSICAL;
-import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.REPORTING_CODES;
 import static org.folio.orders.utils.ResourcePathResolver.SOURCE;
 import static org.folio.orders.utils.ResourcePathResolver.VENDOR_DETAIL;
@@ -27,20 +27,8 @@ import java.util.concurrent.CompletionException;
 import javax.ws.rs.core.Response;
 
 import org.folio.orders.utils.HelperUtils;
-import org.folio.rest.jaxrs.model.Adjustment;
-import org.folio.rest.jaxrs.model.Alert;
-import org.folio.rest.jaxrs.model.Claim;
-import org.folio.rest.jaxrs.model.Cost;
-import org.folio.rest.jaxrs.model.Details;
-import org.folio.rest.jaxrs.model.Eresource;
+import org.folio.rest.jaxrs.model.*;
 import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.FundDistribution;
-import org.folio.rest.jaxrs.model.Location;
-import org.folio.rest.jaxrs.model.Physical;
-import org.folio.rest.jaxrs.model.PoLine;
-import org.folio.rest.jaxrs.model.ReportingCode;
-import org.folio.rest.jaxrs.model.Source;
-import org.folio.rest.jaxrs.model.VendorDetail;
 import org.folio.rest.jaxrs.resource.Orders;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
@@ -58,7 +46,7 @@ public class PostOrderLineHelper extends AbstractHelper {
     super(httpClient, okapiHeaders, asyncResultHandler, ctx, lang);
   }
 
-  public CompletableFuture<PoLine> createPoLine(PoLine compPOL) {
+  public CompletableFuture<CompositePoLine> createPoLine(CompositePoLine compPOL) {
     compPOL.setId(UUID.randomUUID().toString());
     JsonObject line = JsonObject.mapFrom(compPOL);
     List<CompletableFuture<Void>> subObjFuts = new ArrayList<>();
@@ -80,7 +68,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       .thenCompose(v -> {
         try {
           Buffer polBuf = JsonObject.mapFrom(line).toBuffer();
-          return httpClient.request(HttpMethod.POST, polBuf, resourcesPath(PO_LINES), okapiHeaders)
+          return httpClient.request(HttpMethod.POST, polBuf, resourcesPath(COMPOSITE_PO_LINES), okapiHeaders)
             .thenApply(HelperUtils::verifyAndExtractBody)
             .thenApply(body -> {
               logger.info("response from /po_line: " + body.encodePrettily());
@@ -97,7 +85,7 @@ public class PostOrderLineHelper extends AbstractHelper {
 
 
 
-  private CompletableFuture<Void> createAdjustment(PoLine compPOL, JsonObject line, Adjustment adjustment) {
+  private CompletableFuture<Void> createAdjustment(CompositePoLine compPOL, JsonObject line, Adjustment adjustment) {
     return createSubObjIfPresent(line, adjustment, ADJUSTMENT, resourcesPath(ADJUSTMENT))
       .thenAccept(id -> {
         if (id == null) {
@@ -114,7 +102,7 @@ public class PostOrderLineHelper extends AbstractHelper {
   }
 
 
-  private CompletableFuture<Void> createCost(PoLine compPOL, JsonObject line, Cost cost) {
+  private CompletableFuture<Void> createCost(CompositePoLine compPOL, JsonObject line, Cost cost) {
     return createSubObjIfPresent(line, cost, COST, resourcesPath(COST))
       .thenAccept(id -> {
         if (id == null) {
@@ -130,7 +118,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       });
   }
 
-  private CompletableFuture<Void> createDetails(PoLine compPOL, JsonObject line, Details details) {
+  private CompletableFuture<Void> createDetails(CompositePoLine compPOL, JsonObject line, Details details) {
     return createSubObjIfPresent(line, details, DETAILS, resourcesPath(DETAILS))
       .thenAccept(id -> {
         if (id == null) {
@@ -146,7 +134,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       });
   }
 
-  private CompletableFuture<Void> createEresource(PoLine compPOL, JsonObject line, Eresource eresource) {
+  private CompletableFuture<Void> createEresource(CompositePoLine compPOL, JsonObject line, Eresource eresource) {
     return createSubObjIfPresent(line, eresource, ERESOURCE, resourcesPath(ERESOURCE))
       .thenAccept(id -> {
         if (id == null) {
@@ -162,7 +150,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       });
   }
 
-  private CompletableFuture<Void> createLocation(PoLine compPOL, JsonObject line, Location location) {
+  private CompletableFuture<Void> createLocation(CompositePoLine compPOL, JsonObject line, Location location) {
     return createSubObjIfPresent(line, location, LOCATION, resourcesPath(LOCATION))
       .thenAccept(id -> {
         if (id == null) {
@@ -178,7 +166,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       });
   }
 
-  private CompletableFuture<Void> createPhysical(PoLine compPOL, JsonObject line, Physical physical) {
+  private CompletableFuture<Void> createPhysical(CompositePoLine compPOL, JsonObject line, Physical physical) {
     return createSubObjIfPresent(line, physical, PHYSICAL, resourcesPath(PHYSICAL))
       .thenAccept(id -> {
         if (id == null) {
@@ -194,7 +182,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       });
   }
 
-  private CompletableFuture<Void> createVendorDetail(PoLine compPOL, JsonObject line, VendorDetail vendor) {
+  private CompletableFuture<Void> createVendorDetail(CompositePoLine compPOL, JsonObject line, VendorDetail vendor) {
     return createSubObjIfPresent(line, vendor, VENDOR_DETAIL, resourcesPath(VENDOR_DETAIL))
       .thenAccept(id -> {
         if (id == null) {
@@ -210,7 +198,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       });
   }
 
-  private CompletableFuture<Void> createReportingCodes(PoLine compPOL, JsonObject line,
+  private CompletableFuture<Void> createReportingCodes(CompositePoLine compPOL, JsonObject line,
                                                        List<ReportingCode> reportingCodes) {
 
     List<String> reportingIds = new ArrayList<>();
@@ -227,7 +215,7 @@ public class PostOrderLineHelper extends AbstractHelper {
             }))
         );
 
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]))
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
       .thenAccept(t -> {
         line.put(REPORTING_CODES, reportingIds);
         compPOL.setReportingCodes(reportingCodes);
@@ -239,7 +227,7 @@ public class PostOrderLineHelper extends AbstractHelper {
 
   }
 
-  private CompletableFuture<Void> createSource(PoLine compPOL, JsonObject line, Source source) {
+  private CompletableFuture<Void> createSource(CompositePoLine compPOL, JsonObject line, Source source) {
     return createSubObjIfPresent(line, source, SOURCE, resourcesPath(SOURCE))
       .thenAccept(id -> {
         if (id == null) {
@@ -255,7 +243,7 @@ public class PostOrderLineHelper extends AbstractHelper {
       });
   }
 
-  private CompletableFuture<Void> createClaims(PoLine compPOL, JsonObject line, List<Claim> claims) {
+  private CompletableFuture<Void> createClaims(CompositePoLine compPOL, JsonObject line, List<Claim> claims) {
 
     List<String> claimsIds = new ArrayList<>();
     List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -271,7 +259,7 @@ public class PostOrderLineHelper extends AbstractHelper {
             }))
         );
 
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]))
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
       .thenAccept(t -> {
         line.put(CLAIMS, claimsIds);
         compPOL.setClaims(claims);
@@ -285,7 +273,7 @@ public class PostOrderLineHelper extends AbstractHelper {
 
 
 
-  private CompletableFuture<Void> createAlerts(PoLine compPOL, JsonObject line, List<Alert> alerts) {
+  private CompletableFuture<Void> createAlerts(CompositePoLine compPOL, JsonObject line, List<Alert> alerts) {
 
     List<String> alertIds = new ArrayList<>();
     List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -347,7 +335,7 @@ public class PostOrderLineHelper extends AbstractHelper {
     return future;
   }
 
-  private CompletableFuture<Void> createFundDistribution(PoLine compPOL, JsonObject line, List<FundDistribution> fundDistribution) {
+  private CompletableFuture<Void> createFundDistribution(CompositePoLine compPOL, JsonObject line, List<FundDistribution> fundDistribution) {
 
     List<String> fundDistributionIds = new ArrayList<>();
     List<CompletableFuture<Void>> futures = new ArrayList<>();

--- a/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostOrdersHelper.java
@@ -14,10 +14,10 @@ import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.core.Response;
 
 import org.folio.orders.utils.HelperUtils;
+import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
 import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.resource.Orders.PostOrdersCompositeOrdersResponse;
 import org.folio.rest.jaxrs.model.PoNumber;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
@@ -90,7 +90,7 @@ public class PostOrdersHelper extends AbstractHelper {
         })
         .thenCompose(v -> handlePoLines(compPO))
         .thenAccept(lines -> {
-          compPO.setPoLines(lines);
+          compPO.setCompositePoLines(lines);
           compPO.setAdjustment(HelperUtils.calculateAdjustment(lines));
         })
         .thenCompose(v -> {
@@ -111,11 +111,11 @@ public class PostOrdersHelper extends AbstractHelper {
     return future;
   }
 
-  private CompletableFuture<List<PoLine>> handlePoLines(CompositePurchaseOrder compPO) {
-    List<PoLine> lines = new ArrayList<>(compPO.getPoLines().size());
+  private CompletableFuture<List<CompositePoLine>> handlePoLines(CompositePurchaseOrder compPO) {
+    List<CompositePoLine> lines = new ArrayList<>(compPO.getCompositePoLines().size());
     List<CompletableFuture<Void>> futures = new ArrayList<>();
-    for (int i = 0; i < compPO.getPoLines().size(); i++) {
-      PoLine compPOL = compPO.getPoLines().get(i);
+    for (int i = 0; i < compPO.getCompositePoLines().size(); i++) {
+      CompositePoLine compPOL = compPO.getCompositePoLines().get(i);
       compPOL.setPurchaseOrderId(compPO.getId());
       compPOL.setPoLineNumber(compPO.getPoNumber() + "-" + (i + 1));
 

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -17,7 +17,7 @@ import static org.folio.orders.utils.ResourcePathResolver.ERESOURCE;
 import static org.folio.orders.utils.ResourcePathResolver.FUND_DISTRIBUTION;
 import static org.folio.orders.utils.ResourcePathResolver.LOCATION;
 import static org.folio.orders.utils.ResourcePathResolver.PHYSICAL;
-import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.REPORTING_CODES;
 import static org.folio.orders.utils.ResourcePathResolver.SOURCE;
 import static org.folio.orders.utils.ResourcePathResolver.VENDOR_DETAIL;
@@ -133,7 +133,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
    */
   public CompletableFuture<JsonObject> updateOrderLineSummary(String poLineId, JsonObject poLine) {
     logger.debug("Updating PO line...");
-    String endpoint = String.format(URL_WITH_LANG_PARAM, resourceByIdPath(COMPOSITE_PO_LINES, poLineId), lang);
+    String endpoint = String.format(URL_WITH_LANG_PARAM, resourceByIdPath(PO_LINES, poLineId), lang);
     return operateOnSubObj(HttpMethod.PUT, endpoint, poLine, httpClient, ctx, okapiHeaders, logger);
   }
 

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -186,7 +186,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
    * @param itemIds List of item id
    * @return CompletableFuture with newly created Pieces associated with PO line.
    */
-  private CompletableFuture<Void> createPieces(PoLine compPOL, List<String> itemIds) {
+  private CompletableFuture<Void> createPieces(CompositePoLine compPOL, List<String> itemIds) {
 		CompletableFuture<Void> future = new VertxCompletableFuture<>(ctx);
 		if (itemIds.isEmpty()) {
 			future.complete(null);

--- a/src/main/java/org/folio/rest/impl/PutOrdersByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrdersByIdHelper.java
@@ -37,7 +37,7 @@ import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
 import static org.folio.orders.utils.HelperUtils.operateOnSubObj;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.PENDING;
-import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.PURCHASE_ORDER;
 import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
 
@@ -122,7 +122,7 @@ public class PutOrdersByIdHelper extends AbstractHelper {
     if (isNotEmpty(compPO.getCompositePoLines()) || isPoNumberChanged(poFromStorage, compPO)) {
       return getPoLines(poFromStorage.getString(ID), lang, httpClient, ctx, okapiHeaders, logger)
         .thenCompose(jsonObject -> {
-          JsonArray existedPoLinesArray = jsonObject.getJsonArray(COMPOSITE_PO_LINES);
+          JsonArray existedPoLinesArray = jsonObject.getJsonArray(PO_LINES);
           if (isNotEmpty(compPO.getCompositePoLines())) {
             return handlePoLines(compPO, existedPoLinesArray);
           } else {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1767,7 +1767,7 @@ public class OrdersImplTest {
         .header(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10)
       .get(LINES_PATH + "?query=purchase_order_id==" + ORDER_ID_WITH_PO_LINES)
         .then()
-         // .statusCode(200)
+          .statusCode(200)
           .extract()
           .response();
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl;
 
+import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
 import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
 import static org.folio.orders.utils.ResourcePathResolver.ADJUSTMENT;
@@ -11,7 +12,7 @@ import static org.folio.orders.utils.ResourcePathResolver.ERESOURCE;
 import static org.folio.orders.utils.ResourcePathResolver.FUND_DISTRIBUTION;
 import static org.folio.orders.utils.ResourcePathResolver.LOCATION;
 import static org.folio.orders.utils.ResourcePathResolver.PHYSICAL;
-import static org.folio.orders.utils.ResourcePathResolver.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.PURCHASE_ORDER;
 import static org.folio.orders.utils.ResourcePathResolver.REPORTING_CODES;
 import static org.folio.orders.utils.ResourcePathResolver.SOURCE;
@@ -748,10 +749,10 @@ public class OrdersImplTest {
     }
 
     assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
-    assertEquals(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.POST).size(), poLinesFromRequest.size() - sameLinesCount);
-    assertEquals(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.DELETE).size(), poLinesFromStorage.size() - sameLinesCount);
-    assertNotNull(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.PUT));
-    assertEquals(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.PUT).size(), sameLinesCount);
+    assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.POST).size(), poLinesFromRequest.size() - sameLinesCount);
+    assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.DELETE).size(), poLinesFromStorage.size() - sameLinesCount);
+    assertNotNull(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT));
+    assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT).size(), sameLinesCount);
   }
 
   @Test
@@ -810,12 +811,12 @@ public class OrdersImplTest {
     verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), "", 204);
 
     assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
-    assertEquals(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.PUT).size(), storData.getJsonArray(COMPOSITE_PO_LINES).size());
-    MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.PUT).forEach(poLine -> {
+    assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT).size(), storData.getJsonArray(COMPOSITE_PO_LINES).size());
+    MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT).forEach(poLine -> {
       Matcher matcher = poLinePattern.matcher(poLine.getString(PO_LINE_NUMBER));
       assertTrue(matcher.find());
     });
-    assertNull(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.DELETE));
+    assertNull(MockServer.serverRqRs.get(PO_LINES, HttpMethod.DELETE));
   }
 
   @Test
@@ -832,7 +833,7 @@ public class OrdersImplTest {
 
     verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), "", 204);
     verifyPoWithPoLinesUpdate(reqData, storageData);
-    MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.PUT).forEach(poLine -> {
+    MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT).forEach(poLine -> {
       Matcher matcher = poLinePattern.matcher(poLine.getString(PO_LINE_NUMBER));
       assertTrue(matcher.find());
     });
@@ -1201,7 +1202,7 @@ public class OrdersImplTest {
     verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), "", 204);
 
     assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
-    assertNull(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.DELETE));
+    assertNull(MockServer.serverRqRs.get(PO_LINES, HttpMethod.DELETE));
   }
 
   @Test
@@ -1213,7 +1214,7 @@ public class OrdersImplTest {
     verifyPut(COMPOSITE_ORDERS_PATH + "/" + ORDER_ID_WITHOUT_PO_LINES, reqData.toString(), "", 204);
 
     assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
-    assertEquals(MockServer.serverRqRs.get(COMPOSITE_PO_LINES, HttpMethod.POST).size(), reqData.getJsonArray(COMPOSITE_PO_LINES).size());
+    assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.POST).size(), reqData.getJsonArray(COMPOSITE_PO_LINES).size());
 
   }
 
@@ -1578,7 +1579,7 @@ public class OrdersImplTest {
 
     Map<String, List<JsonObject>> column = MockServer.serverRqRs.column(HttpMethod.GET);
     assertEquals(1, column.size());
-    assertThat(column, hasKey(COMPOSITE_PO_LINES));
+    assertThat(column, hasKey(PO_LINES));
 
     column = MockServer.serverRqRs.column(HttpMethod.POST);
     assertEquals(2, column.size());
@@ -1591,7 +1592,7 @@ public class OrdersImplTest {
 
     column = MockServer.serverRqRs.column(HttpMethod.PUT);
     assertEquals(10, column.size());
-    assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, COST, DETAILS, ERESOURCE, LOCATION, PHYSICAL, VENDOR_DETAIL, CLAIMS, FUND_DISTRIBUTION, COMPOSITE_PO_LINES));
+    assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, COST, DETAILS, ERESOURCE, LOCATION, PHYSICAL, VENDOR_DETAIL, CLAIMS, FUND_DISTRIBUTION, PO_LINES));
   }
 
   @Test
@@ -1607,7 +1608,7 @@ public class OrdersImplTest {
 
     Map<String, List<JsonObject>> column = MockServer.serverRqRs.column(HttpMethod.GET);
     assertEquals(1, column.size());
-    assertThat(column, hasKey(COMPOSITE_PO_LINES));
+    assertThat(column, hasKey(PO_LINES));
 
     column = MockServer.serverRqRs.column(HttpMethod.POST);
     assertEquals(3, column.size());
@@ -1618,9 +1619,9 @@ public class OrdersImplTest {
 
     column = MockServer.serverRqRs.column(HttpMethod.PUT);
     assertEquals(8, column.size());
-    assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, COST, DETAILS, ERESOURCE, LOCATION, PHYSICAL, VENDOR_DETAIL, COMPOSITE_PO_LINES));
+    assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, COST, DETAILS, ERESOURCE, LOCATION, PHYSICAL, VENDOR_DETAIL, PO_LINES));
 
-    List<JsonObject> jsonObjects = column.get(COMPOSITE_PO_LINES);
+    List<JsonObject> jsonObjects = column.get(PO_LINES);
     assertThat(jsonObjects, hasSize(1));
     JsonObject entry = jsonObjects.get(0);
 
@@ -1643,7 +1644,7 @@ public class OrdersImplTest {
 
     Map<String, List<JsonObject>> column = MockServer.serverRqRs.column(HttpMethod.GET);
     assertEquals(1, column.size());
-    assertThat(column, hasKey(COMPOSITE_PO_LINES));
+    assertThat(column, hasKey(PO_LINES));
 
     column = MockServer.serverRqRs.column(HttpMethod.POST);
     assertTrue(column.isEmpty());
@@ -1654,9 +1655,9 @@ public class OrdersImplTest {
 
     column = MockServer.serverRqRs.column(HttpMethod.PUT);
     assertEquals(13, column.size());
-    assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, ALERTS, CLAIMS, COST, DETAILS, ERESOURCE, FUND_DISTRIBUTION, LOCATION, PHYSICAL, REPORTING_CODES, SOURCE, VENDOR_DETAIL, COMPOSITE_PO_LINES));
+    assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, ALERTS, CLAIMS, COST, DETAILS, ERESOURCE, FUND_DISTRIBUTION, LOCATION, PHYSICAL, REPORTING_CODES, SOURCE, VENDOR_DETAIL, PO_LINES));
 
-    List<JsonObject> jsonObjects = column.get(COMPOSITE_PO_LINES);
+    List<JsonObject> jsonObjects = column.get(PO_LINES);
     assertThat(jsonObjects, hasSize(1));
     JsonObject entry = jsonObjects.get(0);
 
@@ -1703,7 +1704,7 @@ public class OrdersImplTest {
 
     Map<String, List<JsonObject>> column = MockServer.serverRqRs.column(HttpMethod.GET);
     assertEquals(1, column.size());
-    assertThat(column, hasKey(COMPOSITE_PO_LINES));
+    assertThat(column, hasKey(PO_LINES));
 
     column = MockServer.serverRqRs.column(HttpMethod.POST);
     assertTrue(column.isEmpty());
@@ -1762,7 +1763,7 @@ public class OrdersImplTest {
 
     Map<String, List<JsonObject>> column = MockServer.serverRqRs.column(HttpMethod.GET);
     assertEquals(1, column.size());
-    assertThat(column, hasKey(COMPOSITE_PO_LINES));
+    assertThat(column, hasKey(PO_LINES));
 
     column = MockServer.serverRqRs.column(HttpMethod.POST);
     assertTrue(column.isEmpty());
@@ -1791,7 +1792,7 @@ public class OrdersImplTest {
 
     Map<String, List<JsonObject>> column = MockServer.serverRqRs.column(HttpMethod.GET);
     assertEquals(1, column.size());
-    assertThat(column, hasKey(COMPOSITE_PO_LINES));
+    assertThat(column, hasKey(PO_LINES));
 
     column = MockServer.serverRqRs.column(HttpMethod.POST);
     assertTrue(column.isEmpty());
@@ -1800,9 +1801,9 @@ public class OrdersImplTest {
     assertThat(column.keySet(), containsInAnyOrder(ADJUSTMENT, COST, DETAILS, ERESOURCE, LOCATION, PHYSICAL, VENDOR_DETAIL));
 
     column = MockServer.serverRqRs.column(HttpMethod.PUT);
-    assertThat(column.keySet(), containsInAnyOrder(COMPOSITE_PO_LINES, SOURCE));
+    assertThat(column.keySet(), containsInAnyOrder(PO_LINES, SOURCE));
 
-    JsonObject lineWithIds = column.get(COMPOSITE_PO_LINES).get(0);
+    JsonObject lineWithIds = column.get(PO_LINES).get(0);
 
     // Verify that object has only PO and PO line ids
     assertEquals(lineId, lineWithIds.remove(ID));
@@ -2007,7 +2008,7 @@ public class OrdersImplTest {
       router.route(HttpMethod.POST, "/inventory/instances").handler(this::handlePostInstanceRecord);
       router.route(HttpMethod.POST, "/item-storage/items").handler(this::handlePostItemRecord);
       router.route(HttpMethod.POST, "/holdings-storage/holdings").handler(this::handlePostHoldingRecord);
-      router.route(HttpMethod.POST, resourcesPath(COMPOSITE_PO_LINES)).handler(this::handlePostPOLine);
+      router.route(HttpMethod.POST, resourcesPath(PO_LINES)).handler(this::handlePostPOLine);
       router.route(HttpMethod.POST, resourcesPath(ADJUSTMENT)).handler(ctx -> handlePostGenericSubObj(ctx, ADJUSTMENT));
       router.route(HttpMethod.POST, resourcesPath(ALERTS)).handler(ctx -> handlePostGenericSubObj(ctx, ALERTS));
       router.route(HttpMethod.POST, resourcesPath(CLAIMS)).handler(ctx -> handlePostGenericSubObj(ctx, CLAIMS));
@@ -2031,8 +2032,8 @@ public class OrdersImplTest {
       router.route(HttpMethod.GET, "/item-storage/items").handler(this::handleGetItemsRecords);
       router.route(HttpMethod.GET, "/holdings-storage/holdings").handler(this::handleGetHoldingRecord);
       router.route(HttpMethod.GET, "/loan-types").handler(this::handleGetLoanType);
-      router.route(HttpMethod.GET, resourcesPath(COMPOSITE_PO_LINES)).handler(this::handleGetPoLines);
-      router.route(HttpMethod.GET, resourcePath(COMPOSITE_PO_LINES)).handler(this::handleGetPoLineById);
+      router.route(HttpMethod.GET, resourcesPath(PO_LINES)).handler(this::handleGetPoLines);
+      router.route(HttpMethod.GET, resourcePath(PO_LINES)).handler(this::handleGetPoLineById);
       router.route(HttpMethod.GET, resourcePath(ADJUSTMENT)).handler(this::handleGetAdjustment);
       router.route(HttpMethod.GET, resourcePath(ALERTS)).handler(ctx -> handleGetGenericSubObj(ctx, ALERTS));
       router.route(HttpMethod.GET, resourcePath(CLAIMS)).handler(ctx -> handleGetGenericSubObj(ctx, CLAIMS));
@@ -2049,7 +2050,7 @@ public class OrdersImplTest {
       router.route(HttpMethod.GET, resourcesPath(PIECES)).handler(ctx -> handleGetGenericPieceObj(ctx, PIECES));
 
       router.route(HttpMethod.PUT, resourcePath(PURCHASE_ORDER)).handler(ctx -> handlePutGenericSubObj(ctx, PURCHASE_ORDER));
-      router.route(HttpMethod.PUT, resourcePath(COMPOSITE_PO_LINES)).handler(ctx -> handlePutGenericSubObj(ctx, COMPOSITE_PO_LINES));
+      router.route(HttpMethod.PUT, resourcePath(PO_LINES)).handler(ctx -> handlePutGenericSubObj(ctx, PO_LINES));
       router.route(HttpMethod.PUT, resourcePath(ADJUSTMENT)).handler(ctx -> handlePutGenericSubObj(ctx, ADJUSTMENT));
       router.route(HttpMethod.PUT, resourcePath(ALERTS)).handler(ctx -> handlePutGenericSubObj(ctx, ALERTS));
       router.route(HttpMethod.PUT, resourcePath(CLAIMS)).handler(ctx -> handlePutGenericSubObj(ctx, CLAIMS));
@@ -2065,7 +2066,7 @@ public class OrdersImplTest {
 
 
       router.route(HttpMethod.DELETE, resourcesPath(PURCHASE_ORDER)+"/:id").handler(ctx -> handleDeleteGenericSubObj(ctx, PURCHASE_ORDER));
-      router.route(HttpMethod.DELETE, resourcePath(COMPOSITE_PO_LINES)).handler(ctx -> handleDeleteGenericSubObj(ctx, COMPOSITE_PO_LINES));
+      router.route(HttpMethod.DELETE, resourcePath(PO_LINES)).handler(ctx -> handleDeleteGenericSubObj(ctx, PO_LINES));
       router.route(HttpMethod.DELETE, resourcePath(ADJUSTMENT)).handler(ctx -> handleDeleteGenericSubObj(ctx, ADJUSTMENT));
       router.route(HttpMethod.DELETE, resourcePath(ALERTS)).handler(ctx -> handleDeleteGenericSubObj(ctx, ALERTS));
       router.route(HttpMethod.DELETE, resourcePath(CLAIMS)).handler(ctx -> handleDeleteGenericSubObj(ctx, CLAIMS));
@@ -2290,7 +2291,7 @@ public class OrdersImplTest {
           JsonArray lines = compPO.getJsonArray(COMPOSITE_PO_LINES);
           JsonObject po_lines = new JsonObject();
           if (lines == null) {
-            po_lines.put(COMPOSITE_PO_LINES, new JsonArray())
+            po_lines.put(PO_LINES, new JsonArray())
               .put("total_records", 0)
               .put("first", 0)
               .put("last", 0);
@@ -2301,7 +2302,7 @@ public class OrdersImplTest {
               replaceObjectsByIds(line, ALERTS, CLAIMS, FUND_DISTRIBUTION);
             });
 
-            po_lines.put(COMPOSITE_PO_LINES, lines)
+            po_lines.put(PO_LINES, lines)
               .put("first", lines.isEmpty() ? 0 : 1)
               .put("last", lines.size());
             if (EMPTY_CONFIG_TENANT.equals(tenant)) {
@@ -2352,7 +2353,7 @@ public class OrdersImplTest {
       String id = ctx.request().getParam(ID);
       logger.info("id: " + id);
 
-      addServerRqRsData(HttpMethod.GET, COMPOSITE_PO_LINES, new JsonObject().put(ID, id));
+      addServerRqRsData(HttpMethod.GET, PO_LINES, new JsonObject().put(ID, id));
 
       if (ID_FOR_INTERNAL_SERVER_ERROR.equals(id)) {
         serverResponse(ctx, 500, TEXT_PLAIN, INTERNAL_SERVER_ERROR);
@@ -2364,7 +2365,7 @@ public class OrdersImplTest {
           // Attempt to find POLine in mock server memory
           Map<String, List<JsonObject>> column = serverRqRs.column(HttpMethod.POST);
           if(!column.isEmpty()) {
-            List<JsonObject> objects = new ArrayList<>(column.get(COMPOSITE_PO_LINES));
+            List<JsonObject> objects = new ArrayList<>(column.get(PO_LINES));
             Comparator<JsonObject> comparator = Comparator.comparing(o -> o.getString(ID));
             objects.sort(comparator);
             int ind = Collections.binarySearch(objects, new JsonObject().put(ID, id), comparator);
@@ -2634,7 +2635,7 @@ public class OrdersImplTest {
           .end(JsonObject.mapFrom(pol).encodePrettily());
       }
 
-      addServerRqRsData(HttpMethod.POST, COMPOSITE_PO_LINES, body);
+      addServerRqRsData(HttpMethod.POST, PO_LINES, body);
     }
 
     private void handleGetLocation(RoutingContext ctx) {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -147,6 +147,7 @@ public class OrdersImplTest {
   private static final String PO_LINE_ID_WITH_SUB_OBJECT_OPERATION_500_CODE = "c2755a78-2f8d-47d0-a218-059a9b7391b4";
   private static final String PO_LINE_ID_WITH_FUND_DISTRIBUTION_404_CODE = "f7223ce8-9e92-4c28-8fd9-097596053b7c";
   private static final String ORDER_ID_WITHOUT_PO_LINES = "50fb922c-3fa9-494e-a972-f2801f1b9fd1";
+  private static final String ORDER_ID_WITH_PO_LINES = "ab18897b-0e40-4f31-896b-9c9adc979a87";
 
   // API paths
   private final static String COMPOSITE_ORDERS_PATH = "/orders/composite-orders";
@@ -170,6 +171,7 @@ public class OrdersImplTest {
   private static final String COMP_PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeLines/";
   private static final String MOCK_DATA_ROOT_PATH = "src/test/resources/";
   private static final String listedPrintMonographPath = MOCK_DATA_ROOT_PATH + "/po_listed_print_monograph.json";
+  private static final String POLINES_COLLECTION = PO_LINES_MOCK_DATA_PATH + "/po_line_collection.json";
   private static final String MINIMAL_ORDER_PATH = MOCK_DATA_ROOT_PATH + "/minimal_order.json";
   private static final String poCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_creation_failure.json";
   private static final String poLineCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_line_creation_failure.json";
@@ -1756,20 +1758,20 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testGetOrderPOLinesNoParameters() {
+  public void testGetOrderPOLinesByPoId() {
     logger.info("=== Test Get Orders lines - With empty query ===");
 
     final Response resp = RestAssured
       .with()
         .header(X_OKAPI_URL)
         .header(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10)
-      .get(LINES_PATH)
+      .get(LINES_PATH + "?query=purchase_order_id==" + ORDER_ID_WITH_PO_LINES)
         .then()
          // .statusCode(200)
           .extract()
           .response();
 
-    assertEquals(3, resp.getBody().as(PoLineCollection.class).getTotalRecords().intValue());
+    assertEquals(2, resp.getBody().as(PoLineCollection.class).getTotalRecords().intValue());
   }
 
   @Test
@@ -2152,6 +2154,11 @@ public class OrdersImplTest {
         serverResponse(ctx, 500, TEXT_PLAIN, INTERNAL_SERVER_ERROR);
       } else {
         try {
+          if (id.equals(ORDER_ID_WITH_PO_LINES)) {
+            JsonObject po_lines = new JsonObject(getMockData(POLINES_COLLECTION));
+            serverResponse(ctx, 200, APPLICATION_JSON, po_lines.encodePrettily());
+            return;
+          }
           JsonObject compPO = new JsonObject(getMockData(String.format("%s%s.json", COMP_ORDER_MOCK_DATA_PATH, id)));
           JsonArray lines = compPO.getJsonArray(COMPOSITE_PO_LINES);
           JsonObject po_lines = new JsonObject();

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1032,7 +1032,7 @@ public class OrdersImplTest {
     }
   }
 
-  private void verifyItemsCreated(List<JsonObject> inventoryItems, PoLine pol, int expectedQuantity) {
+  private void verifyItemsCreated(List<JsonObject> inventoryItems, CompositePoLine pol, int expectedQuantity) {
     int actualQuantity = 0;
 
     for (JsonObject item : inventoryItems) {

--- a/src/test/resources/minimal_order.json
+++ b/src/test/resources/minimal_order.json
@@ -9,7 +9,7 @@
     "createdDate": "2010-10-08T03:53:00.000",
     "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
   },
-  "po_lines": [
+  "compositePoLines": [
     {
       "acquisition_method": "Purchase At Vendor System",
       "description": "ABCDEFGH",

--- a/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -32,7 +32,7 @@
     "createdDate": "2018-07-18T00:00:00.000",
     "createdByUserId": "28d102a2-d137-11e8-a8d5-f2801f1b9fd1"
   },
-  "po_lines": [
+  "compositePoLines": [
     {
       "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
       "acquisition_method": "Purchase",

--- a/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
+++ b/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
@@ -25,7 +25,7 @@
     "createdDate": "2018-06-29T00:00:00.000",
     "createdByUserId": "28d0f99c-d137-11e8-a8d5-f2801f1b9fd1"
   },
-  "po_lines": [
+  "compositePoLines": [
     {
       "id": "50fb4bfa-cdf1-11e8-a8d5-f2801f1b9fd1",
       "acquisition_method": "Purchase",

--- a/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
+++ b/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
@@ -10,7 +10,7 @@
   "total_items": 3,
   "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflow_status": "Pending",
-  "po_lines": [
+  "compositePoLines": [
     {
       "id": "c2755a78-2f8d-47d0-a218-059a9b7391b4",
       "acquisition_method": "Purchase",

--- a/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -25,7 +25,7 @@
     "createdDate": "2014-07-06T00:00:00.000",
     "createdByUserId": "28d10cfc-d137-11e8-a8d5-f2801f1b9fd1"
   },
-  "po_lines": [
+  "compositePoLines": [
     {
       "id": "50fb63b0-cdf1-11e8-a8d5-f2801f1b9fd1",
       "acquisition_method": "Purchase",

--- a/src/test/resources/mockdata/compositeOrders/getOrders.json
+++ b/src/test/resources/mockdata/compositeOrders/getOrders.json
@@ -2,19 +2,19 @@
   "composite_purchase_orders" : [ {
     "id" : "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
     "po_number" : "268758",
-    "po_lines" : [ ]
+    "compositePoLines" : [ ]
   }, {
     "id" : "e5ae4afd-3fa9-494e-a972-f541df9b877e",
     "po_number" : "268879",
-    "po_lines" : [ ]
+    "compositePoLines" : [ ]
   }, {
     "id" : "07f65192-44a4-483d-97aa-b137bbd96390",
     "po_number" : "S60402",
-    "po_lines" : [ ]
+    "compositePoLines" : [ ]
   }, {
     "id" : "50fb922c-3fa9-494e-a972-f2801f1b9fd1",
     "po_number" : "268s879",
-    "po_lines" : [ ]
+    "compositePoLines" : [ ]
   } ],
   "total_records" : 4
 }

--- a/src/test/resources/mockdata/lines/po_line_collection.json
+++ b/src/test/resources/mockdata/lines/po_line_collection.json
@@ -1,0 +1,137 @@
+{
+  "po_lines": [
+    {
+      "id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+      "edition": "First edition",
+      "checkin_items": false,
+      "instance_id": "8343e5a0-fed8-11e8-8eb2-f2801f1b9fd1",
+      "agreement_id": "bdc75fea-fed8-11e8-8eb2-f2801f1b9fd1",
+      "acquisition_method": "Purchase At Vendor System",
+      "adjustment": "1363467f-eb47-4e09-9e28-e25aa464adb7",
+      "alerts": [
+        "9a665b22-9fe5-4c95-b4ee-837a5433c95d"
+      ],
+      "cancellation_restriction": false,
+      "cancellation_restriction_note": "ABCDEFGHIJKLMNOPQRSTUVW",
+      "claims": [
+        "f7d7d4e4-255e-46dc-9f08-b953fb1e872d"
+      ],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Ed Mashburn",
+          "contributor_type": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+        }
+      ],
+      "cost": "e047212b-c94f-4cb1-84b0-367848381494",
+      "description": "ABCDEFGH",
+      "details": "349d9438-12bd-4e2e-9eb6-dfa830ab99a4",
+      "donor": "ABCDEFGHIJKLM",
+      "eresource": "468b679c-378b-4009-9a17-a6711cefc85f",
+      "fund_distribution": [
+        "d10879e8-8c2d-4850-bcb9-0ec8e2e10021"
+      ],
+      "location": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+      "order_format": "Physical Resource",
+      "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
+      "payment_status": "Awaiting Payment",
+      "physical": "5ee243f9-72e5-4464-bdbc-43a21873d648",
+      "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
+      "po_line_number": "268758-03",
+      "publication_date": "2017",
+      "publisher": "Schiffer Publishing",
+      "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
+      "receipt_date": "2018-10-09T00:00:00.000Z",
+      "receipt_status": "Awaiting Receipt",
+      "reporting_codes": [
+        "5926dcd7-85f5-4504-8283-712595ebc38b",
+        "fa316c04-8101-4e72-8aaf-01281bac718f",
+        "ea68b696-3125-4940-bf91-1d128323473e"
+      ],
+      "requester": "Leo Bulero",
+      "rush": true,
+      "selector": "ABCD",
+      "source": "024b6f41-c5c6-4280-858e-33fba452a334",
+      "tags": [
+        "ABCDEFGHIJKLMNOPQRSTU",
+        "ABCDEFG",
+        "ABCDEFGHIJKLMNOPQRSTU",
+        "ABCDEFGHIJKLMNO"
+      ],
+      "title": "Kayak Fishing in the Northern Gulf Coast",
+      "vendor_detail": "d5065f0d-fb88-4d23-b0c1-57e754fba40e",
+      "metadata": {
+        "createdDate": "2018-07-19T00:00:00.000+0000",
+        "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
+      }
+    },
+    {
+      "id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+      "edition": "First edition",
+      "checkin_items": false,
+      "instance_id": "8343e5a0-fed8-11e8-8eb2-f2801f1b9fd1",
+      "agreement_id": "bdc75fea-fed8-11e8-8eb2-f2801f1b9fd1",
+      "acquisition_method": "Purchase At Vendor System",
+      "adjustment": "1363467f-eb47-4e09-9e28-e25aa464adb7",
+      "alerts": [
+        "9a665b22-9fe5-4c95-b4ee-837a5433c95d"
+      ],
+      "cancellation_restriction": false,
+      "cancellation_restriction_note": "ABCDEFGHIJKLMNOPQRSTUVW",
+      "claims": [
+        "f7d7d4e4-255e-46dc-9f08-b953fb1e872d"
+      ],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Ed Mashburn",
+          "contributor_type": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+        }
+      ],
+      "cost": "e047212b-c94f-4cb1-84b0-367848381494",
+      "description": "ABCDEFGH",
+      "details": "349d9438-12bd-4e2e-9eb6-dfa830ab99a4",
+      "donor": "ABCDEFGHIJKLM",
+      "eresource": "468b679c-378b-4009-9a17-a6711cefc85f",
+      "fund_distribution": [
+        "d10879e8-8c2d-4850-bcb9-0ec8e2e10021"
+      ],
+      "location": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+      "order_format": "Physical Resource",
+      "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
+      "payment_status": "Awaiting Payment",
+      "physical": "5ee243f9-72e5-4464-bdbc-43a21873d648",
+      "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
+      "po_line_number": "268758-03",
+      "publication_date": "2017",
+      "publisher": "Schiffer Publishing",
+      "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
+      "receipt_date": "2018-10-09T00:00:00.000Z",
+      "receipt_status": "Awaiting Receipt",
+      "reporting_codes": [
+        "5926dcd7-85f5-4504-8283-712595ebc38b",
+        "fa316c04-8101-4e72-8aaf-01281bac718f",
+        "ea68b696-3125-4940-bf91-1d128323473e"
+      ],
+      "requester": "Leo Bulero",
+      "rush": true,
+      "selector": "ABCD",
+      "source": "024b6f41-c5c6-4280-858e-33fba452a334",
+      "tags": [
+        "ABCDEFGHIJKLMNOPQRSTU",
+        "ABCDEFG",
+        "ABCDEFGHIJKLMNOPQRSTU",
+        "ABCDEFGHIJKLMNO"
+      ],
+      "title": "Kayak Fishing in the Northern Gulf Coast",
+      "vendor_detail": "d5065f0d-fb88-4d23-b0c1-57e754fba40e",
+      "metadata": {
+        "createdDate": "2018-07-19T00:00:00.000+0000",
+        "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
+      }
+    }
+  ],
+  "total_records": 2,
+  "first": 1,
+  "last": 2
+}

--- a/src/test/resources/po_creation_failure.json
+++ b/src/test/resources/po_creation_failure.json
@@ -1,6 +1,6 @@
 {
   "po_number": "123",
-  "po_lines": [
+  "compositePoLines": [
     {
       "po_line_number": "12345-1",
       "source": { "code": "FOLIO" }

--- a/src/test/resources/po_line_creation_failure.json
+++ b/src/test/resources/po_line_creation_failure.json
@@ -1,6 +1,6 @@
 {
   "po_number": "TESTDATA0123",
-  "po_lines": [
+  "compositePoLines": [
     {
       "po_line_number": "8675309-1",
       "source": { "code": "FOLIO" }

--- a/src/test/resources/po_listed_electronic_monograph.json
+++ b/src/test/resources/po_listed_electronic_monograph.json
@@ -28,7 +28,7 @@
     "createdDate": "2010-10-08T03:53:00.000",
     "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
   },
-  "po_lines": [
+  "compositePoLines": [
     {
       "acquisition_method": "Purchase At Vendor System",
       "adjustment": {

--- a/src/test/resources/po_listed_print_monograph.json
+++ b/src/test/resources/po_listed_print_monograph.json
@@ -27,7 +27,7 @@
     "createdDate": "2010-10-08T03:53:00.000",
     "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
   },
-  "po_lines": [
+  "compositePoLines": [
     {
       "id": "fca5fa9e-15cb-4a3d-ab09-eeea99b97a47",
       "acquisition_method": "Purchase At Vendor System",

--- a/src/test/resources/po_listed_print_serial.json
+++ b/src/test/resources/po_listed_print_serial.json
@@ -35,7 +35,7 @@
     "createdDate": "2010-10-08T03:53:00.000",
     "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
   },
-  "po_lines": [
+  "compositePoLines": [
     {
       "acquisition_method": "Purchase At Vendor System",
       "adjustment": {

--- a/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
+++ b/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
@@ -10,7 +10,7 @@
   "total_items": 3,
   "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflow_status": "Pending",
-  "po_lines": [
+  "compositePoLines": [
     {
       "id": "50fb4bfa-cdf1-11e8-a8d5-f2801f1b9fd1",
       "acquisition_method": "Purchase",

--- a/src/test/resources/put_order_with_po_lines.json
+++ b/src/test/resources/put_order_with_po_lines.json
@@ -10,7 +10,7 @@
   "total_items": 3,
   "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflow_status": "Pending",
-  "po_lines": [
+  "compositePoLines": [
     {
       "id": "50fb4bfa-cdf1-11e8-a8d5-f2801f1b9fd1",
       "acquisition_method": "Purchase",


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDERS-142
## Purpose
The purpose is to implement endpoint GET /orders/order-lines endpoint

## Approach
* Resolving naming collisions after merging https://github.com/folio-org/acq-models/pull/48
* Implementing GET /orders/order-lines endpoint
* Unit test updates

#### TODOS and Open Questions
Firstly https://github.com/folio-org/acq-models/pull/48 should be merged
Once this is done the following modules have to be updated to consume schema change:
* mod-orders (by current PR)
* UI orders app
* mod-gobi https://github.com/folio-org/mod-gobi/pull/41