### PR TITLE
Release 3.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+## 4.0.0 - Unreleased
+
 ## 3.0.0 - Released
 
 ### Stories

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,30 @@
-## 3.0.0 - Unreleased
+## 3.0.0 - Released
+
+### Stories
+ * [MODORDERS-154](https://issues.folio.org/browse/MODORDERS-154) - PO Line's `location` property is changed to `locations` i.e. from single object to array of objects
+ * [MODORDERS-149](https://issues.folio.org/browse/MODORDERS-149) - Add PO Line's identifier to item record in the inventory
+ * [MODORDERS-148](https://issues.folio.org/browse/MODORDERS-148) - Populate PO `dateOrdered` field field when Order is opened
+ * [MODORDERS-146](https://issues.folio.org/browse/MODORDERS-146) - Return application/json (error.json schema) for all errors
+ * [MODORDERS-142](https://issues.folio.org/browse/MODORDERS-142) - Implemented `GET /orders/order-lines` endpoint
+ * [MODORDERS-134](https://issues.folio.org/browse/MODORDERS-134) - Assign PO Line's id to its sub-objects
+ * [MODORDERS-129](https://issues.folio.org/browse/MODORDERS-129) - PO Lines: share status of corresponding PO
+ * [MODORDERS-126](https://issues.folio.org/browse/MODORDERS-126) - Implemented `GET /orders/composite-orders` endpoint
  * [MODORDERS-124](https://issues.folio.org/browse/MODORDERS-124) - Redefined existing order/lines endpoints
- * [MODORDERS-87](https://issues.folio.org/browse/MODORDERS-87) - Implemented GET PO Number (PO Number generation)
- * [MODORDERS-72](https://issues.folio.org/browse/MODORDERS-72) - Define receiving endpoints
+ * [MODORDERS-121](https://issues.folio.org/browse/MODORDERS-121) - Create Instance Record in inventory when Order's status is changed to `Open`
+ * [MODORDERS-117](https://issues.folio.org/browse/MODORDERS-117) - Business Logic: handle `Create Item` flag for e-Resources
+ * [MODORDERS-105](https://issues.folio.org/browse/MODORDERS-105) - Implemented `GET /orders/receiving-history` endpoint
+ * [MODORDERS-100](https://issues.folio.org/browse/MODORDERS-100) - Create Piece Records in Orders Storage for items quantity ordered on Order Placement
+ * [MODORDERS-99](https://issues.folio.org/browse/MODORDERS-99) - Purchase Order Limit: Set system default to 1
+ * [MODORDERS-96](https://issues.folio.org/browse/MODORDERS-96) - Supporting PO number prefix and suffix
+ * [MODORDERS-93](https://issues.folio.org/browse/MODORDERS-93) - Assign system generated PO Line number when creating a new PO line
+ * [MODORDERS-87](https://issues.folio.org/browse/MODORDERS-87) - Implemented `GET /orders/po-number` endpoint
+ * [MODORDERS-72](https://issues.folio.org/browse/MODORDERS-72) - Define receiving endpoints: `/orders/receive`, `/orders/check-in` and `/orders/receiving-history`
  * [MODORDERS-67](https://issues.folio.org/browse/MODORDERS-67) - Create Item Record in inventory for physical/electronic items quantity
+ * [MODORDERS-66](https://issues.folio.org/browse/MODORDERS-66) - Create Holding Record in inventory for titles ordered that are not currently represented in inventory by a Holding
+
+### Bug Fixes
+ * [MODORDERS-153](https://issues.folio.org/browse/MODORDERS-153) - PO Line's id is absent from sub-objects in response when creating new PO Line
+ * [MODORDERS-145](https://issues.folio.org/browse/MODORDERS-145) - Unable to create new Purchase Order with PO Line
 
 ## 2.0.1 - Released
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -270,67 +270,67 @@
   "requires": [
     {
       "id": "orders-storage.purchase_orders",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.adjustments",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.alerts",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.claims",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.costs",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.details",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.eresources",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.fund-distributions",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.locations",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.pieces",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.physicals",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.receiving-history",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "orders-storage.reporting_codes",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.sources",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.vendor_details",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "orders-storage.po_lines",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "holdings-storage",
@@ -338,7 +338,7 @@
     },
     {
       "id": "orders-storage.po_number",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "identifier-types",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v1.0.1</tag>
+    <tag>v3.0.0</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>3.0.0</version>
+  <version>4.0.0-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v3.0.0</tag>
+    <tag>v1.0.1</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
## Purpose
[MODORDERS-161](https://issues.folio.org/browse/MODORDERS-161) Create release v3.0.0

## Approach
- The required orders storage interface version dependencies are updated
- News file is updates for v3.0.0

#### TODOS and Open Questions
- [x] this PR must be merged only after [mod-orders-storage PR#88](https://github.com/folio-org/mod-orders-storage/pull/88)