### PR TITLE
MODORDERS-103/162 receiving flow for physical and electronic resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Upon receiving a request to receive resources, it does the following:
   * `receivingStatus`: `Received`
   * `locationId`: from the request
   * `receivedDate`: current date
-* Retrieve all involved PO Lines from the storage and updates receipt status. If all pieces of this order line have been received, the receipt status is `Fully Received`. If more than one, but less than the total number of pieces have been received, it is `Partially Received`. If the status is the same, no update is made
+* Retrieve all involved PO Lines from the storage and updates receipt status. If all pieces of an order line have been received, the receipt status is `Fully Received`. If more than one, but less than the total number of pieces have been received, it is `Partially Received`. If the calculated status is the same as current one, no update is made
 * Prepare [response](https://github.com/folio-org/acq-models/blob/master/mod-orders/schemas/receivingResults.json) to the client taking into account any error happened processing particular piece record.
 
 ### Issue tracker

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Upon receiving a request to delete a PO Line, it does the following:
 * Validate that PO id of the PO Line corresponds to order id in the path; then
 * Delete PO Line and its sub-objects
 
+### Receiving logic 
+Upon receiving a request to receive resources, it does the following:
+* Retrieve piece records from the orders storage based on the [request body](https://github.com/folio-org/acq-models/blob/master/mod-orders/schemas/receivingCollection.json).
+* For those pieces which have item id the process is like following:
+  * Retrieve items from inventory.
+  * Update item entities with barcode (if specified) and status
+  * Send PUT requests to inventory to update items. In case any errors happen while updating items, the logic just collects them and does not stop entire process
+* Update piece records with receiving information and send PUT requests to orders storage. If any errors happen, just collect them.  
+  The following is expected to be update in piece:
+  * `receivingStatus`: `Received`
+  * `locationId`: from the request
+  * `receivedDate`: current date
+* Retrieve all involved PO Lines from the storage and updates receipt status. If all pieces of this order line have been received, the receipt status is `Fully Received`. If more than one, but less than the total number of pieces have been received, it is `Partially Received`. If the status is the same, no update is made
+* Prepare [response](https://github.com/folio-org/acq-models/blob/master/mod-orders/schemas/receivingResults.json) to the client taking into account any error happened processing particular piece record.
+
 ### Issue tracker
 
 See project [MODORDERS](https://issues.folio.org/browse/MODORDERS)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -236,9 +236,10 @@
           "modulePermissions": [
             "orders-storage.pieces.collection.get",
             "orders-storage.pieces.item.put",
+            "orders-storage.po_lines.collection.get",
             "orders-storage.po_lines.item.put",
-            "inventory-storage.items.collection.get",
-            "inventory-storage.items.item.put"
+            "inventory.items.collection.get",
+            "inventory.items.item.put"
           ]
         },
         {
@@ -260,8 +261,7 @@
           "pathPattern": "/orders/receiving-history",
           "permissionsRequired": ["orders.receiving-history.collection.get"],
           "modulePermissions": [
-            "orders-storage.receiving-history.collection.get",
-            "inventory.items.item.get"
+            "orders-storage.receiving-history.collection.get"
           ]
         }
       ]
@@ -358,7 +358,7 @@
     },
     {
       "id": "item-storage",
-      "version": "7.2"
+      "version": "7.3"
     },
     {
       "id": "loan-types",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -346,7 +346,7 @@
     },
     {
       "id": "inventory",
-      "version": "8.1"
+      "version": "8.3"
     },
     {
       "id": "instance-types",

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
       <version>19.0</version>
     </dependency>
     <dependency>
+      <groupId>one.util</groupId>
+      <artifactId>streamex</artifactId>
+      <version>0.6.8</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -18,6 +18,7 @@ public enum ErrorCodes {
   PIECE_UPDATE_FAILED("pieceUpdateFailed", "The piece record failed to be updated"),
   ITEM_UPDATE_FAILED("itemUpdateFailed", "The item record failed to be updated"),
   ITEM_NOT_FOUND("itemNotFound", "The item record is not found"),
+  ITEM_NOT_RETRIEVED("itemNotRetrieved", "The item record is not retrieved"),
   ZERO_COST_QTY("zeroCostQty", "Physical and electronic cost quantity must be specified"),
   ZERO_COST_PHYSICAL_QTY("zeroCostQtyPhysical", "Physical cost quantity must be specified"),
   ZERO_COST_ELECTRONIC_QTY("zeroCostQtyElectronic", "Electronic cost quantity must be specified"),

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -11,12 +11,20 @@ public enum ErrorCodes {
   INCORRECT_ORDER_ID_IN_POL("orderIdMismatch", "Mismatch between order id in the request and storage"),
   POL_LINES_LIMIT_EXCEEDED("polLimitExceeded", "Your FOLIO system is configured to limit the number of PO Lines on each order"),
   MISSING_MATERIAL_TYPE("materialTypeRequired", "The Material Type is required but not available in PO line"),
+  PIECE_POL_MISMATCH("piecePolMismatch", "The piece does not correspond to PO line"),
+  PIECE_ALREADY_RECEIVED("pieceAlreadyReceived", "The piece record is already received"),
+  PIECE_NOT_FOUND("pieceNotFound", "The piece record is not found"),
+  PIECE_NOT_RETRIEVED("pieceNotRetrieved", "The piece record is not retrieved"),
+  PIECE_UPDATE_FAILED("pieceUpdateFailed", "The piece record failed to be updated"),
+  ITEM_UPDATE_FAILED("itemUpdateFailed", "The item record failed to be updated"),
+  ITEM_NOT_FOUND("itemNotFound", "The item record is not found"),
   ZERO_COST_QTY("zeroCostQty", "Physical and electronic cost quantity must be specified"),
   ZERO_COST_PHYSICAL_QTY("zeroCostQtyPhysical", "Physical cost quantity must be specified"),
   ZERO_COST_ELECTRONIC_QTY("zeroCostQtyElectronic", "Electronic cost quantity must be specified"),
   NON_ZERO_COST_PHYSICAL_QTY("nonZeroLocQtyPhysical", "Physical cost quantity must not be specified"),
   NON_ZERO_COST_ELECTRONIC_QTY("nonZeroCostQtyElectronic", "Electronic cost quantity must not be specified"),
   PHYSICAL_LOC_QTY_EXCEEDS_COST("locQtyPhysicalExceedsCost", "Locations physical quantity exceeds cost physical quantity"),
+  PHYSICAL_COST_QTY_EXCEEDS_LOC("costQtyPhysicalExceedsLoc", "Cost's physical quantity exceeds locations' physical quantity"),
   ELECTRONIC_LOC_QTY_EXCEEDS_COST("locQtyElectronicExceedsCost", "Locations electronic quantity exceeds cost electronic quantity");
 
   private final String code;

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -25,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import one.util.streamex.StreamEx;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.orders.rest.exceptions.HttpException;
@@ -569,14 +570,12 @@ public class HelperUtils {
   }
 
   /**
-   * Transform piece id's to CQL query
-   * @param ids list of piece id's
-   * @return String representing CQL query to get piece records by id's
+   * Transform list of id's to CQL query using 'or' operation
+   * @param ids list of id's
+   * @return String representing CQL query to get records by id's
    */
   public static String convertIdsToCqlQuery(List<String> ids) {
-    return ids.stream()
-              .map(id -> "id==" + id)
-              .collect(joining(" or "));
+    return StreamEx.of(ids).map(id -> "id==" + id).joining(" or ");
   }
 
   public static CompletableFuture<JsonObject> handleGetRequest(String endpoint, HttpClientInterface

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -1,7 +1,6 @@
 package org.folio.orders.utils;
 
 import static java.util.Objects.nonNull;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.EMPTY;

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -7,12 +7,16 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import one.util.streamex.StreamEx;
 import org.apache.commons.collections4.ListUtils;
 import org.folio.orders.rest.exceptions.HttpException;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.orders.rest.exceptions.InventoryException;
+import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Details;
 import org.folio.rest.jaxrs.model.ProductId;
+import org.folio.rest.jaxrs.model.ReceivedItem;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
@@ -37,10 +41,13 @@ import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.orders.utils.HelperUtils.encodeQuery;
 import static org.folio.orders.utils.HelperUtils.groupLocationsById;
 import static org.folio.orders.utils.HelperUtils.handleGetRequest;
+import static org.folio.orders.utils.HelperUtils.handlePutRequest;
 import static org.folio.orders.utils.HelperUtils.verifyAndExtractBody;
 import static org.folio.rest.impl.AbstractHelper.ID;
 
 public class InventoryHelper {
+
+  private static final int MAX_IDS_FOR_GET_RQ = 15;
 
   static final String INSTANCE_SOURCE = "source";
   static final String INSTANCE_TITLE = "title";
@@ -56,6 +63,7 @@ public class InventoryHelper {
   static final String HOLDING_INSTANCE_ID = "instanceId";
   static final String HOLDING_PERMANENT_LOCATION_ID = "permanentLocationId";
   static final String ITEM_HOLDINGS_RECORD_ID = "holdingsRecordId";
+  static final String ITEM_BARCODE = "barcode";
   static final String ITEM_STATUS = "status";
   static final String ITEM_STATUS_NAME = "name";
   static final String ITEM_STATUS_ON_ORDER = "On order";
@@ -63,10 +71,10 @@ public class InventoryHelper {
   static final String ITEM_PERMANENT_LOAN_TYPE_ID = "permanentLoanTypeId";
   static final String ITEM_PURCHASE_ORDER_LINE_IDENTIFIER = "purchaseOrderLineIdentifier";
 
+  static final String ITEMS = "items";
   private static final String HOLDINGS_RECORDS = "holdingsRecords";
   private static final String IDENTIFIER_TYPES = "identifierTypes";
   private static final String INSTANCES = "instances";
-  private static final String ITEMS = "items";
   private static final String LOAN_TYPES = "loantypes";
 
   private static final String DEFAULT_INSTANCE_TYPE_CODE = "zzz";
@@ -75,9 +83,11 @@ public class InventoryHelper {
   private static final String LOCATION_HEADER = "Location";
   private static final String LOOKUP_INSTANCES_ENDPOINT = "/inventory/instances?query=%s&lang=%s";
   private static final String CREATE_INSTANCE_ENDPOINT = "/inventory/instances?lang=%s";
-  private static final String LOOKUP_ITEMS_QUERY = "purchaseOrderLineIdentifier==%s and holdingsRecordId==%s";
-  private static final String LOOKUP_ITEMS_ENDPOINT = "/item-storage/items?query=%s&limit=%d&lang=%s";
-  private static final String CREATE_ITEM_ENDPOINT = "/item-storage/items?lang=%s";
+  private static final String LOOKUP_ITEM_STOR_QUERY = "purchaseOrderLineIdentifier==%s and holdingsRecordId==%s";
+  private static final String LOOKUP_ITEM_STOR_ENDPOINT = "/item-storage/items?query=%s&limit=%d&lang=%s";
+  private static final String CREATE_ITEM_STOR_ENDPOINT = "/item-storage/items?lang=%s";
+  private static final String LOOKUP_ITEMS_ENDPOINT = "/inventory/items?query=%s&limit=%d&lang=%s";
+  private static final String UPDATE_ITEM_ENDPOINT = "/inventory/items/%s?lang=%s";
   private static final String HOLDINGS_LOOKUP_QUERY = "instanceId==%s and permanentLocationId==%s";
   private static final String HOLDINGS_LOOKUP_ENDPOINT = "/holdings-storage/holdings?query=%s&limit=1&lang=%s";
   private static final String HOLDINGS_CREATE_ENDPOINT = "/holdings-storage/holdings?lang=%s";
@@ -131,6 +141,52 @@ public class InventoryHelper {
         .flatMap(List::stream)
         .collect(toList())
       );
+  }
+
+  /**
+   * Returns list of item records for specified id's.
+   *
+   * @param ids   List of item id's
+   * @return future with list of item records
+   */
+  public CompletableFuture<List<JsonObject>> getItemRecordsByIds(List<String> ids) {
+    List<CompletableFuture<List<JsonObject>>> itemsPerQuery = new ArrayList<>();
+
+    // Split all id's by maximum number of id's for get query
+    StreamEx.ofSubLists(ids, MAX_IDS_FOR_GET_RQ)
+            // Transform id's to CQL query
+            .map(HelperUtils::convertIdsToCqlQuery)
+            // Send get request for each CQL query
+            .forEach(query -> itemsPerQuery.add(
+              searchForItemsByQuery(query)
+                // In case of error juts return empty list
+                .exceptionally(e -> {
+                  logger.error("Some items cannot be retrieved", e);
+                  return Collections.emptyList();
+                })
+            ));
+
+    return collectResultsOnSuccess(itemsPerQuery)
+      .thenApply(results -> StreamEx.of(results).toFlatList(lists -> lists));
+  }
+
+  /**
+   * Returns list of item records for specified id's.
+   *
+   * @param itemRecord item record
+   * @param receivedItem item details specified by user upon receiving flow
+   * @return future with list of item records
+   */
+  public CompletableFuture<Void> receiveItem(JsonObject itemRecord, ReceivedItem receivedItem) {
+    String endpoint = String.format(UPDATE_ITEM_ENDPOINT, itemRecord.getString(ID), lang);
+
+    // Update item record with receiving details
+    itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, receivedItem.getItemStatus()));
+    if (StringUtils.isNotEmpty(receivedItem.getBarcode())) {
+      itemRecord.put(ITEM_BARCODE, receivedItem.getBarcode());
+    }
+
+    return handlePutRequest(endpoint, itemRecord, httpClient, ctx, okapiHeaders, logger);
   }
 
   private CompletableFuture<String> getOrCreateHoldingsRecord(CompositePoLine compPOL, String locationId) {
@@ -328,8 +384,8 @@ public class InventoryHelper {
    * @return future with list of item id's
    */
   private CompletableFuture<List<String>> searchForExistingItems(CompositePoLine compPOL, String holdingId, int expectedQuantity) {
-    String query = encodeQuery(String.format(LOOKUP_ITEMS_QUERY, compPOL.getId(), holdingId), logger);
-    String endpoint = String.format(LOOKUP_ITEMS_ENDPOINT, query, expectedQuantity, lang);
+    String query = encodeQuery(String.format(LOOKUP_ITEM_STOR_QUERY, compPOL.getId(), holdingId), logger);
+    String endpoint = String.format(LOOKUP_ITEM_STOR_ENDPOINT, query, expectedQuantity, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
       .thenApply(items -> {
         List<String> itemIds = collectItemIds(items);
@@ -338,18 +394,39 @@ public class InventoryHelper {
       });
   }
 
+  private CompletableFuture<List<JsonObject>> searchForItemsByQuery(String query) {
+    String endpoint = String.format(LOOKUP_ITEMS_ENDPOINT, encodeQuery(query, logger), MAX_IDS_FOR_GET_RQ, lang);
+    return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+      .thenApply(this::extractItems);
+  }
+
+  /**
+   * Validates if the json object contains items and returns items as list of JsonObject elements
+   * @param itemEntries {@link JsonObject} representing item storage response
+   * @return list of the item records as JsonObject elements
+   */
+  private List<JsonObject> extractItems(JsonObject itemEntries) {
+    return Optional.ofNullable(itemEntries.getJsonArray(ITEMS))
+                   .map(items -> items.stream()
+                                      .map(item -> (JsonObject) item)
+                                      .collect(toList()))
+                   .orElseGet(Collections::emptyList);
+  }
+
   /**
    * Validates if the json object contains items and extracts ids or returns empty list
    * @param itemEntries {@link JsonObject} representing item storage response
    * @return list of the item ids if any item returned
    */
   private List<String> collectItemIds(JsonObject itemEntries) {
-    return Optional.ofNullable(itemEntries.getJsonArray(ITEMS))
-                   .map(items -> items.stream()
-                                      .map(item -> (JsonObject) item)
-                                      .map(this::extractId)
-                                      .collect(toList()))
-                   .orElseGet(Collections::emptyList);
+    List<JsonObject> jsonObjects = extractItems(itemEntries);
+    if (jsonObjects.isEmpty()) {
+      return Collections.emptyList();
+    } else {
+      return jsonObjects.stream()
+                        .map(this::extractId)
+                        .collect(toList());
+    }
   }
 
   /**
@@ -394,7 +471,7 @@ public class InventoryHelper {
    * @return id of newly created entity Record
    */
   private CompletableFuture<String> createItemInInventory(JsonObject itemData) {
-    return createRecordInStorage(itemData, String.format(CREATE_ITEM_ENDPOINT, lang))
+    return createRecordInStorage(itemData, String.format(CREATE_ITEM_STOR_ENDPOINT, lang))
       // In case item creation failed, return null instead of id
       .exceptionally(throwable -> null);
   }

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -302,8 +302,9 @@ public class OrdersImpl implements Orders {
   @Validate
   public void postOrdersReceive(String lang, ReceivingCollection entity, Map<String, String> okapiHeaders,
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    // Return 501 (Not Implemented) for now
-    asyncResultHandler.handle(succeededFuture(Response.status(501).build()));
+    logger.info("Receiving {} items", entity.getTotalRecords());
+    new ReceivingHelper(entity, okapiHeaders, asyncResultHandler, vertxContext, lang)
+      .receiveItems(entity);
   }
 
   @Override

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -4,7 +4,6 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.GET_ALL_POLINES_QUERY_WITH_LIMIT;
 import static org.folio.orders.utils.HelperUtils.PO_LINES_LIMIT_PROPERTY;
-import static org.folio.orders.utils.HelperUtils.convertErrorCodesToErrors;
 import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
 import static org.folio.orders.utils.HelperUtils.handleGetRequest;
 import static org.folio.orders.utils.HelperUtils.loadConfiguration;
@@ -24,6 +23,7 @@ import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.ErrorCodes;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.*;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.resource.Orders;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
@@ -96,9 +96,9 @@ public class OrdersImpl implements Orders {
   public void postOrdersCompositeOrders(String lang, CompositePurchaseOrder compPO, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     // First validate content of the PO and proceed only if all is okay
-    List<ErrorCodes> errorCodes = validateOrder(compPO);
-    if (!errorCodes.isEmpty()) {
-      PostOrdersCompositeOrdersResponse response = PostOrdersCompositeOrdersResponse.respond422WithApplicationJson(convertErrorCodesToErrors(errorCodes));
+    List<Error> errors = validateOrder(compPO);
+    if (!errors.isEmpty()) {
+      PostOrdersCompositeOrdersResponse response = PostOrdersCompositeOrdersResponse.respond422WithApplicationJson(new Errors().withErrors(errors));
       asyncResultHandler.handle(succeededFuture(response));
       return;
     }
@@ -135,12 +135,12 @@ public class OrdersImpl implements Orders {
                                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     // First validate content of the PO and proceed only if all is okay
-    List<ErrorCodes> errorCodes = new ArrayList<>(validateOrder(compPO));
+    List<Error> errors = new ArrayList<>(validateOrder(compPO));
     if (StringUtils.isEmpty(compPO.getPoNumber())) {
-      errorCodes.add(ErrorCodes.PO_NUMBER_REQUIRED);
+      errors.add(ErrorCodes.PO_NUMBER_REQUIRED.toError());
     }
-    if (!errorCodes.isEmpty()) {
-      PutOrdersCompositeOrdersByIdResponse response = PutOrdersCompositeOrdersByIdResponse.respond422WithApplicationJson(convertErrorCodesToErrors(errorCodes));
+    if (!errors.isEmpty()) {
+      PutOrdersCompositeOrdersByIdResponse response = PutOrdersCompositeOrdersByIdResponse.respond422WithApplicationJson(new Errors().withErrors(errors));
       asyncResultHandler.handle(succeededFuture(response));
       return;
     }
@@ -171,13 +171,13 @@ public class OrdersImpl implements Orders {
                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     // First validate content of the PO Line and proceed only if all is okay
-    List<ErrorCodes> errorCodes = new ArrayList<>();
+    List<Error> errors = new ArrayList<>();
     if (poLine.getPurchaseOrderId() == null) {
-      errorCodes.add(ErrorCodes.MISSING_ORDER_ID_IN_POL);
+      errors.add(ErrorCodes.MISSING_ORDER_ID_IN_POL.toError());
     }
-    errorCodes.addAll(validatePoLine(poLine));
-    if (!errorCodes.isEmpty()) {
-      PostOrdersOrderLinesResponse response = PostOrdersOrderLinesResponse.respond422WithApplicationJson(convertErrorCodesToErrors(errorCodes));
+    errors.addAll(validatePoLine(poLine));
+    if (!errors.isEmpty()) {
+      PostOrdersOrderLinesResponse response = PostOrdersOrderLinesResponse.respond422WithApplicationJson(new Errors().withErrors(errors));
       asyncResultHandler.handle(succeededFuture(response));
       return;
     }
@@ -274,12 +274,12 @@ public class OrdersImpl implements Orders {
     }
 
     // First validate content of the PO Line and proceed only if all is okay
-    List<ErrorCodes> errorCodes = new ArrayList<>(validatePoLine(poLine));
+    List<Error> errors = new ArrayList<>(validatePoLine(poLine));
     if (!lineId.equals(poLine.getId())) {
-      errorCodes.add(ErrorCodes.MISMATCH_BETWEEN_ID_IN_PATH_AND_PO_LINE);
+      errors.add(ErrorCodes.MISMATCH_BETWEEN_ID_IN_PATH_AND_PO_LINE.toError());
     }
-    if (!errorCodes.isEmpty()) {
-      PutOrdersOrderLinesByIdResponse response = PutOrdersOrderLinesByIdResponse.respond422WithApplicationJson(convertErrorCodesToErrors(errorCodes));
+    if (!errors.isEmpty()) {
+      PutOrdersOrderLinesByIdResponse response = PutOrdersOrderLinesByIdResponse.respond422WithApplicationJson(new Errors().withErrors(errors));
       asyncResultHandler.handle(succeededFuture(response));
       return;
     }

--- a/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
+++ b/src/main/java/org/folio/rest/impl/PutOrderLineByIdHelper.java
@@ -68,7 +68,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
   private final InventoryHelper inventoryHelper;
   private final Errors processingErrors = new Errors();
 
-  private static final String PIECES_ENDPOINT = resourcesPath(PIECES) + "?query=poLineId=%s";
+  private static final String PIECES_ENDPOINT = resourcesPath(PIECES) + "?query=poLineId==%s";
 
   public PutOrderLineByIdHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context ctx, String lang) {
@@ -222,7 +222,7 @@ public class PutOrderLineByIdHelper extends AbstractHelper {
           .filter(id -> !existingItemIds.contains(id)).collect(Collectors.toList());
 
           // 3. Create piece records     
-          piecesForPhysicalResources.stream().forEach(itemId -> futuresList.add(createPiece(poLineId, itemId)));  
+          piecesForPhysicalResources.forEach(itemId -> futuresList.add(createPiece(poLineId, itemId)));
 	        
 	        // 4. Calculate count for remaining pieces to create when Physical and Electronic resources exists
 	        // Scenario: PO Line of "P/E Mix" format with 3 Physical resources and 2 Electronic resources with `create_inventory` set to `false`.

--- a/src/main/java/org/folio/rest/impl/ReceivingHelper.java
+++ b/src/main/java/org/folio/rest/impl/ReceivingHelper.java
@@ -1,0 +1,532 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import one.util.streamex.EntryStream;
+import one.util.streamex.StreamEx;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.orders.utils.HelperUtils;
+import org.folio.rest.acq.model.Piece;
+import org.folio.rest.acq.model.Piece.ReceivingStatus;
+import org.folio.rest.acq.model.PieceCollection;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.PoLine.ReceiptStatus;
+import org.folio.rest.jaxrs.model.PoLineCollection;
+import org.folio.rest.jaxrs.model.ProcessingStatus;
+import org.folio.rest.jaxrs.model.ReceivedItem;
+import org.folio.rest.jaxrs.model.ReceivingCollection;
+import org.folio.rest.jaxrs.model.ReceivingItemResult;
+import org.folio.rest.jaxrs.model.ReceivingResult;
+import org.folio.rest.jaxrs.model.ReceivingResults;
+import org.folio.rest.jaxrs.model.ToBeReceived;
+import org.folio.rest.jaxrs.resource.Orders;
+
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static me.escoffier.vertx.completablefuture.VertxCompletableFuture.allOf;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.folio.orders.utils.ErrorCodes.ITEM_NOT_FOUND;
+import static org.folio.orders.utils.ErrorCodes.ITEM_UPDATE_FAILED;
+import static org.folio.orders.utils.ErrorCodes.PIECE_ALREADY_RECEIVED;
+import static org.folio.orders.utils.ErrorCodes.PIECE_NOT_FOUND;
+import static org.folio.orders.utils.ErrorCodes.PIECE_NOT_RETRIEVED;
+import static org.folio.orders.utils.ErrorCodes.PIECE_UPDATE_FAILED;
+import static org.folio.orders.utils.ErrorCodes.PIECE_POL_MISMATCH;
+import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
+import static org.folio.orders.utils.HelperUtils.encodeQuery;
+import static org.folio.orders.utils.HelperUtils.handleGetRequest;
+import static org.folio.orders.utils.HelperUtils.handlePutRequest;
+import static org.folio.orders.utils.ResourcePathResolver.PIECES;
+import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
+import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.FULLY_RECEIVED;
+import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.PARTIALLY_RECEIVED;
+import static org.folio.rest.jaxrs.resource.Orders.PostOrdersReceiveResponse.respond200WithApplicationJson;
+
+public class ReceivingHelper extends AbstractHelper {
+
+  static final int MAX_IDS_FOR_GET_RQ = 15;
+  private static final String PIECES_WITH_QUERY_ENDPOINT = resourcesPath(PIECES) + "?limit=%d&lang=%s&query=%s";
+  private static final String PIECES_BY_POL_ID_AND_STATUS_QUERY = "poLineId==%s and receivingStatus==%s";
+
+  /**
+   * Map with PO line id as a key and value is map with piece id as a key and {@link Error} as a value
+   */
+  private final Map<String, Map<String, Error>> processingErrors = new HashMap<>();
+  /**
+   * Map with PO line id as a key and value is map with piece id as a key and {@link ReceivedItem} as a value
+   */
+  private final Map<String, Map<String, ReceivedItem>> receivingItems;
+
+  private final InventoryHelper inventoryHelper;
+  private final GetPOLinesHelper lookupPoLinesHelper;
+
+  ReceivingHelper(ReceivingCollection receivingCollection, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context ctx, String lang) {
+    super(getHttpClient(okapiHeaders), okapiHeaders, asyncResultHandler, ctx, lang);
+    setDefaultHeaders(httpClient);
+
+    inventoryHelper = new InventoryHelper(httpClient, okapiHeaders, ctx, lang);
+    lookupPoLinesHelper = new GetPOLinesHelper(httpClient, okapiHeaders, asyncResultHandler, ctx, lang);
+
+    // Convert request to map representation
+    receivingItems = groupReceivedItemsByPoLineId(receivingCollection);
+
+    // Logging quantity of the piece records to be received
+    if (logger.isDebugEnabled()) {
+      int poLinesQty = receivingItems.size();
+      long piecesQty = StreamEx.of(receivingItems.values())
+                               .flatMap(StreamEx::of)
+                               .count();
+      logger.debug("{} piece record(s) are going to be received for {} PO line(s)", piecesQty, poLinesQty);
+    }
+  }
+
+  public CompletableFuture<ReceivingResults> receiveItems(ReceivingCollection receivingCollection) {
+    CompletableFuture<ReceivingResults> futureForResult = new VertxCompletableFuture<>(ctx);
+    Map<String, List<Piece>> piecesByPoLine = new HashMap<>();
+
+    // 1. Get piece records from storage
+    retrievePieceRecords(piecesByPoLine)
+      // 2. Update items in the Inventory if required
+      .thenCompose(this::updateInventoryItems)
+      // 3. Update piece records with receiving details which do not have associated item
+      .thenApply(this::updatePieceRecordsWithoutItems)
+      // 4. Update received piece records in the storage
+      .thenCompose(this::storeUpdatedPieceRecords)
+      // 5. Update PO Line status
+      .thenCompose(this::updatePoLinesStatus)
+      // 6. Return results to the client
+      .thenAccept(piecesGroupedByPoLine -> {
+        ReceivingResults results = prepareResponseBody(receivingCollection, piecesGroupedByPoLine);
+        futureForResult.complete(results);
+        asyncResultHandler.handle(succeededFuture(respond200WithApplicationJson(results)));
+      })
+      .exceptionally(this::handleError);
+
+    return futureForResult;
+  }
+
+  private ReceivingResults prepareResponseBody(ReceivingCollection receivingCollection, Map<String, List<Piece>> piecesGroupedByPoLine) {
+    ReceivingResults results = new ReceivingResults();
+    results.setTotalRecords(receivingCollection.getTotalRecords());
+    for (ToBeReceived toBeReceived : receivingCollection.getToBeReceived()) {
+      String poLineId = toBeReceived.getPoLineId();
+      ReceivingResult result = new ReceivingResult();
+      results.getReceivingResults().add(result);
+
+      // Get all processed piece records for PO Line
+      Map<String, Piece> processedPiecesForPoLine = StreamEx
+        .of(piecesGroupedByPoLine.getOrDefault(poLineId, Collections.emptyList()))
+        .toMap(Piece::getId, piece -> piece);
+
+      int succeded = 0;
+      int failed = 0;
+      for (ReceivedItem receivedItem : toBeReceived.getReceivedItems()) {
+        String pieceId = receivedItem.getPieceId();
+
+        // Calculate processing status
+        ProcessingStatus status = new ProcessingStatus();
+        if (processedPiecesForPoLine.get(pieceId) != null && getError(poLineId, pieceId) == null) {
+          status.setType(ProcessingStatus.Type.SUCCESS);
+          succeded++;
+        } else {
+          status.setType(ProcessingStatus.Type.FAILURE);
+          status.setError(getError(poLineId, pieceId));
+          failed++;
+        }
+
+        ReceivingItemResult itemResult = new ReceivingItemResult();
+        itemResult.setPieceId(pieceId);
+        itemResult.setProcessingStatus(status);
+        result.getReceivingItemResults().add(itemResult);
+      }
+
+      result.withPoLineId(poLineId)
+            .withProcessedSuccessfully(succeded)
+            .withProcessedWithError(failed);
+    }
+
+    return results;
+  }
+
+  /**
+   * Retrieves piece records from storage based on request data
+   * @param piecesByPoLine map with PO line id as key and list of corresponding pieces as value
+   * @return {@link CompletableFuture} which holds map with PO line id as key and list of corresponding pieces as value
+   */
+  private CompletableFuture<Map<String, List<Piece>>> retrievePieceRecords(Map<String, List<Piece>> piecesByPoLine) {
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+    // Split all piece id's by maximum number of id's for get query
+    StreamEx.ofSubLists(getPieceIds(), MAX_IDS_FOR_GET_RQ)
+            // Send get request for each CQL query
+            .forEach(ids -> futures.add(getPiecesByIds(ids, piecesByPoLine)));
+
+    // Wait for all pieces to be retrieved and complete resulting future
+    return allOf(ctx, futures.toArray(new CompletableFuture[0]))
+      .thenApply(v -> {
+        if (logger.isDebugEnabled()) {
+          int poLinesQty = piecesByPoLine.size();
+          long piecesQty = StreamEx.of(piecesByPoLine.values())
+                                   .flatMap(StreamEx::of)
+                                   .count();
+          logger.debug("{} piece record(s) retrieved from storage for {} PO line(s)", piecesQty, poLinesQty);
+        }
+        return piecesByPoLine;
+      });
+  }
+
+  /**
+   * Gets all piece id's based on request data
+   * @return extract all piece id's
+   */
+  private List<String> getPieceIds() {
+    return StreamEx.ofValues(receivingItems)
+                   .map(Map::keySet)
+                   .toFlatList(ids -> ids);
+  }
+
+  private CompletableFuture<Void> getPiecesByIds(List<String> ids, Map<String, List<Piece>> piecesByPoLine) {
+    // Transform piece id's to CQL query
+    String query = HelperUtils.convertIdsToCqlQuery(ids);
+    String endpoint = String.format(PIECES_WITH_QUERY_ENDPOINT, ids.size(), lang, encodeQuery(query, logger));
+    return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+      .thenAccept(pieceJson -> {
+        List<Piece> pieces = pieceJson.mapTo(PieceCollection.class).getPieces();
+        pieces.forEach(piece -> validateAndProcessPiece(piece, piecesByPoLine));
+        checkIfAllPiecesFound(ids, pieces);
+      })
+      .exceptionally(e -> {
+        logger.error("The issue happened getting piece records", e);
+        ids.forEach(pieceId -> addError(getPoLineIdByPieceId(pieceId), pieceId, PIECE_NOT_RETRIEVED.toError()));
+        return null;
+      });
+  }
+
+  private void validateAndProcessPiece(Piece piece, Map<String, List<Piece>> piecesByPoLine) {
+    String poLineId = piece.getPoLineId();
+    String pieceId = piece.getId();
+
+    // Validate if the piece actually corresponds to PO line specified in the request
+    if (receivingItems.containsKey(poLineId) && receivingItems.get(poLineId).containsKey(pieceId)) {
+      // Validate if the piece is not yet received
+      if (piece.getReceivingStatus() == ReceivingStatus.EXPECTED) {
+        piecesByPoLine.computeIfAbsent(poLineId, v -> new ArrayList<>())
+                      .add(piece);
+      } else {
+        addError(poLineId, pieceId, PIECE_ALREADY_RECEIVED.toError());
+      }
+    } else {
+      addError(getPoLineIdByPieceId(pieceId), pieceId, PIECE_POL_MISMATCH.toError());
+    }
+  }
+
+  private void checkIfAllPiecesFound(List<String> pieceIds, List<Piece> pieces) {
+    // Handle the case when for some reason some pieces are not found
+    if (pieces.size() < pieceIds.size()) {
+      List<String> foundPieces = StreamEx.of(pieces)
+                                         .map(Piece::getId)
+                                         .toList();
+
+      pieceIds.stream()
+              .filter(pieceId -> !foundPieces.contains(pieceId))
+              .forEach(pieceId -> addError(getPoLineIdByPieceId(pieceId), pieceId, PIECE_NOT_FOUND.toError()));
+    }
+  }
+
+  /**
+   * Updates items in the inventory storage with receiving details if any. On success updates corresponding records as received
+   * @return {@link CompletableFuture} which holds map with PO line id as key and list of corresponding pieces as value
+   */
+  private CompletableFuture<Map<String, List<Piece>>> updateInventoryItems(Map<String, List<Piece>> piecesGroupedByPoLine) {
+    // Collect all piece records with non-empty item ids. The result is a map with item id as a key and piece record as a value
+    Map<String, Piece> piecesWithItems = collectPiecesWithItemId(piecesGroupedByPoLine);
+
+    // There is no any piece with item id
+    if (piecesWithItems.isEmpty()) {
+      return completedFuture(piecesGroupedByPoLine);
+    }
+
+    // Get item records from Inventory storage
+    List<String> itemIds = new ArrayList<>(piecesWithItems.keySet());
+    return inventoryHelper
+      .getItemRecordsByIds(itemIds)
+      // Update item records with receiving information and update Piece record on success
+      .thenCompose(items -> {
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+        for (JsonObject item : items) {
+          String itemId = item.getString(ID);
+          Piece piece = piecesWithItems.get(itemId);
+          ReceivedItem receivedItem = receivingItems.get(piece.getPoLineId())
+                                                    .get(piece.getId());
+          futures.add(inventoryHelper
+            // Update item records with receiving information and send updates to Inventory
+            .receiveItem(item, receivedItem)
+            // Update Piece record object with receiving details if item updated successfully
+            .thenApply(v -> {
+              updatePieceWithReceivingInfo(piece);
+              return true;
+            })
+            // Add processing error if item failed to be updated
+            .exceptionally(e -> {
+              logger.error("Item associated with piece '{}' cannot be updated", e, piece.getId());
+              addError(piece.getPoLineId(), piece.getId(), ITEM_UPDATE_FAILED.toError());
+              return false;
+            }));
+
+          // Remove item id to verify if all desired items were actually found
+          itemIds.remove(itemId);
+        }
+
+        // Check if all items retrieved from inventory and process errors if not
+        if (!itemIds.isEmpty()) {
+          itemIds.forEach(itemId -> {
+            Piece piece = piecesWithItems.get(itemId);
+            addError(piece.getPoLineId(), piece.getId(), ITEM_NOT_FOUND.toError());
+          });
+        }
+
+        return collectResultsOnSuccess(futures)
+          .thenApply(results -> {
+            if (logger.isDebugEnabled()) {
+              long successQty = results.stream()
+                                       .filter(result -> result)
+                                       .count();
+              logger.debug("{} out of {} inventory item(s) successfully updated", successQty, results.size());
+            }
+            return piecesGroupedByPoLine;
+          });
+      });
+  }
+
+  /**
+   * Collect all piece records with non-empty item ids. The result is a map with item id as a key and piece record as a value
+   * @param piecesGroupedByPoLine map with PO line id as key and list of corresponding pieces as value
+   * @return map with item id as key and piece record as a value
+   */
+  private Map<String, Piece> collectPiecesWithItemId(Map<String, List<Piece>> piecesGroupedByPoLine) {
+    return StreamEx
+        .of(piecesGroupedByPoLine.values())
+        .flatMap(StreamEx::of)
+        .filter(piece -> StringUtils.isNotEmpty(piece.getItemId()))
+        .toMap(Piece::getItemId, piece -> piece);
+  }
+
+  /**
+   * Updates piece records with receiving details which do not have associated item
+   * @param piecesGroupedByPoLine map with PO line id as key and list of corresponding pieces as value
+   * @return updated map passed as a parameter
+   */
+  private Map<String, List<Piece>> updatePieceRecordsWithoutItems(Map<String, List<Piece>> piecesGroupedByPoLine) {
+    // Collect all piece records without item id and update with receiving information.
+    StreamEx
+      .of(piecesGroupedByPoLine.values())
+      .flatMap(StreamEx::of)
+      .filter(piece -> StringUtils.isEmpty(piece.getItemId()))
+      .forEach(this::updatePieceWithReceivingInfo);
+
+    return piecesGroupedByPoLine;
+  }
+
+  /**
+   * Stores updated piece records with receiving details into storage.
+   * @param piecesGroupedByPoLine map with PO line id as key and list of corresponding pieces as value
+   * @return map passed as a parameter
+   */
+  private CompletableFuture<Map<String, List<Piece>>> storeUpdatedPieceRecords(Map<String, List<Piece>> piecesGroupedByPoLine) {
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+    // Collect all piece records which update with receiving information.
+    StreamEx
+      .of(piecesGroupedByPoLine.values())
+      .flatMap(StreamEx::of)
+      .filter(piece -> piece.getReceivingStatus() == ReceivingStatus.RECEIVED)
+      .forEach(piece -> {
+          String pieceId = piece.getId();
+          futures.add(
+            handlePutRequest(resourceByIdPath(PIECES, pieceId), JsonObject.mapFrom(piece), httpClient, ctx, okapiHeaders, logger)
+              .exceptionally(e -> {
+                addError(getPoLineIdByPieceId(pieceId), pieceId, PIECE_UPDATE_FAILED.toError());
+                return null;
+              }));
+        }
+      );
+
+    return allOf(ctx, futures.toArray(new CompletableFuture[0]))
+      .thenApply(v -> piecesGroupedByPoLine);
+  }
+
+  /**
+   * Updates piece record with receiving information
+   * @param piece piece record to be updated with receiving info
+   */
+  private void updatePieceWithReceivingInfo(Piece piece) {
+    // Get ReceivedItem corresponding to piece record
+    ReceivedItem receivedItem = receivingItems.get(piece.getPoLineId())
+                                              .get(piece.getId());
+
+    piece.setCaption(receivedItem.getCaption());
+    piece.setComment(receivedItem.getComment());
+    piece.setLocationId(receivedItem.getLocationId());
+    piece.setReceivedDate(new Date());
+    piece.setReceivingStatus(ReceivingStatus.RECEIVED);
+  }
+
+  /**
+   * Converts {@link ReceivingCollection} to map with PO line id as a key and value is map with piece id as a key
+   * and {@link ReceivedItem} as a value
+   * @param receivingCollection {@link ReceivingCollection} object
+   * @return map with PO line id as a key and value is map with piece id as a key and {@link ReceivedItem} as a value
+   */
+  private Map<String, Map<String, ReceivedItem>> groupReceivedItemsByPoLineId(ReceivingCollection receivingCollection) {
+    return StreamEx
+      .of(receivingCollection.getToBeReceived())
+      .groupingBy(ToBeReceived::getPoLineId,
+        mapping(ToBeReceived::getReceivedItems,
+          collectingAndThen(toList(),
+            lists -> StreamEx.of(lists)
+              .flatMap(List::stream)
+              .toMap(ReceivedItem::getPieceId, receivedItem -> receivedItem))));
+  }
+
+  private String getPoLineIdByPieceId(String pieceId) {
+    return EntryStream
+      .of(receivingItems)
+      .filter(entry -> entry.getValue()
+                            .containsKey(pieceId))
+      .keys()
+      .findFirst()
+      .orElse(EMPTY);
+  }
+
+  /**
+   * Stores updated piece records with receiving details into storage.
+   * @param piecesGroupedByPoLine map with PO line id as key and list of corresponding pieces as value
+   * @return map passed as a parameter
+   */
+  private CompletableFuture<Map<String, List<Piece>>> updatePoLinesStatus(Map<String, List<Piece>> piecesGroupedByPoLine) {
+    // Get all PO Line id's which potentially require receipt status update
+    List<String> poLineIdsForUpdatedPieces = getPoLineIdsForUpdatedPieces(piecesGroupedByPoLine);
+
+    // Get all PO Lines from storage which potentially require receipt status update
+    List<CompletableFuture<List<PoLine>>> polFutures = StreamEx
+      .ofSubLists(poLineIdsForUpdatedPieces, MAX_IDS_FOR_GET_RQ)
+      // Transform piece id's to CQL query
+      .map(HelperUtils::convertIdsToCqlQuery)
+      // Send get request for each CQL query
+      .map(this::getPoLinesByQuery)
+      .toList();
+
+    // Once all PO Lines are retrieved from storage check if receipt status requires update and persist in storage
+    return collectResultsOnSuccess(polFutures)
+      .thenApply(lists -> StreamEx.of(lists).toFlatList(poLines -> poLines))
+      .thenCompose(poLines -> {
+        // Calculate expected status for each PO Line and update with new one if required
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (PoLine poLine : poLines) {
+          futures.add(calculatePoLineReceiptStatus(poLine)
+            .thenCompose(status -> updatePoLineReceiptStatus(poLine, status)));
+        }
+        return collectResultsOnSuccess(futures)
+          .thenAccept(result -> logger.debug("{} out of {} PO Line(s) updated with new status", result.size(), poLineIdsForUpdatedPieces.size()));
+      })
+      .thenApply(v -> piecesGroupedByPoLine);
+  }
+
+  private CompletableFuture<ReceiptStatus> calculatePoLineReceiptStatus(PoLine poLine) {
+    String query = String.format(PIECES_BY_POL_ID_AND_STATUS_QUERY, poLine.getId(), ReceivingStatus.EXPECTED.value());
+    // Limit to 0 because only total number is important
+    String endpoint = String.format(PIECES_WITH_QUERY_ENDPOINT, 0, lang, encodeQuery(query, logger));
+    // Search for pieces with Expected status
+    return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+      // Check if total records is more than zero
+      .thenApply(json -> json.mapTo(PieceCollection.class).getTotalRecords() > 0)
+      // return expected status
+      .thenApply(isPartiallyReceived -> isPartiallyReceived ? PARTIALLY_RECEIVED : FULLY_RECEIVED)
+      .exceptionally(e -> {
+        logger.error("The expected receipt status for PO Line '{}' cannot be calculated", e, poLine.getId());
+        return null;
+      });
+  }
+
+  private CompletableFuture<Void> updatePoLineReceiptStatus(PoLine poLine, ReceiptStatus status) {
+    if (status == null || poLine.getReceiptStatus() == status) {
+      return completedFuture(null);
+    }
+
+    // Update receipt status and date (if fully received)
+    poLine.setReceiptStatus(status);
+    if (status == FULLY_RECEIVED) {
+      poLine.setReceiptDate(new Date());
+    }
+
+    // Update PO Line in storage
+    return handlePutRequest(resourceByIdPath(PO_LINES, poLine.getId()), JsonObject.mapFrom(poLine), httpClient, ctx, okapiHeaders, logger)
+      .exceptionally(e -> {
+        logger.error("The PO Line '{}' cannot be updated with new receipt status", e, poLine.getId());
+        return null;
+      });
+  }
+
+  private List<String> getPoLineIdsForUpdatedPieces(Map<String, List<Piece>> piecesGroupedByPoLine) {
+    return EntryStream
+      .of(piecesGroupedByPoLine)
+      .filter(entry -> entry.getValue()
+                            .stream()
+                            .anyMatch(piece -> piece.getReceivingStatus() == ReceivingStatus.RECEIVED))
+      .keys()
+      .toList();
+  }
+
+  private CompletableFuture<List<PoLine>> getPoLinesByQuery(String query) {
+    return lookupPoLinesHelper.getPOLines(MAX_IDS_FOR_GET_RQ, 0, query)
+      .thenApply(PoLineCollection::getPoLines)
+      .exceptionally(e -> {
+        logger.error("The issue happened getting PO Lines", e);
+        return null;
+      });
+  }
+
+  private Error getError(String polId, String pieceId) {
+    return processingErrors.computeIfAbsent(polId, k -> Collections.emptyMap())
+                           .get(pieceId);
+  }
+
+  private void addError(String polId, String pieceId, Error error) {
+    processingErrors.computeIfAbsent(polId, k -> new HashMap<>())
+                           .put(pieceId, error);
+  }
+
+  @Override
+  Response buildErrorResponse(int code, Error error) {
+    final Response result;
+    switch (code) {
+      case 400:
+        result = Orders.PostOrdersReceiveResponse.respond400WithApplicationJson(withErrors(error));
+        break;
+      case 422:
+        result = Orders.PostOrdersReceiveResponse.respond422WithApplicationJson(withErrors(error));
+        break;
+      default:
+        result = Orders.PostOrdersReceiveResponse.respond500WithApplicationJson(withErrors(error));
+    }
+    return result;
+  }
+}

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1,14 +1,7 @@
 package org.folio.rest.impl;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static org.folio.orders.utils.ErrorCodes.ELECTRONIC_LOC_QTY_EXCEEDS_COST;
-import static org.folio.orders.utils.ErrorCodes.NON_ZERO_COST_ELECTRONIC_QTY;
-import static org.folio.orders.utils.ErrorCodes.NON_ZERO_COST_PHYSICAL_QTY;
-import static org.folio.orders.utils.ErrorCodes.PHYSICAL_LOC_QTY_EXCEEDS_COST;
-import static org.folio.orders.utils.ErrorCodes.POL_LINES_LIMIT_EXCEEDED;
-import static org.folio.orders.utils.ErrorCodes.ZERO_COST_ELECTRONIC_QTY;
-import static org.folio.orders.utils.ErrorCodes.ZERO_COST_PHYSICAL_QTY;
-import static org.folio.orders.utils.ErrorCodes.ZERO_COST_QTY;
+import static org.folio.orders.utils.ErrorCodes.*;
 import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
 import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
@@ -27,9 +20,11 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -48,7 +43,9 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -60,6 +57,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
+import one.util.streamex.StreamEx;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.IOUtils;
@@ -68,7 +66,7 @@ import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.acq.model.Piece;
-import org.folio.rest.acq.model.PoLineCollection;
+import org.folio.rest.acq.model.PieceCollection;
 import org.folio.rest.acq.model.ReceivingHistoryCollection;
 import org.folio.rest.acq.model.SequenceNumber;
 import org.folio.rest.jaxrs.model.*;
@@ -110,11 +108,9 @@ import javax.ws.rs.core.Response.Status;
 public class OrdersImplTest {
 
   private static final String BAD_REQUEST = "BadRequest";
-  private static final String ORDERS_RECEIVING_HISTORY_ENDPOINT = "/orders/receiving-history";
   private static final String INSTANCE_RECORD = "instance_record";
   private static final String HOLDINGS_RECORD = "holding_record";
   private static final String ITEM_RECORDS = "item_records";
-  private static final String PIECES = "pieces";
   private static final String ORDER_WITHOUT_PO_LINES = "order_without_po_lines.json";
   private static final String ORDER_WITH_PO_LINES_JSON = "put_order_with_po_lines.json";
   private static final String ORDER_WITH_MISMATCH_ID_INT_PO_LINES_JSON = "put_order_with_mismatch_id_in_po_lines.json";
@@ -177,6 +173,8 @@ public class OrdersImplTest {
   private final static String LINES_PATH = "/orders/order-lines";
   private final static String LINE_BY_ID_PATH = "/orders/order-lines/%s";
   private static final String PONUMBER_VALIDATE_PATH = "/orders/po-number/validate";
+  private static final String ORDERS_RECEIVING_HISTORY_ENDPOINT = "/orders/receiving-history";
+  private static final String ORDERS_RECEIVING_ENDPOINT = "/orders/receive";
 
   // Mock data paths
   private static final String BASE_MOCK_DATA_PATH = "mockdata/";
@@ -185,20 +183,21 @@ public class OrdersImplTest {
   private static final String INSTANCE_STATUSES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "instanceStatuses/";
   private static final String INSTANCE_TYPES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "instanceTypes/";
   private static final String ITEMS_RECORDS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "itemsRecords/";
+  private static final String PIECE_RECORDS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "pieces/";
+  private static final String RECEIVING_RQ_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "receiving/";
   private static final String LOAN_TYPES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "loanTypes/";
   private static final String COMP_ORDER_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeOrders/";
+  private static final String PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "lines/";
   private static final String ORDERS_MOCK_DATA_PATH = COMP_ORDER_MOCK_DATA_PATH + "getOrders.json";
   private static final String ORDER_FOR_FAILURE_CASE_MOCK_DATA_PATH = COMP_ORDER_MOCK_DATA_PATH + PO_ID_FOR_FAILURE_CASE + ".json";
-  private static final String PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "lines/";
   private static final String COMP_PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeLines/";
-  private static final String MOCK_DATA_ROOT_PATH = "src/test/resources/";
-  private static final String LISTED_PRINT_MONOGRAPH_PATH = MOCK_DATA_ROOT_PATH + "/po_listed_print_monograph.json";
-  private static final String PE_MIX_PATH = MOCK_DATA_ROOT_PATH + "/po_listed_print_monograph_pe_mix.json";
+  private static final String LISTED_PRINT_MONOGRAPH_PATH = "po_listed_print_monograph.json";
+  private static final String PE_MIX_PATH = "po_listed_print_monograph_pe_mix.json";
   private static final String POLINES_COLLECTION = PO_LINES_MOCK_DATA_PATH + "/po_line_collection.json";
-  private static final String LISTED_PRINT_SERIAL_PATH = MOCK_DATA_ROOT_PATH + "/po_listed_print_serial.json";
-  private static final String MINIMAL_ORDER_PATH = MOCK_DATA_ROOT_PATH + "/minimal_order.json";
-  private static final String poCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_creation_failure.json";
-  private static final String poLineCreationFailurePath = MOCK_DATA_ROOT_PATH + "/po_line_creation_failure.json";
+  private static final String LISTED_PRINT_SERIAL_PATH = "po_listed_print_serial.json";
+  private static final String MINIMAL_ORDER_PATH = "minimal_order.json";
+  private static final String poCreationFailurePath = "po_creation_failure.json";
+  private static final String poLineCreationFailurePath = "po_line_creation_failure.json";
   private static final String CONFIG_MOCK_PATH = BASE_MOCK_DATA_PATH + "configurations.entries/%s.json";
   /** The PO Line with minimal required content */
   private static final String PO_LINE_MIN_CONTENT_PATH = COMP_PO_LINES_MOCK_DATA_PATH + "minimalContent.json";
@@ -1191,8 +1190,7 @@ public class OrdersImplTest {
     // Verify that not all expected items created
     assertThat(items.size(), lessThan(calculateInventoryItemsQuantity(reqData.getCompositePoLines().get(0))));
 
-    // Verify that pieces created for processed items quantity
-    verifyPiecesCreated(items, createdPieces);
+    // Verify that pieces created for processed items quantityverifyPiecesCreated(items, createdPieces);
   }
 
   private void verifyInstanceLinksForUpdatedOrder(CompositePurchaseOrder reqData) {
@@ -2328,13 +2326,13 @@ public class OrdersImplTest {
 
     final Response response = RestAssured
       .with()
-      .header(X_OKAPI_URL)
-      .header(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10)
+        .header(X_OKAPI_URL)
+        .header(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10)
       .get("/orders/po-number")
-      .then()
-      .statusCode(200)
-      .extract()
-      .response();
+        .then()
+          .statusCode(200)
+          .extract()
+            .response();
 
     String actualResponse = response.getBody().asString();
     logger.info(actualResponse);
@@ -2352,13 +2350,13 @@ public class OrdersImplTest {
 
     RestAssured
       .with()
-      .header(X_OKAPI_URL)
-      .header(PO_NUMBER_ERROR_X_OKAPI_TENANT)
+        .header(X_OKAPI_URL)
+        .header(PO_NUMBER_ERROR_X_OKAPI_TENANT)
       .get("/orders/po-number")
-      .then()
-      .statusCode(500)
-      .extract()
-      .response();
+        .then()
+          .statusCode(500)
+          .extract()
+            .response();
   }
 
   @Test
@@ -2429,13 +2427,155 @@ public class OrdersImplTest {
 
   }
 
+  @Test
+  public void testPostReceivingPhysicalAll() {
+    logger.info("=== Test POST Receiving - Receive physical resources");
+
+    ReceivingCollection receivingRq = getMockAsJson(RECEIVING_RQ_MOCK_DATA_PATH + "receive-physical-all-resources.json").mapTo(ReceivingCollection.class);
+
+    ReceivingResults results = verifyPostResponse(ORDERS_RECEIVING_ENDPOINT, JsonObject.mapFrom(receivingRq).encode(),
+      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 200).as(ReceivingResults.class);
+
+    assertThat(results.getTotalRecords(), equalTo(receivingRq.getTotalRecords()));
+
+    Map<String, Set<String>> pieceIdsByPol = verifyReceivingSuccessRs(results);
+
+    List<JsonObject> pieceSearches = MockServer.serverRqRs.get(PIECES, HttpMethod.GET);
+    List<JsonObject> pieceUpdates = MockServer.serverRqRs.get(PIECES, HttpMethod.PUT);
+    List<JsonObject> itemsSearches = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.GET);
+    List<JsonObject> itemUpdates = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.PUT);
+    List<JsonObject> polSearches = MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET);
+    List<JsonObject> polUpdates = MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT);
+
+    assertThat(pieceSearches, not(nullValue()));
+    assertThat(pieceUpdates, not(nullValue()));
+    assertThat(itemsSearches, not(nullValue()));
+    assertThat(itemUpdates, not(nullValue()));
+    assertThat(polSearches, not(nullValue()));
+    assertThat(polUpdates, not(nullValue()));
+
+    int expectedSearchRqQty = Math.floorDiv(receivingRq.getTotalRecords(), ReceivingHelper.MAX_IDS_FOR_GET_RQ) + 1;
+
+    // The piece searches should be made 2 times: 1st time to get all required piece records, 2nd time to calculate expected PO Line status
+    assertThat(pieceSearches, hasSize(expectedSearchRqQty + pieceIdsByPol.size()));
+    assertThat(pieceUpdates, hasSize(receivingRq.getTotalRecords()));
+    assertThat(itemsSearches, hasSize(expectedSearchRqQty));
+    assertThat(itemUpdates, hasSize(receivingRq.getTotalRecords()));
+    assertThat(polSearches, hasSize(pieceIdsByPol.size()));
+    assertThat(polUpdates, hasSize(pieceIdsByPol.size()));
+
+    itemUpdates.forEach(item -> {
+      assertThat(item.getString(ITEM_BARCODE), not(isEmptyString()));
+      assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
+      assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo("Received"));
+    });
+    polUpdates.forEach(pol -> assertThat(pol.mapTo(PoLine.class).getReceiptStatus(), is(PoLine.ReceiptStatus.FULLY_RECEIVED)));
+  }
+
+  @Test
+  public void testPostReceivingElectronicPartially() {
+    logger.info("=== Test POST Receiving - Receive partially electronic resources");
+
+    ReceivingCollection receiving = getMockAsJson(RECEIVING_RQ_MOCK_DATA_PATH + "receive-electronic-5-of-10-resources-no-items.json").mapTo(ReceivingCollection.class);
+
+    ReceivingResults results = verifyPostResponse(ORDERS_RECEIVING_ENDPOINT, JsonObject.mapFrom(receiving).encode(),
+      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 200).as(ReceivingResults.class);
+
+    assertThat(results.getTotalRecords(), equalTo(receiving.getTotalRecords()));
+
+    Map<String, Set<String>> pieceIdsByPol = verifyReceivingSuccessRs(results);
+
+    List<JsonObject> pieceSearches = MockServer.serverRqRs.get(PIECES, HttpMethod.GET);
+    List<JsonObject> pieceUpdates = MockServer.serverRqRs.get(PIECES, HttpMethod.PUT);
+    List<JsonObject> itemsSearches = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.GET);
+    List<JsonObject> itemUpdates = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.PUT);
+    List<JsonObject> polSearches = MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET);
+    List<JsonObject> polUpdates = MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT);
+
+    assertThat(pieceSearches, not(nullValue()));
+    assertThat(pieceUpdates, not(nullValue()));
+    assertThat(itemsSearches, is(nullValue()));
+    assertThat(itemUpdates, is(nullValue()));
+    assertThat(polSearches, not(nullValue()));
+    assertThat(polUpdates, not(nullValue()));
+
+    int expectedSearchRqQty = Math.floorDiv(receiving.getTotalRecords(), ReceivingHelper.MAX_IDS_FOR_GET_RQ) + 1;
+
+    // The piece searches should be made 2 times: 1st time to get all required piece records, 2nd time to calculate expected PO Line status
+    assertThat(pieceSearches, hasSize(expectedSearchRqQty + pieceIdsByPol.size()));
+    assertThat(pieceUpdates, hasSize(receiving.getTotalRecords()));
+    assertThat(polSearches, hasSize(pieceIdsByPol.size()));
+    assertThat(polUpdates, hasSize(pieceIdsByPol.size()));
+
+    polUpdates.forEach(pol -> assertThat(pol.mapTo(PoLine.class).getReceiptStatus(), is(PoLine.ReceiptStatus.PARTIALLY_RECEIVED)));
+  }
+
+  @Test
+  public void testPostReceivingPhysicalWithErrors() {
+    logger.info("=== Test POST Receiving - Receive physical resources with different errors");
+
+    ReceivingCollection receivingRq = getMockAsJson(RECEIVING_RQ_MOCK_DATA_PATH + "receive-physical-resources-6-of-10-with-errors.json").mapTo(ReceivingCollection.class);
+
+    ReceivingResults results = verifyPostResponse(ORDERS_RECEIVING_ENDPOINT, JsonObject.mapFrom(receivingRq).encode(),
+      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 200).as(ReceivingResults.class);
+
+    assertThat(results.getTotalRecords(), is(receivingRq.getTotalRecords()));
+    assertThat(results.getReceivingResults(), hasSize(1));
+
+    ReceivingResult receivingResult = results.getReceivingResults().get(0);
+
+    assertThat(receivingResult.getPoLineId(), not(isEmptyString()));
+    assertThat(receivingResult.getProcessedSuccessfully(), is(4));
+    assertThat(receivingResult.getProcessedWithError(), is(6));
+
+    Set<String> errorCodes = new HashSet<>();
+    for (ReceivingItemResult receivingItemResult : receivingResult.getReceivingItemResults()) {
+      assertThat(receivingItemResult.getPieceId(), not(isEmptyString()));
+      assertThat(receivingItemResult.getProcessingStatus(), not(nullValue()));
+      if (receivingItemResult.getProcessingStatus().getType() == ProcessingStatus.Type.SUCCESS) {
+        assertThat(receivingItemResult.getProcessingStatus().getError(), nullValue());
+      } else {
+        assertThat(receivingItemResult.getProcessingStatus().getError(), not(nullValue()));
+        errorCodes.add(receivingItemResult.getProcessingStatus().getError().getCode());
+      }
+    }
+
+    assertThat(errorCodes, containsInAnyOrder(PIECE_ALREADY_RECEIVED.getCode(),
+      PIECE_POL_MISMATCH.getCode(), PIECE_NOT_FOUND.getCode(), ITEM_UPDATE_FAILED.getCode(), ITEM_NOT_FOUND.getCode(),
+      PIECE_UPDATE_FAILED.getCode()));
+  }
+
+  private Map<String, Set<String>> verifyReceivingSuccessRs(ReceivingResults results) {
+    Map<String, Set<String>> pieceIdsByPol = new HashMap<>();
+    for (ReceivingResult receivingResult : results.getReceivingResults()) {
+      assertThat(receivingResult.getPoLineId(), not(isEmptyString()));
+      assertThat(receivingResult.getProcessedSuccessfully(), is(receivingResult.getReceivingItemResults().size()));
+      assertThat(receivingResult.getProcessedWithError(), is(0));
+
+      for (ReceivingItemResult receivingItemResult : receivingResult.getReceivingItemResults()) {
+        assertThat(receivingItemResult.getPieceId(), not(isEmptyString()));
+        assertThat(receivingItemResult.getProcessingStatus(), not(nullValue()));
+        assertThat(receivingItemResult.getProcessingStatus().getType(), is(ProcessingStatus.Type.SUCCESS));
+        assertThat(receivingItemResult.getProcessingStatus().getError(), nullValue());
+
+        pieceIdsByPol.computeIfAbsent(receivingResult.getPoLineId(), k -> new HashSet<>())
+                     .add(receivingItemResult.getPieceId());
+      }
+    }
+    return pieceIdsByPol;
+  }
+
   private org.folio.rest.acq.model.PoLine getMockLine(String id) {
     return getMockAsJson(PO_LINES_MOCK_DATA_PATH, id).mapTo(org.folio.rest.acq.model.PoLine.class);
   }
 
   private JsonObject getMockAsJson(String path, String id) {
+    return getMockAsJson(String.format("%s%s.json", path, id));
+  }
+
+  private JsonObject getMockAsJson(String fullPath) {
     try {
-      return new JsonObject(getMockData(String.format("%s%s.json", path, id)));
+      return new JsonObject(getMockData(fullPath));
     } catch (IOException e) {
       fail(e.getMessage());
     }
@@ -2511,7 +2651,7 @@ public class OrdersImplTest {
       router.route().handler(BodyHandler.create());
       router.route(HttpMethod.POST, resourcesPath(PURCHASE_ORDER)).handler(this::handlePostPurchaseOrder);
       router.route(HttpMethod.POST, "/inventory/instances").handler(this::handlePostInstanceRecord);
-      router.route(HttpMethod.POST, "/item-storage/items").handler(this::handlePostItemRecord);
+      router.route(HttpMethod.POST, "/item-storage/items").handler(this::handlePostItemStorRecord);
       router.route(HttpMethod.POST, "/holdings-storage/holdings").handler(this::handlePostHoldingRecord);
       router.route(HttpMethod.POST, resourcesPath(PO_LINES)).handler(this::handlePostPOLine);
       router.route(HttpMethod.POST, resourcesPath(ADJUSTMENT)).handler(ctx -> handlePostGenericSubObj(ctx, ADJUSTMENT));
@@ -2534,7 +2674,8 @@ public class OrdersImplTest {
       router.route(HttpMethod.GET, "/instance-statuses").handler(this::handleGetInstanceStatus);
       router.route(HttpMethod.GET, "/identifier-types").handler(this::handleGetIdentifierType);
       router.route(HttpMethod.GET, "/inventory/instances").handler(this::handleGetInstanceRecord);
-      router.route(HttpMethod.GET, "/item-storage/items").handler(this::handleGetItemsRecords);
+      router.route(HttpMethod.GET, "/item-storage/items").handler(this::handleGetItemRecordsFromStorage);
+      router.route(HttpMethod.GET, "/inventory/items").handler(this::handleGetInventoryItemRecords);
       router.route(HttpMethod.GET, "/holdings-storage/holdings").handler(this::handleGetHoldingRecord);
       router.route(HttpMethod.GET, "/loan-types").handler(this::handleGetLoanType);
       router.route(HttpMethod.GET, resourcesPath(PO_LINES)).handler(this::handleGetPoLines);
@@ -2552,12 +2693,13 @@ public class OrdersImplTest {
       router.route(HttpMethod.GET, resourcePath(SOURCE)).handler(ctx -> handleGetGenericSubObj(ctx, SOURCE));
       router.route(HttpMethod.GET, resourcePath(VENDOR_DETAIL)).handler(ctx -> handleGetGenericSubObj(ctx, VENDOR_DETAIL));
       router.route(HttpMethod.GET, resourcesPath(PO_NUMBER)).handler(this::handleGetPoNumber);
-      router.route(HttpMethod.GET, resourcesPath(PIECES)).handler(this::handleGetGenericPieceObj);
+      router.route(HttpMethod.GET, resourcesPath(PIECES)).handler(this::handleGetPieces);
       router.route(HttpMethod.GET, resourcesPath(RECEIVING_HISTORY)).handler(this::handleGetReceivingHistory);
       router.route(HttpMethod.GET, resourcesPath(PO_LINE_NUMBER)).handler(this::handleGetPoLineNumber);
 
       router.route(HttpMethod.PUT, resourcePath(PURCHASE_ORDER)).handler(ctx -> handlePutGenericSubObj(ctx, PURCHASE_ORDER));
       router.route(HttpMethod.PUT, resourcePath(PO_LINES)).handler(ctx -> handlePutGenericSubObj(ctx, PO_LINES));
+      router.route(HttpMethod.PUT, resourcePath(PIECES)).handler(ctx -> handlePutGenericSubObj(ctx, PIECES));
       router.route(HttpMethod.PUT, resourcePath(ADJUSTMENT)).handler(ctx -> handlePutGenericSubObj(ctx, ADJUSTMENT));
       router.route(HttpMethod.PUT, resourcePath(ALERTS)).handler(ctx -> handlePutGenericSubObj(ctx, ALERTS));
       router.route(HttpMethod.PUT, resourcePath(CLAIMS)).handler(ctx -> handlePutGenericSubObj(ctx, CLAIMS));
@@ -2570,7 +2712,7 @@ public class OrdersImplTest {
       router.route(HttpMethod.PUT, resourcePath(REPORTING_CODES)).handler(ctx -> handlePutGenericSubObj(ctx, REPORTING_CODES));
       router.route(HttpMethod.PUT, resourcePath(SOURCE)).handler(ctx -> handlePutGenericSubObj(ctx, SOURCE));
       router.route(HttpMethod.PUT, resourcePath(VENDOR_DETAIL)).handler(ctx -> handlePutGenericSubObj(ctx, VENDOR_DETAIL));
-
+      router.route(HttpMethod.PUT, "/inventory/items/:id").handler(ctx -> handlePutGenericSubObj(ctx, ITEM_RECORDS));
 
       router.route(HttpMethod.DELETE, resourcesPath(PURCHASE_ORDER)+"/:id").handler(ctx -> handleDeleteGenericSubObj(ctx, PURCHASE_ORDER));
       router.route(HttpMethod.DELETE, resourcePath(PO_LINES)).handler(ctx -> handleDeleteGenericSubObj(ctx, PO_LINES));
@@ -2631,7 +2773,7 @@ public class OrdersImplTest {
         .end();
     }
 
-    private void handlePostItemRecord(RoutingContext ctx) {
+    private void handlePostItemStorRecord(RoutingContext ctx) {
       String bodyAsString = ctx.getBodyAsString();
       logger.info("handlePostItemRecord got: " + bodyAsString);
 
@@ -2677,8 +2819,8 @@ public class OrdersImplTest {
       serverResponse(ctx, 200, APPLICATION_JSON, instance.encodePrettily());
     }
 
-    private void handleGetItemsRecords(RoutingContext ctx) {
-      logger.info("handleGetItemsRecords got: " + ctx.request().path());
+    private void handleGetItemRecordsFromStorage(RoutingContext ctx) {
+      logger.info("handleGetItemRecordsFromStorage got: " + ctx.request().path());
 
       try {
         JsonObject items;
@@ -2691,8 +2833,40 @@ public class OrdersImplTest {
         serverResponse(ctx, 200, APPLICATION_JSON, items.encodePrettily());
       } catch (IOException e) {
         ctx.response()
-          .setStatusCode(404)
-          .end();
+           .setStatusCode(404)
+           .end();
+      }
+    }
+
+    private void handleGetInventoryItemRecords(RoutingContext ctx) {
+      logger.info("handleGetInventoryItemRecords got: " + ctx.request().path());
+
+      String query = ctx.request().getParam("query");
+
+      try {
+        JsonObject items = new JsonObject(getMockData(ITEMS_RECORDS_MOCK_DATA_PATH + "inventoryItemsCollection.json"));
+        JsonArray jsonArray = items.getJsonArray(ITEMS);
+
+        if (query.contains("id==")) {
+          List<String> itemIds = extractIdsFromQuery(query);
+          final Iterator iterator = jsonArray.iterator();
+          while (iterator.hasNext()) {
+            JsonObject item = (JsonObject) iterator.next();
+            if (!itemIds.contains(item.getString(ID))) {
+              iterator.remove();
+            }
+          }
+        }
+
+        items.put("totalRecords", jsonArray.size());
+        addServerRqRsData(HttpMethod.GET, ITEM_RECORDS, items);
+
+        ctx.response()
+           .setStatusCode(200)
+           .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+           .end(items.encodePrettily());
+      } catch (Exception e) {
+        serverResponse(ctx, 500, APPLICATION_JSON, INTERNAL_SERVER_ERROR);
       }
     }
 
@@ -2832,19 +3006,38 @@ public class OrdersImplTest {
       } else if (queryParam.contains(ID_FOR_INTERNAL_SERVER_ERROR)) {
         serverResponse(ctx, 500, APPLICATION_JSON, Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
       } else {
-        String id = queryParam.split("purchase_order_id==")[1];
+        String poId = StringUtils.EMPTY;
         String tenant = ctx.request().getHeader(OKAPI_HEADER_TENANT);
+        List<String> polIds = Collections.emptyList();
+
+        if (queryParam.contains("purchase_order_id")) {
+          poId = queryParam.split("purchase_order_id==")[1];
+        } else if (queryParam.startsWith("id==")) {
+          polIds = extractIdsFromQuery(queryParam);
+        }
 
         try {
           JsonObject po_lines;
-          if (id.equals(ORDER_ID_WITH_PO_LINES)) {
-            po_lines = new JsonObject(getMockData(POLINES_COLLECTION));
+          if (poId.equals(ORDER_ID_WITH_PO_LINES) || !polIds.isEmpty()) {
+            PoLineCollection poLineCollection = new JsonObject(getMockData(POLINES_COLLECTION)).mapTo(PoLineCollection.class);
+
+            // Filter PO Lines either by PO id or by expected line ids
+            Iterator<PoLine> iterator = poLineCollection.getPoLines().iterator();
+            while (iterator.hasNext()) {
+              PoLine poLine = iterator.next();
+              if (polIds.isEmpty() ? !poId.equals(poLine.getPurchaseOrderId()) : !polIds.contains(poLine.getId())) {
+                iterator.remove();
+              }
+            }
+            poLineCollection.setTotalRecords(poLineCollection.getPoLines().size());
+
+            po_lines = JsonObject.mapFrom(poLineCollection);
           } else {
             String filePath;
-            if (ID_FOR_PRINT_MONOGRAPH_ORDER.equals(id)) {
+            if (ID_FOR_PRINT_MONOGRAPH_ORDER.equals(poId)) {
               filePath = LISTED_PRINT_MONOGRAPH_PATH;
             } else {
-              filePath = String.format("%s%s.json", COMP_ORDER_MOCK_DATA_PATH, id);
+              filePath = String.format("%s%s.json", COMP_ORDER_MOCK_DATA_PATH, poId);
             }
             JsonObject compPO = new JsonObject(getMockData(filePath));
             // Build PoLineCollection to make sure content is valid
@@ -2854,6 +3047,7 @@ public class OrdersImplTest {
 
           logger.info(po_lines.encodePrettily());
 
+          addServerRqRsData(HttpMethod.GET, PO_LINES, po_lines);
           serverResponse(ctx, 200, APPLICATION_JSON, po_lines.encode());
         } catch (IOException e) {
           PoLineCollection poLineCollection = new PoLineCollection();
@@ -2867,30 +3061,26 @@ public class OrdersImplTest {
       PoLineCollection result = new PoLineCollection();
       if (lines == null || lines.isEmpty()) {
         result.setTotalRecords(0);
-        result.setFirst(0);
-        result.setLast(0);
       } else {
         // Transform composite PO Lines to storage representation
-        List<org.folio.rest.acq.model.PoLine> poLines = lines
+        List<PoLine> poLines = lines
           .stream()
           .map(l -> (JsonObject) l)
           .map(line -> {
             replaceObjectById(line, ADJUSTMENT, COST, DETAILS, ERESOURCE, PHYSICAL, SOURCE, VENDOR_DETAIL);
             replaceObjectsByIds(line, ALERTS, CLAIMS, FUND_DISTRIBUTION, LOCATIONS, REPORTING_CODES);
-            return line.mapTo(org.folio.rest.acq.model.PoLine.class);
+            return line.mapTo(PoLine.class);
           })
           .collect(Collectors.toList());
 
         // Set PO Line number if empty
-        for (org.folio.rest.acq.model.PoLine line : poLines) {
+        for (PoLine line : poLines) {
           if (StringUtils.isEmpty(line.getPoLineNumber())) {
             line.setPoLineNumber(PO_NUMBER_VALUE + "-1");
           }
         }
 
         result.setPoLines(poLines);
-        result.setFirst(1);
-        result.setLast(lines.size());
         if (EMPTY_CONFIG_TENANT.equals(tenant)) {
           result.setTotalRecords(Integer.parseInt(DEFAULT_POLINE_LIMIT));
         } else {
@@ -2991,33 +3181,80 @@ public class OrdersImplTest {
       }
     }
 
-    private void handleGetGenericPieceObj(RoutingContext ctx) {
-      logger.info("got: " + ctx.request().path());
-      String id = ctx.request().getParam("query").split("poLineId=")[1];
-      logger.info("id: " + id);
+    private void handleGetPieces(RoutingContext ctx) {
+      logger.info("handleGetPieces got: " + ctx.request().path());
+      String query = ctx.request().getParam("query");
 
-      JsonArray pieces = new JsonArray();
-      JsonObject data = new JsonObject().put("pieces", pieces).put("total_records", 0);
-      addServerRqRsData(HttpMethod.GET, OrdersImplTest.PIECES, data);
+      PieceCollection pieces;
+      try {
+        if (query.contains("poLineId==")) {
+          List<String> conditions = StreamEx
+            .split(query, " or ")
+            .flatMap(s -> StreamEx.split(s, " and "))
+            .toList();
+
+          String polId = StringUtils.EMPTY;
+          String status = StringUtils.EMPTY;
+          for (String condition : conditions) {
+            if (condition.startsWith("poLineId")) {
+              polId = condition.split("poLineId==")[1];
+            } else if (condition.startsWith("receivingStatus")) {
+              status = condition.split("receivingStatus==")[1];
+            }
+          }
+          logger.info("poLineId: " + polId);
+          logger.info("receivingStatus: " + status);
+
+          String path = PIECE_RECORDS_MOCK_DATA_PATH + String.format("pieceRecords-%s.json", polId);
+          pieces = new JsonObject(getMockData(path)).mapTo(PieceCollection.class);
+
+          // Filter piece records by receiving status
+          if (StringUtils.isNotEmpty(status)) {
+            Piece.ReceivingStatus receivingStatus = Piece.ReceivingStatus.fromValue(status);
+            pieces.getPieces().removeIf(piece -> receivingStatus != piece.getReceivingStatus());
+          }
+        } else {
+          pieces = new JsonObject(getMockData(PIECE_RECORDS_MOCK_DATA_PATH + "pieceRecordsCollection.json")).mapTo(PieceCollection.class);
+
+          if (query.contains("id==")) {
+            List<String> pieceIds = extractIdsFromQuery(query);
+            pieces.getPieces().removeIf(piece -> !pieceIds.contains(piece.getId()));
+          }
+        }
+
+        pieces.setTotalRecords(pieces.getPieces().size());
+
+      } catch (Exception e) {
+        pieces = new PieceCollection();
+      }
+
+      JsonObject data = JsonObject.mapFrom(pieces);
+      addServerRqRsData(HttpMethod.GET, PIECES, data);
 
       ctx.response()
-        .setStatusCode(200)
-        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .end(data.encodePrettily());
+         .setStatusCode(200)
+         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+         .end(data.encodePrettily());
+    }
+
+    private List<String> extractIdsFromQuery(String query) {
+      return StreamEx
+        .split(query, " or ")
+        .flatMap(s -> StreamEx.split(s, "=="))
+        .map(String::trim)
+        .filter(s -> !ID.equals(s))
+        .toList();
     }
 
     private void handlePutGenericSubObj(RoutingContext ctx, String subObj) {
       logger.info("handlePutGenericSubObj got: PUT " + ctx.request().path());
       String id = ctx.request().getParam(ID);
 
-      JsonObject body = ctx.getBodyAsJson();
-      logger.info("body: " + body.encodePrettily());
-
-      addServerRqRsData(HttpMethod.PUT, subObj, body);
+      addServerRqRsData(HttpMethod.PUT, subObj, ctx.getBodyAsJson());
 
       if (ID_DOES_NOT_EXIST.equals(id)) {
         serverResponse(ctx, 404, APPLICATION_JSON, id);
-      } else if (ID_FOR_INTERNAL_SERVER_ERROR.equals(id)) {
+      } else if (ID_FOR_INTERNAL_SERVER_ERROR.equals(id) || ctx.getBodyAsString().contains("500500500500")) {
         serverResponse(ctx, 500, APPLICATION_JSON, INTERNAL_SERVER_ERROR);
       } else {
         ctx.response()

--- a/src/test/resources/mockdata/compositeLines/2bafc9e1-9dd3-4ede-9f23-c4a03f8bb2d5.json
+++ b/src/test/resources/mockdata/compositeLines/2bafc9e1-9dd3-4ede-9f23-c4a03f8bb2d5.json
@@ -1,0 +1,54 @@
+{
+  "id": "2bafc9e1-9dd3-4ede-9f23-c4a03f8bb2d5",
+  "acquisition_method": "Purchase At Vendor System",
+  "cancellation_restriction": false,
+  "collection": false,
+  "cost": {
+    "list_price": 10.00,
+    "currency": "USD",
+    "quantity_physical": 25,
+    "po_line_estimated_price": 250.00
+  },
+  "description": "25 physical resources for 2 locations",
+  "details": {
+    "receiving_note": "Receive all 25 items",
+    "product_ids": [
+      {
+        "product_id": "9780439708184",
+        "product_id_type": "ISBN"
+      }
+    ],
+    "material_types": [
+      "1a54b431-2e4f-452d-9cae-9cee66c9a892"
+    ]
+  },
+  "locations": [
+    {
+      "location_id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+      "quantity_physical": 20
+    },
+    {
+      "location_id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+      "quantity_physical": 5
+    }
+  ],
+  "order_format": "Physical Resource",
+  "payment_status": "Fully Paid",
+  "physical": {
+    "volumes": [
+      "vol.1"
+    ],
+    "material_supplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
+    "receipt_due": "2020-10-10T00:00:00.000Z"
+  },
+  "po_line_description": "Harry Potter (Book 1)",
+  "publication_date": "1998",
+  "publisher": "Scholastic",
+  "receipt_status": "Awaiting Receipt",
+  "requester": "Leo Bulero",
+  "rush": true,
+  "source": {
+    "code": "FOLIO"
+  },
+  "title": "Harry Potter and the Sorcerer's Stone"
+}

--- a/src/test/resources/mockdata/itemsRecords/inventoryItemsCollection.json
+++ b/src/test/resources/mockdata/itemsRecords/inventoryItemsCollection.json
@@ -1,0 +1,1370 @@
+{
+  "items": [
+    {
+      "id": "98eba19f-11c6-4a45-b4c0-0b9f30148f22",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000252",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.672+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.672+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/98eba19f-11c6-4a45-b4c0-0b9f30148f22"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "d3505286-ffbf-408d-96ec-b0c3a6b8bca8",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000255",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.693+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.693+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/d3505286-ffbf-408d-96ec-b0c3a6b8bca8"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "5a8b32b3-3e11-4af9-b652-c8eeb1c2b8b8",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000258",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.852+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.852+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/5a8b32b3-3e11-4af9-b652-c8eeb1c2b8b8"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "a146dc53-be76-4431-8fce-f1c27e323ed2",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000259",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.860+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.860+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/a146dc53-be76-4431-8fce-f1c27e323ed2"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "984e32d0-b46c-4612-b44c-6c8349ff5717",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000266",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.066+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.066+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/984e32d0-b46c-4612-b44c-6c8349ff5717"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "5d3d815a-0e51-4632-8f99-a2929df4eb01",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000265",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.067+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.067+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/5d3d815a-0e51-4632-8f99-a2929df4eb01"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "690e058d-48b3-449b-8a91-de95efc5960f",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000270",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.220+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.220+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/690e058d-48b3-449b-8a91-de95efc5960f"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "07f91e36-b22b-4114-aa8c-73cfaf4f1871",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000275",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.388+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.388+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/07f91e36-b22b-4114-aa8c-73cfaf4f1871"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "c27f379f-3bc4-49a4-b184-c173ec627169",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000267",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.068+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.068+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/c27f379f-3bc4-49a4-b184-c173ec627169"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "a3c36d4f-0698-4444-8fbb-fcd36dcb4e41",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000273",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.292+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.292+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/a3c36d4f-0698-4444-8fbb-fcd36dcb4e41"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "585092c4-6585-4512-bc74-055ab9d58c6f",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000253",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.675+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.675+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/585092c4-6585-4512-bc74-055ab9d58c6f"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "8ced07ec-0c19-4515-8a37-6e749dfa716a",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000254",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.685+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.685+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/8ced07ec-0c19-4515-8a37-6e749dfa716a"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "8967bbe9-c0af-4293-a03e-4bfd3fd25bfa",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000256",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.687+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.687+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/8967bbe9-c0af-4293-a03e-4bfd3fd25bfa"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "09c180f7-35ca-402a-810f-5599568012b4",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000257",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.784+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.784+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/09c180f7-35ca-402a-810f-5599568012b4"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "e3759cba-5303-49fe-b9ed-20d5ff4effe9",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000260",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.864+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.864+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/e3759cba-5303-49fe-b9ed-20d5ff4effe9"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "eb88f76e-8158-4c8b-a777-371e8e31228e",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000272",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.222+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.222+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/eb88f76e-8158-4c8b-a777-371e8e31228e"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "b941c136-d8b1-49ed-9c33-466cabce3a1d",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000261",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.885+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.885+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/b941c136-d8b1-49ed-9c33-466cabce3a1d"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "2dff0db1-563b-4b70-b2a1-579f45b0f12f",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000262",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.914+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.914+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/2dff0db1-563b-4b70-b2a1-579f45b0f12f"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "505f7a3f-863a-4e98-a7a7-567b17d7217b",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000271",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.221+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.221+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/505f7a3f-863a-4e98-a7a7-567b17d7217b"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "73db3f0a-4091-403b-ab36-b4e286d98d56",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000276",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.411+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.411+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/73db3f0a-4091-403b-ab36-b4e286d98d56"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "78992e05-8325-4da8-b527-e2f466913ebc",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000263",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.029+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.029+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/78992e05-8325-4da8-b527-e2f466913ebc"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "836f7d07-0072-4060-9d72-793515eebc32",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000268",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.139+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.139+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/836f7d07-0072-4060-9d72-793515eebc32"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "58093488-a593-4ed4-8930-f9a141d89e9e",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000264",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.044+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.044+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/58093488-a593-4ed4-8930-f9a141d89e9e"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "1984d052-bc2b-495a-984d-7fd07f65b7fe",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000269",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.181+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.181+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/1984d052-bc2b-495a-984d-7fd07f65b7fe"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "011fed67-57b0-45e6-bfab-b4803d267dea",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000274",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:45.328+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:45.328+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/011fed67-57b0-45e6-bfab-b4803d267dea"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "15231514-7aaf-46df-b009-8a4cfa3392af",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000303",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.576+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.576+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/15231514-7aaf-46df-b009-8a4cfa3392af"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "248ed3cf-cd2f-4f95-93b7-e09c8c1dc6eb",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000306",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.621+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.621+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/248ed3cf-cd2f-4f95-93b7-e09c8c1dc6eb"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "e81ec61f-a8e7-4d76-ad97-1c462ea8f00e",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000308",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.709+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.709+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/e81ec61f-a8e7-4d76-ad97-1c462ea8f00e"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "c0ac82e3-e53f-48d1-a435-86d965250e47",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000311",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.860+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.860+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/c0ac82e3-e53f-48d1-a435-86d965250e47"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "883b67bd-8a69-45c2-8db2-441ce393e85f",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000304",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.619+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.619+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/883b67bd-8a69-45c2-8db2-441ce393e85f"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "5319cb55-eb71-4528-80d4-472bbd48541d",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000305",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.594+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.594+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/5319cb55-eb71-4528-80d4-472bbd48541d"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
+      "id": "b92b9b57-00ce-4fac-b199-fc638097fe76",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000307",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.680+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.680+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/b92b9b57-00ce-4fac-b199-fc638097fe76"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "08955027-88c5-4065-b0a5-01258aabdb50",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000309",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.757+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.757+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/08955027-88c5-4065-b0a5-01258aabdb50"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "14359fb4-20e0-4198-94ca-88017f43d8e7",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000310",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "fee56afa-f2c5-410a-8a87-7155599dd1c7",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.756+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.756+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/14359fb4-20e0-4198-94ca-88017f43d8e7"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "e8e20101-807c-4f77-8836-04da15a443f4",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000302",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "cf447221-29b9-481e-947c-9ad545f22888",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-21T09:50:12.560+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-21T09:50:12.560+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/e8e20101-807c-4f77-8836-04da15a443f4"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    }
+  ],
+  "totalRecords": 35
+}

--- a/src/test/resources/mockdata/lines/po_line_collection.json
+++ b/src/test/resources/mockdata/lines/po_line_collection.json
@@ -31,7 +31,9 @@
       "fund_distribution": [
         "d10879e8-8c2d-4850-bcb9-0ec8e2e10021"
       ],
-      "locations": ["a4e65e03-99a4-4b39-8e6a-ae666ac52bea"],
+      "locations": [
+        "a4e65e03-99a4-4b39-8e6a-ae666ac52bea"
+      ],
       "order_format": "Physical Resource",
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "payment_status": "Awaiting Payment",
@@ -40,7 +42,7 @@
       "po_line_number": "268758-03",
       "publication_date": "2017",
       "publisher": "Schiffer Publishing",
-      "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
+      "purchase_order_id": "ab18897b-0e40-4f31-896b-9c9adc979a87",
       "receipt_date": "2018-10-09T00:00:00.000Z",
       "receipt_status": "Awaiting Receipt",
       "reporting_codes": [
@@ -107,7 +109,7 @@
       "po_line_number": "268758-03",
       "publication_date": "2017",
       "publisher": "Schiffer Publishing",
-      "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
+      "purchase_order_id": "ab18897b-0e40-4f31-896b-9c9adc979a87",
       "receipt_date": "2018-10-09T00:00:00.000Z",
       "receipt_status": "Awaiting Receipt",
       "reporting_codes": [
@@ -131,9 +133,84 @@
         "createdDate": "2018-07-19T00:00:00.000+0000",
         "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
       }
+    },
+    {
+      "id": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "instance_id": "b252d8f4-e14f-4f27-9f11-876b1f8ed13a",
+      "acquisition_method": "Purchase At Vendor System",
+      "alerts": [],
+      "cancellation_restriction": false,
+      "claims": [],
+      "collection": false,
+      "contributors": [],
+      "cost": "bb4e98be-e787-4193-a97a-9496341cf2c1",
+      "description": "25 physical resources for 2 locations",
+      "details": "92656b58-2528-46f4-b8ff-8fa976051a6d",
+      "fund_distribution": [],
+      "locations": [
+        "a24c922c-a224-4620-97e6-05b4468f8f27",
+        "f527db3a-fb25-40e8-a027-93775ca8b2eb"
+      ],
+      "order_format": "Physical Resource",
+      "payment_status": "Fully Paid",
+      "physical": "0ae68bf4-48e6-47d8-8846-297fae67f88e",
+      "po_line_description": "Harry Potter (Book 1)",
+      "po_line_number": "2LINES1PHYS1EL-1",
+      "publication_date": "1998",
+      "publisher": "Scholastic",
+      "purchase_order_id": "555a155e-8bb7-4670-ace4-463fc70c2a75",
+      "receipt_status": "Awaiting Receipt",
+      "reporting_codes": [],
+      "requester": "Leo Bulero",
+      "rush": true,
+      "source": "2306a19c-b675-4c87-88a1-0a1079c65117",
+      "tags": [],
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:43.854+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.418+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      }
+    },
+    {
+      "id": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "acquisition_method": "Purchase At Vendor System",
+      "alerts": [],
+      "cancellation_restriction": false,
+      "claims": [],
+      "collection": false,
+      "contributors": [],
+      "cost": "2a030c58-7a30-4c4f-abca-2bc8dd799bf3",
+      "description": "10 electronic resources for 1 location",
+      "details": "007e607d-7617-4bc3-9f6d-563519b3d401",
+      "eresource": "22837acf-46fb-471b-ac7f-6b68f14155f2",
+      "fund_distribution": [],
+      "locations": [
+        "642a281d-8d8e-4d4b-8d3a-0905074b1f73"
+      ],
+      "order_format": "Electronic Resource",
+      "payment_status": "Fully Paid",
+      "physical": "53349162-6c44-4438-b651-3057b598140d",
+      "po_line_description": "Harry Potter (Book 2)",
+      "po_line_number": "2LINES1PHYS1EL-2",
+      "publication_date": "2000",
+      "publisher": "Scholastic Paperbacks",
+      "purchase_order_id": "555a155e-8bb7-4670-ace4-463fc70c2a75",
+      "receipt_status": "Awaiting Receipt",
+      "reporting_codes": [],
+      "requester": "Leo Bulero",
+      "rush": true,
+      "source": "ef5e635c-0af9-46bf-ba16-1e417028a1bb",
+      "tags": [],
+      "title": "Harry Potter and the Chamber of Secrets",
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:43.877+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:43.877+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      }
     }
   ],
-  "total_records": 2,
-  "first": 1,
-  "last": 2
+  "total_records": 4
 }

--- a/src/test/resources/mockdata/pieces/pieceRecords-0dd8f1d2-ac2e-4155-a407-72071f6d5f4a.json
+++ b/src/test/resources/mockdata/pieces/pieceRecords-0dd8f1d2-ac2e-4155-a407-72071f6d5f4a.json
@@ -1,0 +1,4 @@
+{
+  "pieces": [],
+  "total_records": 0
+}

--- a/src/test/resources/mockdata/pieces/pieceRecords-daa9cfd1-b330-4b65-8c2a-3663aaae5130.json
+++ b/src/test/resources/mockdata/pieces/pieceRecords-daa9cfd1-b330-4b65-8c2a-3663aaae5130.json
@@ -1,0 +1,30 @@
+{
+  "pieces": [
+    {
+      "id": "cc3cb47d-a39a-42f6-8317-06178c62ffa1",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "7fb84824-4f37-421e-bca4-ab966e517021",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "4c74a8ae-2f36-4201-826d-2ae94ef36b37",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "e3c8c400-e0a8-4499-b33b-509a65fe99ea",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "81f65edb-d73c-4a41-ab4a-5bc36a455cf1",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    }
+  ],
+  "total_records": 5
+}

--- a/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
+++ b/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
@@ -1,0 +1,259 @@
+{
+  "pieces": [
+    {
+      "id": "cc3cb47d-a39a-42f6-8317-06178c62ffa1",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "7fb84824-4f37-421e-bca4-ab966e517021",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "4c74a8ae-2f36-4201-826d-2ae94ef36b37",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "e3c8c400-e0a8-4499-b33b-509a65fe99ea",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "81f65edb-d73c-4a41-ab4a-5bc36a455cf1",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "2beff851-d9df-4a8d-a65b-762c9d78340d",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "73d7c872-ce17-4b6c-9729-309e844fef9b",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "f8bb5de0-fa1c-49b7-82b3-c2c2dfd0925d",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "2d10cd5a-8325-4873-a940-2fcf838a54af",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "36840b87-b4b4-48dd-b2fc-a5370df4034a",
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "84a6597e-0895-4756-ba32-170a3aac8fae",
+      "itemId": "585092c4-6585-4512-bc74-055ab9d58c6f",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "17f1c5d4-77dc-4f73-8484-e20c5cc11499",
+      "itemId": "984e32d0-b46c-4612-b44c-6c8349ff5717",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "bb3af75f-cb01-46b6-a84c-8b7d1a470254",
+      "itemId": "c27f379f-3bc4-49a4-b184-c173ec627169",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "e1746e80-ac75-4183-a89b-dc764afea8c9",
+      "itemId": "73db3f0a-4091-403b-ab36-b4e286d98d56",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "eaeb6ddf-38e8-4221-ac9e-b3c0df0ea99d",
+      "itemId": "07f91e36-b22b-4114-aa8c-73cfaf4f1871",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "cb8dcb28-5631-49e7-9f26-b7f9df0e840e",
+      "itemId": "98eba19f-11c6-4a45-b4c0-0b9f30148f22",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "a2d37678-3f68-42c2-a997-0f3c81f1948c",
+      "itemId": "8ced07ec-0c19-4515-8a37-6e749dfa716a",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "13b79316-58c4-4d4f-bbec-5870c8088021",
+      "itemId": "8967bbe9-c0af-4293-a03e-4bfd3fd25bfa",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "0065b764-c522-4a88-957c-9ecce226515c",
+      "itemId": "d3505286-ffbf-408d-96ec-b0c3a6b8bca8",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "30972298-8f03-4674-8758-a5ed6ce313b9",
+      "itemId": "09c180f7-35ca-402a-810f-5599568012b4",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "963a058b-5171-4869-8f8b-4d102ae4dff4",
+      "itemId": "5a8b32b3-3e11-4af9-b652-c8eeb1c2b8b8",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "4819f32b-1aed-43a7-814a-1994c3434360",
+      "itemId": "a146dc53-be76-4431-8fce-f1c27e323ed2",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "23e0c592-1c3c-4b50-a6fd-7c1826ea5b81",
+      "itemId": "2dff0db1-563b-4b70-b2a1-579f45b0f12f",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "57e41ac9-3d59-4380-8be9-c41385f7d646",
+      "itemId": "78992e05-8325-4da8-b527-e2f466913ebc",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "a16b54a3-b6bc-4edb-ad43-113f090eb3f8",
+      "itemId": "5d3d815a-0e51-4632-8f99-a2929df4eb01",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "8c7c3b2a-dd60-4dd7-bf0b-84844628f2ba",
+      "itemId": "1984d052-bc2b-495a-984d-7fd07f65b7fe",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "35a7d8d4-6847-4699-8f76-464c7cecaf47",
+      "itemId": "690e058d-48b3-449b-8a91-de95efc5960f",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "cd341e06-4579-4a0d-ae73-31475ebc4551",
+      "itemId": "505f7a3f-863a-4e98-a7a7-567b17d7217b",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "51686715-5c81-400e-b219-30bb7e9c6139",
+      "itemId": "a3c36d4f-0698-4444-8fbb-fcd36dcb4e41",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "43d51a47-d867-4c08-be11-25c925016854",
+      "itemId": "011fed67-57b0-45e6-bfab-b4803d267dea",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "46992f8a-bcdc-4c05-b002-25b3a2ab819c",
+      "itemId": "b941c136-d8b1-49ed-9c33-466cabce3a1d",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "ef29ae20-d9bb-41f6-a10d-148b4784573d",
+      "itemId": "e3759cba-5303-49fe-b9ed-20d5ff4effe9",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "b70bcd05-f63d-43ed-8e05-6b70b53abdd4",
+      "itemId": "58093488-a593-4ed4-8930-f9a141d89e9e",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "55c9587a-60fe-424b-8dd0-642ff71e9201",
+      "itemId": "836f7d07-0072-4060-9d72-793515eebc32",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "6a1a71c9-e53a-4213-b2df-25f35e5a772f",
+      "itemId": "eb88f76e-8158-4c8b-a777-371e8e31228e",
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "5062d4d7-2164-4cc0-bbb1-aa755324b95c",
+      "itemId": "e8e20101-807c-4f77-8836-04da15a443f4",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "5e8e29c4-801d-4e5b-a07c-3a975861db1c",
+      "itemId": "15231514-7aaf-46df-b009-8a4cfa3392af",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "70502e16-f07a-4156-a6b9-492862f1f8f3",
+      "itemId": "5319cb55-eb71-4528-80d4-472bbd48541d",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "f7272eb2-499f-4c29-985e-7ffc468d2360",
+      "itemId": "883b67bd-8a69-45c2-8db2-441ce393e85f",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "168f8a86-d26c-406e-813f-c7527f241ac3",
+      "itemId": "248ed3cf-cd2f-4f95-93b7-e09c8c1dc6eb",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "2f6056bd-e7f1-4e51-add2-b0c803066c74",
+      "itemId": "2f6056bd-e7f1-4e51-add2-b0c803066c74",
+      "poLineId": "2f6056bd-e7f1-4e51-add2-b0c803066c74",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "2884f2cd-ccab-47e1-a021-9b22a05230d9",
+      "itemId": "14359fb4-20e0-4198-94ca-88017f43d8e7",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "6f495150-9a7c-4104-84fa-16f3ec9ab005",
+      "itemId": "6f495150-9a7c-4104-84fa-16f3ec9ab005",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "8c057872-9c75-4fb1-879d-de3b089b0388",
+      "itemId": "c0ac82e3-e53f-48d1-a435-86d965250e47",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Received"
+    }
+  ],
+  "total_records": 44
+}

--- a/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
+++ b/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
@@ -225,7 +225,7 @@
       "receivingStatus": "Expected"
     },
     {
-      "id": "168f8a86-d26c-406e-813f-c7527f241ac3",
+      "id": "de647d4a-cc53-440d-be2b-da12559ba51c",
       "itemId": "248ed3cf-cd2f-4f95-93b7-e09c8c1dc6eb",
       "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
       "receivingStatus": "Expected"
@@ -253,7 +253,14 @@
       "itemId": "c0ac82e3-e53f-48d1-a435-86d965250e47",
       "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
       "receivingStatus": "Received"
+    },
+    {
+      "id": "46dd0dad-9f35-431f-8f40-556bc389e628",
+      "comment": "Expected error itemNotRetrieved",
+      "itemId": "168f8a86-d26c-406e-813f-c7527f241ac3",
+      "poLineId": "826eb2fd-7c0b-4d59-a55c-7d25195adc62",
+      "receivingStatus": "Expected"
     }
   ],
-  "total_records": 44
+  "total_records": 45
 }

--- a/src/test/resources/mockdata/receiving/receive-500-error-for-items-lookup.json
+++ b/src/test/resources/mockdata/receiving/receive-500-error-for-items-lookup.json
@@ -1,0 +1,18 @@
+{
+  "toBeReceived": [
+    {
+      "poLineId": "826eb2fd-7c0b-4d59-a55c-7d25195adc62",
+      "received": 1,
+      "receivedItems": [
+        {
+          "barcode": 21111311113,
+          "comment": "Expected error itemNotRetrieved",
+          "itemStatus": "Received",
+          "locationId": "168f8a86-d26c-406e-813f-c7527f241ac3",
+          "pieceId": "46dd0dad-9f35-431f-8f40-556bc389e628"
+        }
+      ]
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/mockdata/receiving/receive-500-error-for-pieces-lookup.json
+++ b/src/test/resources/mockdata/receiving/receive-500-error-for-pieces-lookup.json
@@ -1,0 +1,18 @@
+{
+  "toBeReceived": [
+    {
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "received": 1,
+      "receivedItems": [
+        {
+          "barcode": 21111311112,
+          "comment": "Expected error pieceNotRetrieved",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "168f8a86-d26c-406e-813f-c7527f241ac3"
+        }
+      ]
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/mockdata/receiving/receive-electronic-5-of-10-resources-no-items.json
+++ b/src/test/resources/mockdata/receiving/receive-electronic-5-of-10-resources-no-items.json
@@ -1,0 +1,51 @@
+{
+  "toBeReceived": [
+    {
+      "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
+      "received": 10,
+      "receivedItems": [
+        {
+          "barcode": 21111111112,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "36840b87-b4b4-48dd-b2fc-a5370df4034a"
+        },
+        {
+          "barcode": 21111111113,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "2d10cd5a-8325-4873-a940-2fcf838a54af"
+        },
+        {
+          "barcode": 21111111114,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "f8bb5de0-fa1c-49b7-82b3-c2c2dfd0925d"
+        },
+        {
+          "barcode": 21111111115,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "73d7c872-ce17-4b6c-9729-309e844fef9b"
+        },
+        {
+          "barcode": 21111111116,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "2beff851-d9df-4a8d-a65b-762c9d78340d"
+        }
+      ]
+    }
+  ],
+  "totalRecords": 5
+}

--- a/src/test/resources/mockdata/receiving/receive-electronic-5-of-10-resources-no-items.json
+++ b/src/test/resources/mockdata/receiving/receive-electronic-5-of-10-resources-no-items.json
@@ -2,7 +2,7 @@
   "toBeReceived": [
     {
       "poLineId": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
-      "received": 10,
+      "received": 5,
       "receivedItems": [
         {
           "barcode": 21111111112,

--- a/src/test/resources/mockdata/receiving/receive-physical-all-resources.json
+++ b/src/test/resources/mockdata/receiving/receive-physical-all-resources.json
@@ -1,0 +1,211 @@
+{
+  "toBeReceived": [
+    {
+      "poLineId": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "received": 25,
+      "receivedItems": [
+        {
+          "barcode": 21111111122,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "eaeb6ddf-38e8-4221-ac9e-b3c0df0ea99d"
+        },
+        {
+          "barcode": 21111111123,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "43d51a47-d867-4c08-be11-25c925016854"
+        },
+        {
+          "barcode": 21111111124,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "51686715-5c81-400e-b219-30bb7e9c6139"
+        },
+        {
+          "barcode": 21111111125,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "6a1a71c9-e53a-4213-b2df-25f35e5a772f"
+        },
+        {
+          "barcode": 21111111126,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "e1746e80-ac75-4183-a89b-dc764afea8c9"
+        },
+        {
+          "barcode": 21111111127,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "cd341e06-4579-4a0d-ae73-31475ebc4551"
+        },
+        {
+          "barcode": 21111111128,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "35a7d8d4-6847-4699-8f76-464c7cecaf47"
+        },
+        {
+          "barcode": 21111111129,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "8c7c3b2a-dd60-4dd7-bf0b-84844628f2ba"
+        },
+        {
+          "barcode": 21111111130,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "55c9587a-60fe-424b-8dd0-642ff71e9201"
+        },
+        {
+          "barcode": 21111111131,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "bb3af75f-cb01-46b6-a84c-8b7d1a470254"
+        },
+        {
+          "barcode": 21111111132,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "b70bcd05-f63d-43ed-8e05-6b70b53abdd4"
+        },
+        {
+          "barcode": 21111111133,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "a16b54a3-b6bc-4edb-ad43-113f090eb3f8"
+        },
+        {
+          "barcode": 21111111134,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "17f1c5d4-77dc-4f73-8484-e20c5cc11499"
+        },
+        {
+          "barcode": 21111111135,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "57e41ac9-3d59-4380-8be9-c41385f7d646"
+        },
+        {
+          "barcode": 21111111136,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "23e0c592-1c3c-4b50-a6fd-7c1826ea5b81"
+        },
+        {
+          "barcode": 21111111137,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "ef29ae20-d9bb-41f6-a10d-148b4784573d"
+        },
+        {
+          "barcode": 21111111138,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "46992f8a-bcdc-4c05-b002-25b3a2ab819c"
+        },
+        {
+          "barcode": 21111111139,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "4819f32b-1aed-43a7-814a-1994c3434360"
+        },
+        {
+          "barcode": 21111111140,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "963a058b-5171-4869-8f8b-4d102ae4dff4"
+        },
+        {
+          "barcode": 21111111141,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "30972298-8f03-4674-8758-a5ed6ce313b9"
+        },
+        {
+          "barcode": 21111111142,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "0065b764-c522-4a88-957c-9ecce226515c"
+        },
+        {
+          "barcode": 21111111143,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "13b79316-58c4-4d4f-bbec-5870c8088021"
+        },
+        {
+          "barcode": 21111111144,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "a2d37678-3f68-42c2-a997-0f3c81f1948c"
+        },
+        {
+          "barcode": 21111111145,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "84a6597e-0895-4756-ba32-170a3aac8fae"
+        },
+        {
+          "barcode": 21111111146,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "cb8dcb28-5631-49e7-9f26-b7f9df0e840e"
+        }
+      ]
+    }
+  ],
+  "totalRecords": 25
+}

--- a/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
+++ b/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
@@ -1,0 +1,91 @@
+{
+  "toBeReceived": [
+    {
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "received": 10,
+      "receivedItems": [
+        {
+          "barcode": 11111111112,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "8c057872-9c75-4fb1-879d-de3b089b0388"
+        },
+        {
+          "barcode": 11111111113,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "6f495150-9a7c-4104-84fa-16f3ec9ab005"
+        },
+        {
+          "barcode": 11111111114,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "2884f2cd-ccab-47e1-a021-9b22a05230d9"
+        },
+        {
+          "barcode": 11111111115,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "2f6056bd-e7f1-4e51-add2-b0c803066c74"
+        },
+        {
+          "barcode": 11111111116,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "99e04f91-6985-48df-997d-289773fd8c44"
+        },
+        {
+          "barcode": 11111111117,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "168f8a86-d26c-406e-813f-c7527f241ac3"
+        },
+        {
+          "barcode": 11111111118,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "f7272eb2-499f-4c29-985e-7ffc468d2360"
+        },
+        {
+          "barcode": 11111111119,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "70502e16-f07a-4156-a6b9-492862f1f8f3"
+        },
+        {
+          "barcode": 11111111120,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "5e8e29c4-801d-4e5b-a07c-3a975861db1c"
+        },
+        {
+          "barcode": 500500500500,
+          "comment": "Very important note",
+          "caption": "Vol. 1",
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+          "pieceId": "5062d4d7-2164-4cc0-bbb1-aa755324b95c"
+        }
+      ]
+    }
+  ],
+  "totalRecords": 10
+}

--- a/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
+++ b/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
@@ -6,7 +6,7 @@
       "receivedItems": [
         {
           "barcode": 11111111112,
-          "comment": "Very important note",
+          "comment": "Expected error pieceAlreadyReceived",
           "caption": "Vol. 1",
           "itemStatus": "Received",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
@@ -14,7 +14,7 @@
         },
         {
           "barcode": 11111111113,
-          "comment": "Very important note",
+          "comment": "Expected error itemNotFound",
           "caption": "Vol. 1",
           "itemStatus": "Received",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
@@ -30,7 +30,7 @@
         },
         {
           "barcode": 11111111115,
-          "comment": "Very important note",
+          "comment": "Expected error piecePolMismatch",
           "caption": "Vol. 1",
           "itemStatus": "Received",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
@@ -38,7 +38,7 @@
         },
         {
           "barcode": 11111111116,
-          "comment": "Very important note",
+          "comment": "Expected error pieceNotFound",
           "caption": "Vol. 1",
           "itemStatus": "Received",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
@@ -46,11 +46,11 @@
         },
         {
           "barcode": 11111111117,
-          "comment": "Very important note",
+          "comment": "500500500500 Expected error pieceUpdateFailed",
           "caption": "Vol. 1",
           "itemStatus": "Received",
-          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
-          "pieceId": "168f8a86-d26c-406e-813f-c7527f241ac3"
+          "locationId": "168f8a86-d26c-406e-813f-c7527f241ac3",
+          "pieceId": "de647d4a-cc53-440d-be2b-da12559ba51c"
         },
         {
           "barcode": 11111111118,
@@ -78,7 +78,7 @@
         },
         {
           "barcode": 500500500500,
-          "comment": "Very important note",
+          "comment": "Expected error itemUpdateFailed",
           "caption": "Vol. 1",
           "itemStatus": "Received",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",

--- a/src/test/resources/mockdata/receivingHistory/receivingHistory.json
+++ b/src/test/resources/mockdata/receivingHistory/receivingHistory.json
@@ -17,7 +17,5 @@
         "title": "Kayak Fishing in the Northern Gulf Coast"
       }
     ],
-  "total_records": 1,
-  "first": 1,
-  "last": 1
+  "total_records": 1
 }

--- a/src/test/resources/po_one_physical_one_electronic_lines.json
+++ b/src/test/resources/po_one_physical_one_electronic_lines.json
@@ -5,11 +5,11 @@
     "Order with one line of Physical and one of Electronic Resources format"
   ],
   "order_type": "One-Time",
-  "po_number": "2LINES1PHYS1EL",
+  "po_number": "TEST2POL1PHYS1EL",
   "re_encumber": false,
   "total_estimated_price": 350.00,
   "total_items": 35,
-  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "vendor": "8be1cd0a-acab-488d-b650-65ceb96aa148",
   "workflow_status": "Open",
   "compositePoLines": [
     {
@@ -85,10 +85,11 @@
           }
         ],
         "material_types": [
-          "1a54b431-2e4f-452d-9cae-9cee66c9a892"
+          "615b8413-82d5-4203-aa6e-e37984cb5ac3"
         ]
       },
       "eresource": {
+        "access_provider": "8be1cd0a-acab-488d-b650-65ceb96aa148",
         "create_inventory": false
       },
       "locations": [
@@ -99,13 +100,6 @@
       ],
       "order_format": "Electronic Resource",
       "payment_status": "Fully Paid",
-      "physical": {
-        "volumes": [
-          "vol.2"
-        ],
-        "material_supplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
-        "receipt_due": "2020-10-10T00:00:00.000Z"
-      },
       "po_line_description": "Harry Potter (Book 2)",
       "publication_date": "2000",
       "publisher": "Scholastic Paperbacks",

--- a/src/test/resources/po_one_physical_one_electronic_lines.json
+++ b/src/test/resources/po_one_physical_one_electronic_lines.json
@@ -27,7 +27,11 @@
         "receiving_note": "Receive all 25 items",
         "product_ids": [
           {
-            "product_id": "9780439708184",
+            "product_id": "0439708184",
+            "product_id_type": "ISBN"
+          },
+          {
+            "product_id": "9780439708180",
             "product_id_type": "ISBN"
           }
         ],

--- a/src/test/resources/po_one_physical_one_electronic_lines.json
+++ b/src/test/resources/po_one_physical_one_electronic_lines.json
@@ -1,0 +1,121 @@
+{
+  "approved": true,
+  "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "notes": [
+    "Order with one line of Physical and one of Electronic Resources format"
+  ],
+  "order_type": "One-Time",
+  "po_number": "2LINES1PHYS1EL",
+  "re_encumber": false,
+  "total_estimated_price": 350.00,
+  "total_items": 35,
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "workflow_status": "Open",
+  "compositePoLines": [
+    {
+      "acquisition_method": "Purchase At Vendor System",
+      "cancellation_restriction": false,
+      "collection": false,
+      "cost": {
+        "list_price": 10.00,
+        "currency": "USD",
+        "quantity_physical": 25,
+        "po_line_estimated_price": 250.00
+      },
+      "description": "25 physical resources for 2 locations",
+      "details": {
+        "receiving_note": "Receive all 25 items",
+        "product_ids": [
+          {
+            "product_id": "9780439708184",
+            "product_id_type": "ISBN"
+          }
+        ],
+        "material_types": [
+          "1a54b431-2e4f-452d-9cae-9cee66c9a892"
+        ]
+      },
+      "locations": [
+        {
+          "location_id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "quantity_physical": 20
+        },
+        {
+          "location_id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+          "quantity_physical": 5
+        }
+      ],
+      "order_format": "Physical Resource",
+      "payment_status": "Fully Paid",
+      "physical": {
+        "volumes": [
+          "vol.1"
+        ],
+        "material_supplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
+        "receipt_due": "2020-10-10T00:00:00.000Z"
+      },
+      "po_line_description": "Harry Potter (Book 1)",
+      "publication_date": "1998",
+      "publisher": "Scholastic",
+      "receipt_status": "Awaiting Receipt",
+      "requester": "Leo Bulero",
+      "rush": true,
+      "source": {
+        "code": "FOLIO"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone"
+    },
+    {
+      "acquisition_method": "Purchase At Vendor System",
+      "cancellation_restriction": false,
+      "collection": false,
+      "cost": {
+        "list_price": 10.00,
+        "currency": "USD",
+        "quantity_electronic": 10,
+        "po_line_estimated_price": 100.00
+      },
+      "description": "10 electronic resources for 1 location",
+      "details": {
+        "receiving_note": "Receive 10 items",
+        "product_ids": [
+          {
+            "product_id": "9780439064873",
+            "product_id_type": "ISBN"
+          }
+        ],
+        "material_types": [
+          "1a54b431-2e4f-452d-9cae-9cee66c9a892"
+        ]
+      },
+      "eresource": {
+        "create_inventory": false
+      },
+      "locations": [
+        {
+          "location_id": "b241764c-1466-4e1d-a028-1a3684a5da87",
+          "quantity_electronic": 10
+        }
+      ],
+      "order_format": "Electronic Resource",
+      "payment_status": "Fully Paid",
+      "physical": {
+        "volumes": [
+          "vol.2"
+        ],
+        "material_supplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
+        "receipt_due": "2020-10-10T00:00:00.000Z"
+      },
+      "po_line_description": "Harry Potter (Book 2)",
+      "publication_date": "2000",
+      "publisher": "Scholastic Paperbacks",
+      "receipt_status": "Awaiting Receipt",
+      "requester": "Leo Bulero",
+      "rush": true,
+      "source": {
+        "code": "FOLIO"
+      },
+      "title": "Harry Potter and the Chamber of Secrets"
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-103](https://issues.folio.org/browse/MODORDERS-103) Implement receiving flow for physical resources
[MODORDERS-162](https://issues.folio.org/browse/MODORDERS-162) Implement receiving flow for electronic resources

## Approach
Upon receiving a request to receive resources, it does the following:
* Retrieve piece records from the orders storage based on the [request body](https://github.com/folio-org/acq-models/blob/master/mod-orders/schemas/receivingCollection.json).
* For those pieces which have item id the process is like following:
  * Retrieve items from inventory.
  * Update item entities with barcode (if specified) and status
  * Send PUT requests to inventory to update items. In case any errors happen while updating items, the logic just collects them and does not stop entire process
* Update piece records with receiving information and send PUT requests to orders storage. If any errors happen, just collect them.  
  The following is expected to be update in piece:
  * `receivingStatus`: `Received`
  * `locationId`: from the request
  * `receivedDate`: current date
* Retrieve all involved PO Lines from the storage and update receipt status.
  * If all pieces of this order line have been received, the receipt status is `Fully Received`.
  * If more than one, but less than the total number of pieces have been received, it is `Partially Received`.
  * If the status is the same, no update is made
* Prepare [response](https://github.com/folio-org/acq-models/blob/master/mod-orders/schemas/receivingResults.json) to the client taking into account any error happened processing particular piece record.

## Learning
The logic implemented in the ReceivingHelper uses some of the features of the [StreamEx library](https://github.com/amaembo/streamex)  
StreamEx library main points are following:
* Shorter and convenient ways to do the common tasks.
* 100% compatibility with original JDK streams.
* Friendliness for parallel processing: any new feature takes the advantage on parallel streams as much as possible.
* Performance and minimal overhead. If StreamEx allows to solve the task using less code compared to standard Stream, it should not be significantly slower than the standard way (and sometimes it's even faster).

[StreamEx Cheatsheet](https://github.com/amaembo/streamex/blob/master/CHEATSHEET.md)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards ([sonarcloud mod-orders PR#107](https://sonarcloud.io/project/issues?id=org.folio%3Amod-orders&pullRequest=107&resolved=false))?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] No
