### PR TITLE
MODORDERS-146 error code is absent in error message (BUG)

### DIFF
--- a/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
+++ b/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
@@ -5,39 +5,52 @@ import org.folio.orders.utils.ErrorCodes;
 public class HttpException extends Exception {
   private static final long serialVersionUID = 8109197948434861504L;
 
+  private static final String GENERIC_ERROR_CODE = "genericError";
   private final int code;
+  private final String errorCode;
 
   public HttpException(int code) {
     this.code = code;
+    this.errorCode = GENERIC_ERROR_CODE;
   }
 
   public HttpException(int code, String message) {
     super(message);
     this.code = code;
+    this.errorCode = GENERIC_ERROR_CODE;
   }
 
   public HttpException(int code, ErrorCodes errCodes) {
     super(errCodes.getDescription());
+    this.errorCode = errCodes.getCode();
     this.code = code;
   }
 
   public HttpException(int code, Throwable cause) {
     super(cause);
     this.code = code;
+    this.errorCode = GENERIC_ERROR_CODE;
   }
 
   public HttpException(int code, String message, Throwable cause) {
     super(message, cause);
     this.code = code;
+    this.errorCode = GENERIC_ERROR_CODE;
   }
 
   public HttpException(int code, String message, Throwable cause,
-      boolean enableSuppression, boolean writableStackTrace) {
+                       boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
     this.code = code;
+    this.errorCode = GENERIC_ERROR_CODE;
+
   }
 
   public int getCode() {
     return code;
+  }
+
+  public String getErrorCode() {
+    return errorCode;
   }
 }

--- a/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
+++ b/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
@@ -43,7 +43,6 @@ public class HttpException extends Exception {
     super(message, cause, enableSuppression, writableStackTrace);
     this.code = code;
     this.errorCode = GENERIC_ERROR_CODE;
-
   }
 
   public int getCode() {

--- a/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
+++ b/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
@@ -9,11 +9,6 @@ public class HttpException extends Exception {
   private final int code;
   private final String errorCode;
 
-  public HttpException(int code) {
-    this.code = code;
-    this.errorCode = GENERIC_ERROR_CODE;
-  }
-
   public HttpException(int code, String message) {
     super(message);
     this.code = code;
@@ -24,25 +19,6 @@ public class HttpException extends Exception {
     super(errCodes.getDescription());
     this.errorCode = errCodes.getCode();
     this.code = code;
-  }
-
-  public HttpException(int code, Throwable cause) {
-    super(cause);
-    this.code = code;
-    this.errorCode = GENERIC_ERROR_CODE;
-  }
-
-  public HttpException(int code, String message, Throwable cause) {
-    super(message, cause);
-    this.code = code;
-    this.errorCode = GENERIC_ERROR_CODE;
-  }
-
-  public HttpException(int code, String message, Throwable cause,
-                       boolean enableSuppression, boolean writableStackTrace) {
-    super(message, cause, enableSuppression, writableStackTrace);
-    this.code = code;
-    this.errorCode = GENERIC_ERROR_CODE;
   }
 
   public int getCode() {

--- a/src/main/java/org/folio/rest/impl/AbstractHelper.java
+++ b/src/main/java/org/folio/rest/impl/AbstractHelper.java
@@ -93,8 +93,9 @@ public abstract class AbstractHelper {
     final Throwable t = throwable.getCause();
     final String message = t.getMessage();
     if (t instanceof HttpException) {
-      final int code = ((HttpException) t).getCode();
-      result = succeededFuture(buildErrorResponse(code, new Error().withMessage(message)));
+      final int httpCode = ((HttpException) t).getCode();
+      final String errorCode = ((HttpException) t).getErrorCode();
+      result = succeededFuture(buildErrorResponse(httpCode, new Error().withMessage(message).withCode(errorCode)));
     } else if (t instanceof ValidationException) {
       result = succeededFuture(buildErrorResponse(422, ((ValidationException) t).getError()));
     } else {


### PR DESCRIPTION
## Purpose
Error code is absent in error response in case of handling HttpException.
(example: POST purchase order with the existing `po_number`)

## Approach
* adding error code for error response mapping
* adding default error code for other exceptions
