### PR TITLE
Add pre-merge checklist to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -49,3 +49,29 @@
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->
+
+## Pre-Merge Checklist:
+Before merging this PR, please go through the following list and take appropriate actions.
+
+- Does this introduce breaking changes?
+  - [ ] Were any API paths or methods changed, added or removed?
+  - [ ] Were there any schema changes?
+  - [ ] Did any of the interface versions change?
+  - [ ] Were permissions changed, added, or removed?
+  - [ ] Are there new interface dependencies?
+
+If the answer to any of those questions is yes, **STOP** and consider the following:
+
+- What other modules will these changes impact?
+- Do JIRAs exist to update the impacted modules?
+  - [ ] If not, please create them
+  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
+  - [ ] Do they have all they appropriate links to blocked/related issues?
+- Are the JIRAs under active development?  
+  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
+- Do PRs exist for these changes?
+  - [ ] If so, have they been approved?
+
+Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  
+
+While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -53,14 +53,19 @@
 ## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.
 
+- Does this PR meet or exceed the expected quality standards?
+  - [ ] Code coverage on new code is 80% or greater
+  - [ ] Duplications on new code is 3% or less
+  - [ ] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
-
-If the answer to any of those questions is yes, **STOP** and consider the following:
+  - [ ] There are no breaking changes in this PR.
+  
+If there are breaking changes, please **STOP** and consider the following:
 
 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?


### PR DESCRIPTION
## Purpose
In order to reduce the chance of breaking the nightly folio-testing build by merging breaking changes to master, we need to be more careful and consider the wider impact of the merge.

## Approach
Add a pre-merge checklist to the PR template.  Ideally the assignee of the PR will quickly go through the checklist before merging.  
