### PR TITLE
 MODORDERS-149 Add PO Line identifier to item record

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -358,7 +358,7 @@
     },
     {
       "id": "item-storage",
-      "version": "7.1"
+      "version": "7.2"
     },
     {
       "id": "loan-types",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -43,7 +43,10 @@
             "inventory-storage.instance-types.collection.get",
             "inventory-storage.instance-statuses.collection.get",
             "inventory-storage.holdings.item.post",
-            "inventory-storage.holdings.collection.get"
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.items.item.post",
+            "inventory-storage.loan-types.collection.get"
           ]
         },
         {
@@ -94,7 +97,10 @@
             "inventory-storage.instance-types.collection.get",
             "inventory-storage.instance-statuses.collection.get",
             "inventory-storage.holdings.item.post",
-            "inventory-storage.holdings.collection.get"
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.items.collection.get",
+            "inventory-storage.items.item.post",
+            "inventory-storage.loan-types.collection.get"
           ]
         },
         {

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -301,13 +301,10 @@ public class InventoryHelper {
     buildItemRecordJsonObject(compPOL, holdingId)
       .thenCompose(itemData -> createItemRecords(itemData, count))
       .thenAccept(createdItemIds -> {
-        // In case no items created at all, throw an exception because nothing can be done at this stage
+        // In case no items created, return an exception because nothing can be done at this stage
         if (createdItemIds.isEmpty()) {
-          throw new InventoryException(String.format("No items created for PO Line with %s id", compPOL.getId()));
-        } else if (count != createdItemIds.size()) {
-          // Just logging the error. The logic should try to create piece records for successfully created items
-          logger.error("The issue happened creating items for PO Line with '{}' id. Expected {} but {} created",
-            compPOL.getId(), count, createdItemIds.size());
+          String message = String.format("No items created for PO Line with %s id", compPOL.getId());
+          result.completeExceptionally(new InventoryException(message));
         }
         result.complete(createdItemIds);
       })
@@ -416,8 +413,7 @@ public class InventoryHelper {
         itemRecord.put("status", new JsonObject().put("name", ON_ORDER_ITEM_STATUS));
         itemRecord.put("materialTypeId", materialTypeId);
         itemRecord.put("permanentLoanTypeId", loanTypeId);
-        // TODO uncomment once MODINVSTOR-245 merged to master
-        //itemRecord.put("purchaseOrderLineIdentifier", compPOL.getId());
+        itemRecord.put("purchaseOrderLineIdentifier", compPOL.getId());
         return itemRecord;
       });
   }

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.orders.rest.exceptions.InventoryException;
 import org.folio.orders.rest.exceptions.ValidationException;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.rest.acq.model.Piece;
@@ -170,13 +171,18 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
       .thenCompose(v -> inventoryHelper.getOrCreateHoldingsRecord(compPOL))
       .thenCompose(holdingsId -> inventoryHelper.handleItemRecords(compPOL, holdingsId))
       .thenCompose(itemIds -> {
-        // Temporal check. The idea is to create piece records for successfully created items and then throw exception
-        if (itemIds.size() != expectedItemsQuantity) {
-          throw new IllegalStateException("Expected items quantity does not correspond to created items");
-        }
-        return completedFuture(itemIds);
-      })
-      .thenCompose(itemIds -> createPieces(compPOL, itemIds));
+        int itemsSize = itemIds.size();
+
+        // Create piece records for successfully created items
+        return createPieces(compPOL, itemIds)
+          .thenAccept(v -> {
+            if (itemsSize != expectedItemsQuantity) {
+              String message = String.format("The issue happened creating items for PO Line with '%s' id. Expected %d but %d created",
+                compPOL.getId(), expectedItemsQuantity, itemsSize);
+              throw new InventoryException(message);
+            }
+          });
+      });
   }
 
   /**


### PR DESCRIPTION
## Purpose
[MODORDERS-149](https://issues.folio.org/browse/MODORDERS-149) Add PO Line identifier to item record
The https://github.com/folio-org/mod-inventory-storage/pull/240 has been already merged and updated inventory storage is already available in testing

## Approach
- populating `purchaseOrderLineIdentifier` item's property
- required Inventory module permissions added to module descriptor
- update `item-storage`'s interface version to 7.2
- in case number of items created less than expected, create piece records for successfully created items and return exception after this

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards ([sonar PR#97](https://sonarcloud.io/project/issues?id=org.folio%3Amod-orders&pullRequest=97&resolved=false))?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues

## API Tests
Order transition from Pending to Open

![image](https://user-images.githubusercontent.com/43410167/52129075-adaf6f80-2647-11e9-8d0f-724719820085.png)

Open Order creation

![image](https://user-images.githubusercontent.com/43410167/52129113-c3249980-2647-11e9-9122-3a9360a7be55.png)
