### PR TITLE
Create pieces when item record does not exists

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -443,6 +443,18 @@ public class HelperUtils {
   }
 
   /**
+   * Calculates total quantity based of cost for electronic and physical resources
+   *
+   * @param compPOL composite PO Line
+   * @return total quantity for PO Line
+   */
+  public static int calculateTotalQuantity(CompositePoLine compPOL) {
+  	int eQuantity = compPOL.getCost().getQuantityElectronic()!=null ? compPOL.getCost().getQuantityElectronic() : 0;
+    int physicalQuantity = compPOL.getCost().getQuantityPhysical()!=null ? compPOL.getCost().getQuantityPhysical() : 0;
+    return eQuantity + physicalQuantity;
+  }
+  
+  /**
    * Calculates total items quantity for all locations.
    * The quantity is based on Order Format (please see MODORDERS-117):<br/>
    * If format equals Physical the associated quantities will result in item records<br/>

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -31,6 +31,7 @@ import org.folio.rest.client.ConfigurationsClient;
 import org.folio.rest.jaxrs.model.Adjustment;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.Eresource;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Location;
@@ -445,12 +446,12 @@ public class HelperUtils {
   /**
    * Calculates total quantity based of cost for electronic and physical resources
    *
-   * @param compPOL composite PO Line
+   * @param cost Cost associated with PO Line
    * @return total quantity for PO Line
    */
-  public static int calculateTotalQuantity(CompositePoLine compPOL) {
-  	int eQuantity = compPOL.getCost().getQuantityElectronic()!=null ? compPOL.getCost().getQuantityElectronic() : 0;
-    int physicalQuantity = compPOL.getCost().getQuantityPhysical()!=null ? compPOL.getCost().getQuantityPhysical() : 0;
+  public static int calculateTotalQuantity(Cost cost) {
+  	int eQuantity = cost.getQuantityElectronic()!=null ? cost.getQuantityElectronic() : 0;
+    int physicalQuantity = cost.getQuantityPhysical()!=null ? cost.getQuantityPhysical() : 0;
     return eQuantity + physicalQuantity;
   }
   

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -207,7 +207,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
       .thenAccept(body -> {
         PieceCollection pieces = body.mapTo(PieceCollection.class);
         int remainingPiecesToCreate = 0;
-        int existingPieces = 0;
+        int existingPieces = pieces.getPieces().size();
         
         if(itemIds!=null) {
           // 1. Get list of item Id's which are already associated with piece records
@@ -227,12 +227,10 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
 	        // 4. Calculate count for remaining pieces to create when Physical and Electronic resources exists
 	        // Scenario: PO Line of "P/E Mix" format with 3 Physical resources and 2 Electronic resources with `create_inventory` set to `false`.
 	        // Create 2 piece records for Electronic resources
-          existingPieces = pieces.getPieces().size();
 	        remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL.getCost()) - piecesForPhysicalResources.size() - existingPieces);   
         }
         else {
           // Calculate count for remaining pieces to create on the basis of the total quantity of resources(Physical and Electronic) 
-        	existingPieces = pieces.getPieces().size();
         	remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL.getCost()) - existingPieces);
         }
         

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -165,9 +165,9 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
     if (expectedItemsQuantity == 0) {
     	// Create pieces if items does not exists
     	return createPieces(compPOL, null)
-    	.thenRun(() -> {
-    		logger.info("Created pieces for PO Line with '{}' id where inventory updates are not required", compPOL.getId());
-    	});
+    	.thenRun(() -> 
+    		logger.info("Create pieces for PO Line with '{}' id where inventory updates are not required", compPOL.getId())
+    	);
     }
     
     return inventoryHelper.handleInstanceRecord(compPOL)

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -223,7 +223,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
         else {
           // Create pieces on the basis of the total quantity of resources
         	int existingPieces = pieces.getPieces().size();
-        	int remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL) - existingPieces);
+        	int remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL.getCost()) - existingPieces);
           IntStream.range(0, remainingPiecesToCreate).forEach(i -> futuresList.add(createPiece(poLineId, null)));
         }
         allOf(futuresList.toArray(new CompletableFuture[0]))

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -222,7 +222,9 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
         }
         else {
           // Create pieces on the basis of the total quantity of resources
-          IntStream.range(0, calculateTotalQuantity(compPOL)).forEach(i -> futuresList.add(createPiece(poLineId, null)));
+        	int existingPieces = pieces.getPieces().size();
+        	int remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL) - existingPieces);
+          IntStream.range(0, remainingPiecesToCreate).forEach(i -> futuresList.add(createPiece(poLineId, null)));
         }
         allOf(futuresList.toArray(new CompletableFuture[0]))
           .thenAccept(v -> future.complete(null))

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -166,8 +166,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
     	// Create pieces if items does not exists
     	return createPieces(compPOL, null)
     	.thenRun(() -> {
-    		logger.info("Create pieces for PO Line with '{}' id where inventory updates are not required", compPOL.getId());
-    		completedFuture(null);
+    		logger.info("Created pieces for PO Line with '{}' id where inventory updates are not required", compPOL.getId());
     	});
     }
     

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -5,6 +5,7 @@ import static me.escoffier.vertx.completablefuture.VertxCompletableFuture.allOf;
 import static me.escoffier.vertx.completablefuture.VertxCompletableFuture.completedFuture;
 import static org.folio.orders.utils.HelperUtils.URL_WITH_LANG_PARAM;
 import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
+import static org.folio.orders.utils.HelperUtils.calculateTotalQuantity;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.orders.utils.HelperUtils.getPoLineById;
 import static org.folio.orders.utils.HelperUtils.handleGetRequest;
@@ -221,10 +222,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
         }
         
         // Calculate total quantity and create pieces when item record does not exists
-        int eQuantity = compPOL.getCost().getQuantityElectronic()!=null ? compPOL.getCost().getQuantityElectronic() : 0;
-        int physicalQuantity = compPOL.getCost().getQuantityPhysical()!=null ? compPOL.getCost().getQuantityPhysical() : 0;
-        int totalQuantity = eQuantity + physicalQuantity;
-        int diff = Math.abs(totalQuantity - calculateInventoryItemsQuantity(compPOL));
+        int diff = Math.abs(calculateTotalQuantity(compPOL) - calculateInventoryItemsQuantity(compPOL));
         IntStream.range(0, diff).forEach(i -> futuresList.add(createPiece(poLineId, null)));
         
         allOf(futuresList.toArray(new CompletableFuture[0]))
@@ -243,7 +241,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
 		return future;
   }
 
-  /**
+	/**
    * Construct Piece object associated with PO Line and create in the storage
    *
    * @param poLineId PO line identifier

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -207,6 +207,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
       .thenAccept(body -> {
         PieceCollection pieces = body.mapTo(PieceCollection.class);
         int remainingPiecesToCreate = 0;
+        int existingPieces = 0;
         
         if(itemIds!=null) {
           // 1. Get list of item Id's which are already associated with piece records
@@ -226,11 +227,12 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
 	        // 4. Calculate count for remaining pieces to create when Physical and Electronic resources exists
 	        // Scenario: PO Line of "P/E Mix" format with 3 Physical resources and 2 Electronic resources with `create_inventory` set to `false`.
 	        // Create 2 piece records for Electronic resources
-	        remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL.getCost()) - piecesForPhysicalResources.size());   
+          existingPieces = pieces.getPieces().size();
+	        remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL.getCost()) - piecesForPhysicalResources.size() - existingPieces);   
         }
         else {
           // Calculate count for remaining pieces to create on the basis of the total quantity of resources(Physical and Electronic) 
-        	int existingPieces = pieces.getPieces().size();
+        	existingPieces = pieces.getPieces().size();
         	remainingPiecesToCreate = Math.abs(calculateTotalQuantity(compPOL.getCost()) - existingPieces);
         }
         

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -208,24 +208,21 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
         PieceCollection pieces = body.mapTo(PieceCollection.class);
 
         if(itemIds!=null) {
-        // Extract item Id's which already associated with piece records
-        List<String> existingItemIds = pieces.getPieces()
-            .stream()
-            .map(Piece::getItemId)
-            .filter(StringUtils::isNotEmpty)
-            .collect(Collectors.toList());
+          // Extract item Id's which are already associated with piece records
+          List<String> existingItemIds = pieces.getPieces()
+																	             .stream()
+																	             .map(Piece::getItemId)
+																	             .filter(StringUtils::isNotEmpty)
+																	             .collect(Collectors.toList());
 
-        // Create piece records for item id's which do not have piece records yet
-        
+          // Create piece records for item id's which do not have piece records yet     
 	        itemIds.stream()
 	               .filter(id -> !existingItemIds.contains(id))
 	               .forEach(itemId -> futuresList.add(createPiece(poLineId, itemId)));
         }
         else {
-        // Calculate total quantity and create pieces when item record does not exists
-        //int diff = Math.abs(calculateTotalQuantity(compPOL) - calculateInventoryItemsQuantity(compPOL));
-        	logger.debug("------------------- calculateTotalQuantity(compPOL) --------------------\n" + calculateTotalQuantity(compPOL));
-        IntStream.range(0, calculateTotalQuantity(compPOL)).forEach(i -> futuresList.add(createPiece(poLineId, null)));
+          // Create pieces on the basis of the total quantity of resources
+          IntStream.range(0, calculateTotalQuantity(compPOL)).forEach(i -> futuresList.add(createPiece(poLineId, null)));
         }
         allOf(futuresList.toArray(new CompletableFuture[0]))
           .thenAccept(v -> future.complete(null))

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1186,7 +1186,7 @@ public class OrdersImplTest {
     List<JsonObject> createdPieces = MockServer.serverRqRs.get(PIECES, HttpMethod.POST);
 
     // Assert that items quantity equals to created ieces
-    assertEquals(createdPieces.size(), items.size());
+    assertEquals(createdPieces.size(), HelperUtils.calculateTotalQuantity(reqData.getCompositePoLines().get(0).getCost()));
 
     // Verify that not all expected items created
     assertThat(items.size(), lessThan(calculateInventoryItemsQuantity(reqData.getCompositePoLines().get(0))));

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -533,21 +533,24 @@ public class OrdersImplTest {
     assertEquals(2, reqData.getCompositePoLines().size());
 
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
-    reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(false);
-    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(false);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
 
     List<JsonObject> createdPieces = MockServer.serverRqRs.get(PIECES, HttpMethod.POST);
     int piecesSize = createdPieces!=null ? createdPieces.size() : 0;
+
+
+    // Verify total number of pieces created should be equal to total quantity
+    assertEquals( piecesSize, calculateTotalQuantity(reqData));
+  }
+   
+  private int calculateTotalQuantity(CompositePurchaseOrder reqData) {
     int eQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() : 0;
     int physicalQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() : 0;
     int eQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() : 0;
     int physicalQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() : 0;
-    int totalQuantity = eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
-    // Verify total number of pieces created should be equal to total quantity
-    assertEquals( piecesSize, totalQuantity);
+    return eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
   }
-   
+  
   @Test
   public void testPlaceOrderMinimal() throws Exception {
     logger.info("=== Test Placement of minimal order ===");
@@ -1204,14 +1207,14 @@ public class OrdersImplTest {
     // All existing and created items
     List<JsonObject> items = joinExistingAndNewItems();
 
-    int eQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() : 0;
-    int physicalQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() : 0;
-    int eQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() : 0;
-    int physicalQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() : 0;
+//    int eQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() : 0;
+//    int physicalQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() : 0;
+//    int eQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() : 0;
+//    int physicalQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() : 0;
+//
+//    int totalQuantity0 = eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
 
-    int totalQuantity0 = eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
-
-    assertEquals(createdPieces.size(), totalQuantity0);
+    assertEquals(createdPieces.size(), calculateTotalQuantity(reqData));
 
     for (CompositePoLine pol : reqData.getCompositePoLines()) {
       verifyInstanceCreated(createdInstances, pol);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1177,7 +1177,15 @@ public class OrdersImplTest {
     // All existing and created items
     List<JsonObject> items = joinExistingAndNewItems();
 
-    assertEquals(createdPieces.size(), items.size());
+    int eQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() : 0;
+    int physicalQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() : 0;
+    int eQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() : 0;
+    int physicalQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() : 0;
+
+    int totalQuantity0 = eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
+
+    assertEquals(createdPieces.size(), totalQuantity0);
+
     for (CompositePoLine pol : reqData.getCompositePoLines()) {
       verifyInstanceCreated(createdInstances, pol);
       verifyHoldingsCreated(createdHoldings, pol);
@@ -1260,7 +1268,8 @@ public class OrdersImplTest {
       Piece piece = pieceObj.mapTo(Piece.class);
 
       // Check if itemId in inventoryItems match itemId in piece record
-      assertThat(itemIds, hasItem(piece.getItemId()));
+      if(piece.getItemId()!=null)
+      	assertThat(itemIds, hasItem(piece.getItemId()));
       assertThat(piece.getReceivingStatus(), equalTo(Piece.ReceivingStatus.EXPECTED));
     }
 	}

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -537,18 +537,21 @@ public class OrdersImplTest {
 
     List<JsonObject> createdPieces = MockServer.serverRqRs.get(PIECES, HttpMethod.POST);
     int piecesSize = createdPieces!=null ? createdPieces.size() : 0;
-
-
     // Verify total number of pieces created should be equal to total quantity
     assertEquals( piecesSize, calculateTotalQuantity(reqData));
   }
    
+  // Calculate total quantity of resources based of the cost
   private int calculateTotalQuantity(CompositePurchaseOrder reqData) {
-    int eQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() : 0;
-    int physicalQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() : 0;
-    int eQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() : 0;
-    int physicalQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() : 0;
-    return eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
+		int eQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() != null
+		    ? reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() : 0;
+		int physicalQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() != null
+		    ? reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() : 0;
+		int eQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() != null
+		    ? reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() : 0;
+		int physicalQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() != null
+		    ? reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() : 0;
+		return eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
   }
   
   @Test
@@ -1206,14 +1209,6 @@ public class OrdersImplTest {
 
     // All existing and created items
     List<JsonObject> items = joinExistingAndNewItems();
-
-//    int eQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityElectronic() : 0;
-//    int physicalQuantity0 = reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(0).getCost().getQuantityPhysical() : 0;
-//    int eQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityElectronic() : 0;
-//    int physicalQuantity1 = reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical()!=null ? reqData.getCompositePoLines().get(1).getCost().getQuantityPhysical() : 0;
-//
-//    int totalQuantity0 = eQuantity0 + physicalQuantity0 + eQuantity1 + physicalQuantity1;
-
     assertEquals(createdPieces.size(), calculateTotalQuantity(reqData));
 
     for (CompositePoLine pol : reqData.getCompositePoLines()) {

--- a/src/test/resources/po_listed_print_monograph_pe_mix.json
+++ b/src/test/resources/po_listed_print_monograph_pe_mix.json
@@ -108,9 +108,9 @@
         {
           "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
           "location_id": "758258bc-ecc1-41b8-abca-f7b610822ffd",
-          "quantity": 0,
+          "quantity": 3,
           "quantity_electronic": 0,
-          "quantity_physical": 0
+          "quantity_physical": 3
         }
       ],
       "order_format": "P/E Mix",

--- a/src/test/resources/po_listed_print_monograph_pe_mix.json
+++ b/src/test/resources/po_listed_print_monograph_pe_mix.json
@@ -1,0 +1,148 @@
+{
+  "adjustment": {
+    "credit": 0.0,
+    "discount": 0.0,
+    "insurance": 0.0,
+    "overhead": 0.0,
+    "shipment": 0.0,
+    "tax_1": 0.0,
+    "tax_2": 0.0,
+    "use_pro_rate": false
+  },
+  "approved": true,
+  "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "notes": [
+    "ABCDEFGHIJKLMNO",
+    "ABCDEFGHIJKLMNOPQRST",
+    "ABCDEFGHIJKLMNOPQRSTUV"
+  ],
+  "order_type": "One-Time",
+  "po_number": "268758",
+  "re_encumber": false,
+  "total_estimated_price": 49.98,
+  "total_items": 2,
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "workflow_status": "Pending",
+  "metadata": {
+    "createdDate": "2010-10-08T03:53:00.000",
+    "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
+  },
+  "compositePoLines": [
+    {
+      "id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+      "acquisition_method": "Purchase",
+      "adjustment": {
+        "credit": 0.0,
+        "discount": 0.0,
+        "insurance": 0.0,
+        "invoice_id": "2ddfeb5c-1237-476f-aa88-57f7cbf74ca4",
+        "overhead": 0.0,
+        "shipment": 0.0,
+        "tax_1": 0.0,
+        "tax_2": 0.0,
+        "use_pro_rate": false,
+        "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+      },
+      "alerts": [],
+      "cancellation_restriction": false,
+      "cancellation_restriction_note": "",
+      "claims": [
+        {
+          "claimed": false,
+          "grace": 0,
+          "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+        }
+      ],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Ed Mashburn",
+          "contributor_type": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+        }
+      ],
+      "cost": {
+        "list_price": 25.10,
+        "currency": "USD",
+        "quantity_physical": 3,
+        "quantity_electronic": 2,
+        "po_line_estimated_price": 75.30,
+        "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+      },
+      "description": "",
+      "details": {
+        "receiving_note": "",
+        "product_ids": [
+          {
+            "product_id": "9781118416068",
+            "product_id_type": "ISBN"
+          }
+        ],
+        "material_types": [
+          "615b8413-82d5-4203-aa6e-e37984cb5ac3"
+        ],
+        "subscription_from": null,
+        "subscription_interval": 0,
+        "subscription_to": null,
+        "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+      },
+      "donor": "",
+      "eresource": {
+        "create_inventory": false
+      },
+      "fund_distribution": [
+        {
+          "code": "MISCHIST-FY19",
+          "percentage": 100.0,
+          "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08015",
+          "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+        }
+      ],
+      "locations": [
+        {
+          "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+          "location_id": "b241764c-1466-4e1d-a028-1a3684a5da87",
+          "quantity": 2,
+          "quantity_electronic": 2,
+          "quantity_physical": 0
+        },
+        {
+          "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+          "location_id": "758258bc-ecc1-41b8-abca-f7b610822ffd",
+          "quantity": 0,
+          "quantity_electronic": 0,
+          "quantity_physical": 0
+        }
+      ],
+      "order_format": "P/E Mix",
+      "owner": "LTS E-Resources & Serials",
+      "payment_status": "Awaiting Payment",
+      "po_line_description": "",
+      "publication_date": "2017",
+      "publisher": "John Wiley & Sons, Inc.",
+      "receipt_date": "2020-10-10T00:00:00.000Z",
+      "receipt_status": "Fully Received",
+      "reporting_codes": [],
+      "requester": "",
+      "rush": false,
+      "selector": "Woods",
+      "source": {
+        "code": "FOLIO",
+        "description": "Manually entered"
+      },
+      "tags": [""],
+      "title": "Roitt's essential immunology / Peter J. Delves, Seamus J. Martin, Dennis R. Burton, Ivan M. Roitt.",
+      "vendor_detail": {
+        "note_from_vendor": "",
+        "instructions": "ABCDEFG",
+        "ref_number": "999632785",
+        "ref_number_type": "Supplier's unique order line reference number",
+        "vendor_account": "12345-50",
+        "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+      },
+      "metadata": {
+        "createdDate": "2010-10-08T03:53:00.000",
+        "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDERS-100

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
- Create piece records, even if not creating item records

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Calculate total quantity using `compPOL.getCost().getQuantityPhysical()` and `compPOL.getCost().getQuantityElectronic()`
- Subtract inventory items from total quantity to create remaining pieces
- Update tests

Extra:
Update `dateOrdered` tests to verify against month and year to avoid time zone issues
 
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
