### PR TITLE
Modorders 171 receieving history additional data for receiving flow

### DIFF
--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -2190,6 +2190,7 @@ public class OrdersImplTest {
     assertEquals(lineId, lineWithIds.remove(ID));
     assertEquals(orderId, lineWithIds.remove(PURCHASE_ORDER_ID));
     assertEquals(poLineNumber, lineWithIds.remove(PO_LINE_NUMBER));
+    assertEquals(org.folio.rest.acq.model.PoLine.ReceiptStatus.PENDING.value(), lineWithIds.remove("receipt_status"));
     lineWithIds.stream().forEach(entry -> {
       Object value = entry.getValue();
       // Required properties

--- a/src/test/resources/mockdata/receivingHistory/receivingHistory.json
+++ b/src/test/resources/mockdata/receivingHistory/receivingHistory.json
@@ -10,6 +10,8 @@
         "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
         "poLineId": "c1498090-538a-4470-9525-27e4e0c74b07",
         "poLineNumber": "268758-03",
+        "poLineOrderFormat": "Physical Resource",
+        "poLineReceiptStatus": "Partially Received",
         "purchaseOrderId": "0804ddec-6545-404a-b54d-a693f505681d",
         "receivedDate": "2018-10-09T00:00:00.000Z",
         "receivingNote": "ASD FGH ABCDEFGHIJKLMNOPQ",


### PR DESCRIPTION
## Purpose
[MODORDERS-171](https://issues.folio.org/browse/MODORDERS-171) The GET /orders/receiving-history endpoint needs to be enhanced to return additional data required for [UIREC-16](https://issues.folio.org/browse/UIREC-16) and [UIREC-20](https://issues.folio.org/browse/UIREC-20):
- PO Line's receipt status
- PO Line's order format

## Approach
 - updated ramls/acq-models submodule
 - unit tests updated

#### TODOS and Open Questions

- [x] Merge [folio-org/mod-orders-storage#89](https://github.com/folio-org/mod-orders-storage/pull/89) first


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
