### PR TITLE
MODORDERS-175 Add ability to move a received piece back to "Expected"

### DIFF
--- a/ramls/order.raml
+++ b/ramls/order.raml
@@ -147,7 +147,10 @@ resourceTypes:
                   value: !include raml-util/examples/errors.sample
   /receive:
     displayName: Receive items
-    description: Receive items spanning one or more PO lines
+    description: |
+      Receive items spanning one or more PO lines. The endpoint is used to:
+      - receive pieces and associated inventory items
+      - move a received piece back to "Expected" in case "receivedItems" element's "itemStatus" is "On order"
     type:
       post-with-200:
         requestSchema: receiving-collection

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -173,9 +173,15 @@ public class InventoryHelper {
     itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, receivedItem.getItemStatus()));
     if (StringUtils.isNotEmpty(receivedItem.getBarcode())) {
       itemRecord.put(ITEM_BARCODE, receivedItem.getBarcode());
+    } else if (isOnOrderItemStatus(receivedItem)) {
+      itemRecord.remove(ITEM_BARCODE);
     }
 
     return handlePutRequest(endpoint, itemRecord, httpClient, ctx, okapiHeaders, logger);
+  }
+
+  public boolean isOnOrderItemStatus(ReceivedItem receivedItem) {
+    return ITEM_STATUS_ON_ORDER.equalsIgnoreCase(receivedItem.getItemStatus());
   }
 
   private CompletableFuture<String> getOrCreateHoldingsRecord(CompositePoLine compPOL, String locationId) {

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -173,13 +173,16 @@ public class InventoryHelper {
     itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, receivedItem.getItemStatus()));
     if (StringUtils.isNotEmpty(receivedItem.getBarcode())) {
       itemRecord.put(ITEM_BARCODE, receivedItem.getBarcode());
-    } else if (isOnOrderItemStatus(receivedItem)) {
-      itemRecord.remove(ITEM_BARCODE);
     }
 
     return handlePutRequest(endpoint, itemRecord, httpClient, ctx, okapiHeaders, logger);
   }
 
+  /**
+   * Checks if the {@link ReceivedItem} has item status as "On order"
+   * @param receivedItem item details specified by user upon receiving flow
+   * @return {@code true} if the item status is "On order"
+   */
   public boolean isOnOrderItemStatus(ReceivedItem receivedItem) {
     return ITEM_STATUS_ON_ORDER.equalsIgnoreCase(receivedItem.getItemStatus());
   }

--- a/src/main/java/org/folio/rest/impl/ReceivingHelper.java
+++ b/src/main/java/org/folio/rest/impl/ReceivingHelper.java
@@ -242,7 +242,7 @@ public class ReceivingHelper extends AbstractHelper {
 
   /**
    * Verifies if the current status of the piece record is "Received" and the client would like to roll-back to Expected
-   * @param piece piece reqcord involved in receiving flow
+   * @param piece piece record to asses
    * @return {@code true} if piece record is already received and has to be rolled-back to Expected
    */
   private boolean isRevertReceivedItem(Piece piece) {

--- a/src/main/java/org/folio/rest/impl/ReceivingHelper.java
+++ b/src/main/java/org/folio/rest/impl/ReceivingHelper.java
@@ -56,6 +56,7 @@ import static org.folio.orders.utils.ResourcePathResolver.PIECES;
 import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.AWAITING_RECEIPT;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.FULLY_RECEIVED;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.PARTIALLY_RECEIVED;
 import static org.folio.rest.jaxrs.resource.Orders.PostOrdersReceiveResponse.respond200WithApplicationJson;
@@ -228,7 +229,7 @@ public class ReceivingHelper extends AbstractHelper {
     // Validate if the piece actually corresponds to PO line specified in the request
     if (receivingItems.containsKey(poLineId) && receivingItems.get(poLineId).containsKey(pieceId)) {
       // Validate if the piece is not yet received
-      if (piece.getReceivingStatus() == ReceivingStatus.EXPECTED) {
+      if (piece.getReceivingStatus() == ReceivingStatus.EXPECTED || isRevertReceivedItem(piece)) {
         piecesByPoLine.computeIfAbsent(poLineId, v -> new ArrayList<>())
                       .add(piece);
       } else {
@@ -237,6 +238,16 @@ public class ReceivingHelper extends AbstractHelper {
     } else {
       addError(getPoLineIdByPieceId(pieceId), pieceId, PIECE_POL_MISMATCH.toError());
     }
+  }
+
+  /**
+   * Verifies if the current status of the piece record is "Received" and the client would like to roll-back to Expected
+   * @param piece piece reqcord involved in receiving flow
+   * @return {@code true} if piece record is already received and has to be rolled-back to Expected
+   */
+  private boolean isRevertReceivedItem(Piece piece) {
+    return piece.getReceivingStatus() == ReceivingStatus.RECEIVED
+      && inventoryHelper.isOnOrderItemStatus(receivingItems.get(piece.getPoLineId()).get(piece.getId()));
   }
 
   /**
@@ -411,11 +422,24 @@ public class ReceivingHelper extends AbstractHelper {
     ReceivedItem receivedItem = receivingItems.get(piece.getPoLineId())
                                               .get(piece.getId());
 
-    piece.setCaption(receivedItem.getCaption());
-    piece.setComment(receivedItem.getComment());
-    piece.setLocationId(receivedItem.getLocationId());
-    piece.setReceivedDate(new Date());
-    piece.setReceivingStatus(ReceivingStatus.RECEIVED);
+    if (StringUtils.isNotEmpty(receivedItem.getCaption())) {
+      piece.setCaption(receivedItem.getCaption());
+    }
+    if (StringUtils.isNotEmpty(receivedItem.getComment())) {
+      piece.setComment(receivedItem.getComment());
+    }
+    if (StringUtils.isNotEmpty(receivedItem.getLocationId())) {
+      piece.setLocationId(receivedItem.getLocationId());
+    }
+
+    // Piece record might be received or rolled-back to Expected
+    if (inventoryHelper.isOnOrderItemStatus(receivedItem)) {
+      piece.setReceivedDate(null);
+      piece.setReceivingStatus(ReceivingStatus.EXPECTED);
+    } else {
+      piece.setReceivedDate(new Date());
+      piece.setReceivingStatus(ReceivingStatus.RECEIVED);
+    }
   }
 
   /**
@@ -428,7 +452,7 @@ public class ReceivingHelper extends AbstractHelper {
     CompletableFuture[] futures = StreamEx
       .ofValues(piecesGroupedByPoLine)
       .flatMap(List::stream)
-      .filter(piece -> piece.getReceivingStatus() == ReceivingStatus.RECEIVED)
+      .filter(piece -> getError(piece.getPoLineId(), piece.getId()) == null)
       .map(this::storeUpdatedPieceRecord)
       .toArray(new CompletableFuture[0]);
 
@@ -503,7 +527,7 @@ public class ReceivingHelper extends AbstractHelper {
         // Calculate expected status for each PO Line and update with new one if required
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (PoLine poLine : poLines) {
-          futures.add(calculatePoLineReceiptStatus(poLine)
+          futures.add(calculatePoLineReceiptStatus(poLine, getSuccessfullyProcessedPieces(poLine.getId(), piecesGroupedByPoLine))
             .thenCompose(status -> updatePoLineReceiptStatus(poLine, status)));
         }
         return collectResultsOnSuccess(futures)
@@ -512,20 +536,57 @@ public class ReceivingHelper extends AbstractHelper {
       .thenApply(v -> piecesGroupedByPoLine);
   }
 
-  private CompletableFuture<ReceiptStatus> calculatePoLineReceiptStatus(PoLine poLine) {
-    String query = String.format(PIECES_BY_POL_ID_AND_STATUS_QUERY, poLine.getId(), ReceivingStatus.EXPECTED.value());
-    // Limit to 0 because only total number is important
-    String endpoint = String.format(PIECES_WITH_QUERY_ENDPOINT, 0, lang, encodeQuery(query, logger));
+  private List<Piece> getSuccessfullyProcessedPieces(String poLineId, Map<String, List<Piece>> piecesGroupedByPoLine) {
+    return StreamEx.of(piecesGroupedByPoLine.get(poLineId))
+                   .filter(piece -> getError(poLineId, piece.getId()) == null)
+                   .toList();
+  }
+
+  /**
+   * @param poLine PO Line record from storage
+   * @param pieces list of pieces
+   * @return
+   */
+  private CompletableFuture<ReceiptStatus> calculatePoLineReceiptStatus(PoLine poLine, List<Piece> pieces) {
     // Search for pieces with Expected status
-    return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
-      // Check if total records is more than zero
-      .thenApply(json -> json.mapTo(PieceCollection.class).getTotalRecords() > 0)
-      // return expected status
-      .thenApply(isPartiallyReceived -> isPartiallyReceived ? PARTIALLY_RECEIVED : FULLY_RECEIVED)
+    return getPiecesQuantityByPoLineAndStatus(poLine.getId(), ReceivingStatus.EXPECTED)
+      // Calculate receipt status
+      .thenCompose(expectedQty -> calculatePoLineReceiptStatus(expectedQty, poLine, pieces))
       .exceptionally(e -> {
         logger.error("The expected receipt status for PO Line '{}' cannot be calculated", e, poLine.getId());
         return null;
       });
+  }
+
+  private CompletableFuture<Integer> getPiecesQuantityByPoLineAndStatus(String poLineId, ReceivingStatus receivingStatus) {
+    String query = String.format(PIECES_BY_POL_ID_AND_STATUS_QUERY, poLineId, receivingStatus.value());
+    // Limit to 0 because only total number is important
+    String endpoint = String.format(PIECES_WITH_QUERY_ENDPOINT, 0, lang, encodeQuery(query, logger));
+    // Search for pieces with Expected status
+    return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+      // Return total records quantity
+      .thenApply(json -> json.mapTo(PieceCollection.class).getTotalRecords());
+  }
+
+  /**
+   * Returns "Fully Received" status if quantity of expected piece records is zero, otherwise checks how many received pieces.
+   * If quantity of received piece records is zero, returns "Awaiting Receipt" status, otherwise - "Partially Received"
+   * @param expectedPiecesQuantity expected piece records quantity
+   * @param poLine PO Line record representation from storage
+   * @return completable future holding calculated PO Line's receipt status
+   */
+  private CompletableFuture<ReceiptStatus> calculatePoLineReceiptStatus(int expectedPiecesQuantity, PoLine poLine, List<Piece> pieces) {
+    // Fully Received: In case there is no any expected piece remaining
+    if (expectedPiecesQuantity == 0) {
+      return CompletableFuture.completedFuture(FULLY_RECEIVED);
+    }
+    // Partially Received: In case there is at least one successfully received piece
+    if (StreamEx.of(pieces).anyMatch(piece -> ReceivingStatus.RECEIVED == piece.getReceivingStatus())) {
+      return CompletableFuture.completedFuture(PARTIALLY_RECEIVED);
+    }
+    // Pieces were rolled-back to Expected. In this case we have to check if there is any Received piece in the storage
+    return getPiecesQuantityByPoLineAndStatus(poLine.getId(), ReceivingStatus.RECEIVED)
+      .thenApply(receivedQty -> receivedQty == 0 ? AWAITING_RECEIPT : PARTIALLY_RECEIVED);
   }
 
   private CompletableFuture<Void> updatePoLineReceiptStatus(PoLine poLine, ReceiptStatus status) {
@@ -537,6 +598,8 @@ public class ReceivingHelper extends AbstractHelper {
     poLine.setReceiptStatus(status);
     if (status == FULLY_RECEIVED) {
       poLine.setReceiptDate(new Date());
+    } else {
+      poLine.setReceiptDate(null);
     }
 
     // Update PO Line in storage
@@ -552,7 +615,8 @@ public class ReceivingHelper extends AbstractHelper {
       .of(piecesGroupedByPoLine)
       .filter(entry -> entry.getValue()
                             .stream()
-                            .anyMatch(piece -> piece.getReceivingStatus() == ReceivingStatus.RECEIVED))
+                            // Check if there is at least one piece record which processed successfully
+                            .anyMatch(piece -> getError(entry.getKey(), piece.getId()) == null))
       .keys()
       .toList();
   }

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -2522,7 +2522,11 @@ public class OrdersImplTest {
       assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
       assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo("Received"));
     });
-    polUpdates.forEach(pol -> assertThat(pol.mapTo(PoLine.class).getReceiptStatus(), is(PoLine.ReceiptStatus.FULLY_RECEIVED)));
+    polUpdates.forEach(pol -> {
+      PoLine poLine = pol.mapTo(PoLine.class);
+      assertThat(poLine.getReceiptStatus(), is(PoLine.ReceiptStatus.FULLY_RECEIVED));
+      assertThat(poLine.getReceiptDate(), is(notNullValue()));
+    });
   }
 
   @Test
@@ -2560,7 +2564,11 @@ public class OrdersImplTest {
     assertThat(polSearches, hasSize(pieceIdsByPol.size()));
     assertThat(polUpdates, hasSize(pieceIdsByPol.size()));
 
-    polUpdates.forEach(pol -> assertThat(pol.mapTo(PoLine.class).getReceiptStatus(), is(PoLine.ReceiptStatus.PARTIALLY_RECEIVED)));
+    polUpdates.forEach(pol -> {
+      PoLine poLine = pol.mapTo(PoLine.class);
+      assertThat(poLine.getReceiptStatus(), is(PoLine.ReceiptStatus.PARTIALLY_RECEIVED));
+      assertThat(poLine.getReceiptDate(), is(nullValue()));
+    });
   }
 
   @Test
@@ -2596,6 +2604,17 @@ public class OrdersImplTest {
     assertThat(errorCodes, containsInAnyOrder(PIECE_ALREADY_RECEIVED.getCode(),
       PIECE_POL_MISMATCH.getCode(), PIECE_NOT_FOUND.getCode(), ITEM_UPDATE_FAILED.getCode(), ITEM_NOT_FOUND.getCode(),
       PIECE_UPDATE_FAILED.getCode()));
+
+    List<JsonObject> polSearches = MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET);
+    List<JsonObject> polUpdates = MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT);
+    assertThat(polSearches, hasSize(1));
+    assertThat(polUpdates, hasSize(1));
+
+    polUpdates.forEach(pol -> {
+      PoLine poLine = pol.mapTo(PoLine.class);
+      assertThat(poLine.getReceiptStatus(), is(PoLine.ReceiptStatus.PARTIALLY_RECEIVED));
+      assertThat(poLine.getReceiptDate(), is(nullValue()));
+    });
   }
 
   @Test
@@ -2674,6 +2693,102 @@ public class OrdersImplTest {
     assertThat(itemUpdates, is(nullValue()));
     assertThat(polSearches, is(nullValue()));
     assertThat(polUpdates, is(nullValue()));
+  }
+
+  @Test
+  public void testPostReceivingRevertMixedResources() {
+    logger.info("=== Test POST Receiving - Revert received P/E Mix resources");
+
+    ReceivingCollection receivingRq = getMockAsJson(RECEIVING_RQ_MOCK_DATA_PATH + "revert-pe-mix-4-of-5-resources.json").mapTo(ReceivingCollection.class);
+
+    ReceivingResults results = verifyPostResponse(ORDERS_RECEIVING_ENDPOINT, JsonObject.mapFrom(receivingRq).encode(),
+      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 200).as(ReceivingResults.class);
+
+    assertThat(results.getTotalRecords(), equalTo(receivingRq.getTotalRecords()));
+
+    Map<String, Set<String>> pieceIdsByPol = verifyReceivingSuccessRs(results);
+
+    List<JsonObject> pieceSearches = MockServer.serverRqRs.get(PIECES, HttpMethod.GET);
+    List<JsonObject> pieceUpdates = MockServer.serverRqRs.get(PIECES, HttpMethod.PUT);
+    List<JsonObject> itemsSearches = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.GET);
+    List<JsonObject> itemUpdates = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.PUT);
+    List<JsonObject> polSearches = MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET);
+    List<JsonObject> polUpdates = MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT);
+
+    assertThat(pieceSearches, not(nullValue()));
+    assertThat(pieceUpdates, not(nullValue()));
+    assertThat(itemsSearches, not(nullValue()));
+    assertThat(itemUpdates, not(nullValue()));
+    assertThat(polSearches, not(nullValue()));
+    assertThat(polUpdates, not(nullValue()));
+
+    // The piece searches should be made 3 times: 1st time to get all required piece records, 2nd and 3rd times to calculate expected PO Line status
+    assertThat(pieceSearches, hasSize(3));
+    // In total 4 pieces required update
+    assertThat(pieceUpdates, hasSize(4));
+    assertThat(itemsSearches, hasSize(1));
+    // There are 3 piece records with item id's
+    assertThat(itemUpdates, hasSize(3));
+    assertThat(polSearches, hasSize(pieceIdsByPol.size()));
+    assertThat(polUpdates, hasSize(pieceIdsByPol.size()));
+
+    itemUpdates.forEach(item -> {
+      assertThat(item.getString(ITEM_BARCODE), nullValue());
+      assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
+      assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo(ITEM_STATUS_ON_ORDER));
+    });
+    polUpdates.forEach(pol -> {
+      PoLine poLine = pol.mapTo(PoLine.class);
+      assertThat(poLine.getReceiptStatus(), is(PoLine.ReceiptStatus.PARTIALLY_RECEIVED));
+      assertThat(poLine.getReceiptDate(), is(nullValue()));
+    });
+  }
+
+  @Test
+  public void testPostReceivingRevertElectronicResource() {
+    logger.info("=== Test POST Receiving - Revert received electronic resource");
+
+    ReceivingCollection receivingRq = getMockAsJson(RECEIVING_RQ_MOCK_DATA_PATH + "revert-electronic-1-of-1-resource.json").mapTo(ReceivingCollection.class);
+
+    ReceivingResults results = verifyPostResponse(ORDERS_RECEIVING_ENDPOINT, JsonObject.mapFrom(receivingRq).encode(),
+      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 200).as(ReceivingResults.class);
+
+    assertThat(results.getTotalRecords(), equalTo(receivingRq.getTotalRecords()));
+
+    Map<String, Set<String>> pieceIdsByPol = verifyReceivingSuccessRs(results);
+
+    List<JsonObject> pieceSearches = MockServer.serverRqRs.get(PIECES, HttpMethod.GET);
+    List<JsonObject> pieceUpdates = MockServer.serverRqRs.get(PIECES, HttpMethod.PUT);
+    List<JsonObject> itemsSearches = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.GET);
+    List<JsonObject> itemUpdates = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.PUT);
+    List<JsonObject> polSearches = MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET);
+    List<JsonObject> polUpdates = MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT);
+
+    assertThat(pieceSearches, not(nullValue()));
+    assertThat(pieceUpdates, not(nullValue()));
+    assertThat(itemsSearches, not(nullValue()));
+    assertThat(itemUpdates, not(nullValue()));
+    assertThat(polSearches, not(nullValue()));
+    assertThat(polUpdates, not(nullValue()));
+
+    // The piece searches should be made 3 times: 1st time to get piece record, 2nd and 3rd times to calculate expected PO Line status
+    assertThat(pieceSearches, hasSize(3));
+    assertThat(pieceUpdates, hasSize(1));
+    assertThat(itemsSearches, hasSize(1));
+    assertThat(itemUpdates, hasSize(1));
+    assertThat(polSearches, hasSize(1));
+    assertThat(polUpdates, hasSize(1));
+
+    itemUpdates.forEach(item -> {
+      assertThat(item.getString(ITEM_BARCODE), nullValue());
+      assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
+      assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo(ITEM_STATUS_ON_ORDER));
+    });
+    polUpdates.forEach(pol -> {
+      PoLine poLine = pol.mapTo(PoLine.class);
+      assertThat(poLine.getReceiptStatus(), is(PoLine.ReceiptStatus.AWAITING_RECEIPT));
+      assertThat(poLine.getReceiptDate(), is(nullValue()));
+    });
   }
 
   private Map<String, Set<String>> verifyReceivingSuccessRs(ReceivingResults results) {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -2733,7 +2733,6 @@ public class OrdersImplTest {
     assertThat(polUpdates, hasSize(pieceIdsByPol.size()));
 
     itemUpdates.forEach(item -> {
-      assertThat(item.getString(ITEM_BARCODE), nullValue());
       assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
       assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo(ITEM_STATUS_ON_ORDER));
     });
@@ -2780,7 +2779,6 @@ public class OrdersImplTest {
     assertThat(polUpdates, hasSize(1));
 
     itemUpdates.forEach(item -> {
-      assertThat(item.getString(ITEM_BARCODE), nullValue());
       assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
       assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo(ITEM_STATUS_ON_ORDER));
     });

--- a/src/test/resources/mockdata/itemsRecords/inventoryItemsCollection.json
+++ b/src/test/resources/mockdata/itemsRecords/inventoryItemsCollection.json
@@ -1364,7 +1364,167 @@
         "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
         "name": "Main Library"
       }
+    },
+    {
+      "id": "fbd41843-569b-4a15-95da-6d543fe489ad",
+      "status": {
+        "name": "Received"
+      },
+      "title": "Kayak Fishing in the Northern Gulf Coast",
+      "hrid": "it00001200",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "6fef5d5e-54a9-4a82-b857-1279bc2c483c",
+      "barcode": "11111111334",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-03-05T07:52:48.563+0000",
+        "createdByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9",
+        "updatedDate": "2019-03-05T08:06:58.442+0000",
+        "updatedByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/fbd41843-569b-4a15-95da-6d543fe489ad"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "821559ef-4ee7-4b19-a835-a6787c2bafb9",
+      "status": {
+        "name": "Received"
+      },
+      "title": "Kayak Fishing in the Northern Gulf Coast",
+      "hrid": "it00001199",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "1c5e6f42-204b-433a-9748-1b5e1876508e",
+      "barcode": "11111111331",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-03-05T07:52:48.656+0000",
+        "createdByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9",
+        "updatedDate": "2019-03-05T08:06:58.435+0000",
+        "updatedByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/821559ef-4ee7-4b19-a835-a6787c2bafb9"
+      },
+      "effectiveLocation": {
+        "id": "b241764c-1466-4e1d-a028-1a3684a5da87",
+        "name": "Popular Reading Collection"
+      }
+    },
+    {
+      "id": "a940a524-ec08-42a4-8e63-2b7f8194371e",
+      "status": {
+        "name": "Received"
+      },
+      "title": "Kayak Fishing in the Northern Gulf Coast",
+      "hrid": "it00001201",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "6fef5d5e-54a9-4a82-b857-1279bc2c483c",
+      "barcode": "11111111333",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-03-05T07:52:48.573+0000",
+        "createdByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9",
+        "updatedDate": "2019-03-05T08:06:58.456+0000",
+        "updatedByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/a940a524-ec08-42a4-8e63-2b7f8194371e"
+      },
+      "effectiveLocation": {
+        "id": "f34d27c6-a8eb-461b-acd6-5dea81771e70",
+        "name": "SECOND FLOOR"
+      }
+    },
+    {
+      "id": "17b9bbc2-f2fa-4bbc-b82b-d40476b30872",
+      "status": {
+        "name": "Received"
+      },
+      "title": "Roitt's essential immunology / Peter J. Delves, Seamus J. Martin, Dennis R. Burton, Ivan M. Roitt.",
+      "hrid": "it00001206",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "73499948-6b8d-45bb-ad81-c25fda22ced2",
+      "barcode": "11111111335",
+      "copyNumbers": [],
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "f217a5c2-2c56-4d05-9412-a96cfc8e52de",
+      "materialType": {
+        "id": "615b8413-82d5-4203-aa6e-e37984cb5ac3",
+        "name": "electronic resource"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-03-05T07:52:48.657+0000",
+        "createdByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9",
+        "updatedDate": "2019-03-05T08:43:38.089+0000",
+        "updatedByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/17b9bbc2-f2fa-4bbc-b82b-d40476b30872"
+      },
+      "effectiveLocation": {
+        "id": "758258bc-ecc1-41b8-abca-f7b610822ffd",
+        "name": "ORWIG ETHNO CD"
+      }
     }
   ],
-  "totalRecords": 35
+  "totalRecords": 39
 }

--- a/src/test/resources/mockdata/lines/po_line_collection.json
+++ b/src/test/resources/mockdata/lines/po_line_collection.json
@@ -174,6 +174,41 @@
       }
     },
     {
+      "id": "cf447221-29b9-481e-947c-9ad545f22888",
+      "instance_id": "b252d8f4-e14f-4f27-9f11-876b1f8ed13a",
+      "acquisition_method": "Purchase At Vendor System",
+      "cancellation_restriction": false,
+      "collection": false,
+      "cost": "bb4e98be-e787-4193-a97a-9496341cf2c1",
+      "description": "10 physical resources",
+      "details": "92656b58-2528-46f4-b8ff-8fa976051a6d",
+      "fund_distribution": [],
+      "locations": [
+        "a24c922c-a224-4620-97e6-05b4468f8f27",
+        "f527db3a-fb25-40e8-a027-93775ca8b2eb"
+      ],
+      "order_format": "Physical Resource",
+      "payment_status": "Fully Paid",
+      "physical": "0ae68bf4-48e6-47d8-8846-297fae67f88e",
+      "po_line_description": "Harry Potter (Book 1)",
+      "po_line_number": "LINE-1",
+      "publication_date": "1998",
+      "publisher": "Scholastic",
+      "purchase_order_id": "555a155e-8bb7-4670-ace4-463fc70c2a75",
+      "receipt_status": "Awaiting Receipt",
+      "reporting_codes": [],
+      "requester": "Leo Bulero",
+      "rush": true,
+      "source": "2306a19c-b675-4c87-88a1-0a1079c65117",
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:43.854+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.418+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      }
+    },
+    {
       "id": "daa9cfd1-b330-4b65-8c2a-3663aaae5130",
       "acquisition_method": "Purchase At Vendor System",
       "alerts": [],
@@ -210,7 +245,110 @@
         "updatedDate": "2019-02-20T19:49:43.877+0000",
         "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
       }
+    },
+    {
+      "id": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "instance_id": "b82e1191-453d-4d41-91c5-b5c386018685",
+      "acquisition_method": "Purchase At Vendor System",
+      "cancellation_restriction": false,
+      "cancellation_restriction_note": "ABCDEFGHIJKLMNOPQRSTUVW",
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Ed Mashburn",
+          "contributor_type": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+        }
+      ],
+      "cost": "8ae8c511-a355-43c8-8293-44dda118c21e",
+      "description": "ABCDEFGH",
+      "details": "30f107af-c616-4193-b012-cbfce03da023",
+      "donor": "ABCDEFGHIJKLM",
+      "eresource": "d218ec74-45e8-47b9-a2d7-fc865630a240",
+      "fund_distribution": [
+        "b73f279d-babc-4afb-8bc1-71b7750e5416",
+        "b6985ad0-dcec-4cd8-b276-760f10998055"
+      ],
+      "locations": [
+        "b51ceba3-3da0-4db6-b1c7-9ff5b590ac89",
+        "7b0e2b10-a30b-4737-97b1-dfe52b0c0b14",
+        "3f2c235d-6f8f-455a-abd2-b24c78faf9b3"
+      ],
+      "order_format": "P/E Mix",
+      "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
+      "payment_status": "Awaiting Payment",
+      "physical": "586c3bb8-f9d6-4bb9-a287-d4501382aa6f",
+      "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
+      "po_line_number": "10080-1",
+      "publication_date": "2017",
+      "publisher": "Schiffer Publishing",
+      "purchase_order_id": "18f2185a-a40b-40da-acd2-067fd24cd1a5",
+      "receipt_date": "2019-03-05T08:06:58.721+0000",
+      "receipt_status": "Fully Received",
+      "reporting_codes": [
+        "9397990a-96f9-4c55-a958-f5f6941b9e68"
+      ],
+      "requester": "Leo Bulero",
+      "rush": true,
+      "selector": "ABCD",
+      "source": "0df216fd-679c-4b9e-a348-9143d0168319",
+      "title": "Kayak Fishing in the Northern Gulf Coast",
+      "vendor_detail": "7b8f0f74-96d4-4f21-b248-7e8ef70a7d9d",
+      "metadata": {
+        "createdDate": "2019-03-05T07:52:47.992+0000",
+        "createdByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9",
+        "updatedDate": "2019-03-05T08:06:58.757+0000",
+        "updatedByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9"
+      }
+    },
+    {
+      "id": "f217a5c2-2c56-4d05-9412-a96cfc8e52de",
+      "instance_id": "9085cdef-0758-4d8f-8c35-54795739472e",
+      "acquisition_method": "Purchase",
+      "adjustment": "75e9c1c7-32e5-4c27-accc-331d615d0f91",
+      "alerts": [],
+      "cancellation_restriction": false,
+      "cancellation_restriction_note": "",
+      "claims": [
+        "e96856eb-4b67-411c-9691-7856f84de7b0"
+      ],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Ed Mashburn",
+          "contributor_type": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+        }
+      ],
+      "cost": "0fd29d37-70eb-408a-bb28-53a514247f68",
+      "description": "",
+      "details": "58f12422-6535-4127-b1aa-e73d128b11a6",
+      "donor": "",
+      "eresource": "995d7df3-6e11-47ee-a5e6-2b1643c5eb0c",
+      "locations": [
+        "4d9b665b-87d4-4a58-88b6-e0315eb190c1",
+        "f29a0fef-7977-4f00-b8bb-49639e2de786"
+      ],
+      "order_format": "Electronic Resource",
+      "owner": "LTS E-Resources & Serials",
+      "payment_status": "Awaiting Payment",
+      "po_line_description": "",
+      "po_line_number": "10080-2",
+      "publication_date": "2017",
+      "publisher": "John Wiley & Sons, Inc.",
+      "purchase_order_id": "18f2185a-a40b-40da-acd2-067fd24cd1a5",
+      "receipt_date": "2019-03-05T08:43:38.235+0000",
+      "receipt_status": "Fully Received",
+      "rush": false,
+      "selector": "Woods",
+      "source": "c58cda63-df41-4f2f-95c0-c4b6b72beb94",
+      "title": "Roitt's essential immunology / Peter J. Delves, Seamus J. Martin, Dennis R. Burton, Ivan M. Roitt.",
+      "vendor_detail": "a81df210-27b4-48c7-9bf2-2ea0ca8a3983",
+      "metadata": {
+        "createdDate": "2019-03-05T07:52:48.026+0000",
+        "createdByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9",
+        "updatedDate": "2019-03-05T08:43:38.271+0000",
+        "updatedByUserId": "3b1b3a38-76a0-5b65-887f-278d728034d9"
+      }
     }
   ],
-  "total_records": 4
+  "total_records": 7
 }

--- a/src/test/resources/mockdata/pieces/pieceRecords-cf447221-29b9-481e-947c-9ad545f22888.json
+++ b/src/test/resources/mockdata/pieces/pieceRecords-cf447221-29b9-481e-947c-9ad545f22888.json
@@ -1,0 +1,12 @@
+{
+  "pieces": [
+    {
+      "id": "8c057872-9c75-4fb1-879d-de3b089b0388",
+      "itemId": "821559ef-4ee7-4b19-a835-a6787c2bafb9",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    }
+  ],
+  "total_records": 1
+}

--- a/src/test/resources/mockdata/pieces/pieceRecords-f217a5c2-2c56-4d05-9412-a96cfc8e52de.json
+++ b/src/test/resources/mockdata/pieces/pieceRecords-f217a5c2-2c56-4d05-9412-a96cfc8e52de.json
@@ -1,0 +1,12 @@
+{
+  "pieces": [
+    {
+      "id": "56fbfde4-6335-4dd7-9a03-d100821f1d18",
+      "itemId": "17b9bbc2-f2fa-4bbc-b82b-d40476b30872",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "f217a5c2-2c56-4d05-9412-a96cfc8e52de",
+      "receivingStatus": "Expected"
+    }
+  ],
+  "total_records": 1
+}

--- a/src/test/resources/mockdata/pieces/pieceRecords-fe47e95d-24e9-4a9a-9dc0-bcba64b51f56.json
+++ b/src/test/resources/mockdata/pieces/pieceRecords-fe47e95d-24e9-4a9a-9dc0-bcba64b51f56.json
@@ -1,0 +1,37 @@
+{
+  "pieces": [
+    {
+      "id": "38138008-edf5-4bf0-a349-0234c7bf6c49",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Received",
+      "receivedDate": "2019-03-05T08:06:58.473+0000"
+    },
+    {
+      "id": "7802b94d-68b4-41e5-91ff-0cee8cd8f029",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "4d19a3ff-986f-4150-95a2-2f2da797591c",
+      "itemId": "a940a524-ec08-42a4-8e63-2b7f8194371e",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "6a53eb3c-f9dd-46f5-bbf8-5768cf97ec6d",
+      "itemId": "fbd41843-569b-4a15-95da-6d543fe489ad",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "61437764-03e4-4c75-a743-d40f71ff9161",
+      "itemId": "821559ef-4ee7-4b19-a835-a6787c2bafb9",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Expected"
+    }
+  ],
+  "total_records": 5
+}

--- a/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
+++ b/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
@@ -260,7 +260,54 @@
       "itemId": "168f8a86-d26c-406e-813f-c7527f241ac3",
       "poLineId": "826eb2fd-7c0b-4d59-a55c-7d25195adc62",
       "receivingStatus": "Expected"
+    },
+    {
+      "id": "7802b94d-68b4-41e5-91ff-0cee8cd8f029",
+      "caption": "Vol. 1",
+      "comment": "Very important note",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Received",
+      "receivedDate": "2019-03-05T08:06:58.447+0000"
+    },
+    {
+      "id": "4d19a3ff-986f-4150-95a2-2f2da797591c",
+      "caption": "Vol. 1",
+      "comment": "Very important note",
+      "itemId": "a940a524-ec08-42a4-8e63-2b7f8194371e",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Received",
+      "receivedDate": "2019-03-05T08:06:58.498+0000"
+    },
+    {
+      "id": "6a53eb3c-f9dd-46f5-bbf8-5768cf97ec6d",
+      "caption": "Vol. 1",
+      "comment": "Very important note",
+      "itemId": "fbd41843-569b-4a15-95da-6d543fe489ad",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Received",
+      "receivedDate": "2019-03-05T08:06:58.496+0000"
+    },
+    {
+      "id": "61437764-03e4-4c75-a743-d40f71ff9161",
+      "caption": "Vol. 1",
+      "comment": "Very important note",
+      "itemId": "821559ef-4ee7-4b19-a835-a6787c2bafb9",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Received",
+      "receivedDate": "2019-03-05T08:06:58.473+0000"
+    },
+    {
+      "id": "56fbfde4-6335-4dd7-9a03-d100821f1d18",
+      "itemId": "17b9bbc2-f2fa-4bbc-b82b-d40476b30872",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "f217a5c2-2c56-4d05-9412-a96cfc8e52de",
+      "receivingStatus": "Received",
+      "receivedDate": "2019-03-05T08:43:38.122+0000"
     }
   ],
-  "total_records": 45
+  "total_records": 50
 }

--- a/src/test/resources/mockdata/receiving/revert-electronic-1-of-1-resource.json
+++ b/src/test/resources/mockdata/receiving/revert-electronic-1-of-1-resource.json
@@ -1,0 +1,15 @@
+{
+  "toBeReceived": [
+    {
+      "poLineId": "f217a5c2-2c56-4d05-9412-a96cfc8e52de",
+      "received": 1,
+      "receivedItems": [
+        {
+          "itemStatus": "On order",
+          "pieceId": "56fbfde4-6335-4dd7-9a03-d100821f1d18"
+        }
+      ]
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/mockdata/receiving/revert-pe-mix-4-of-5-resources.json
+++ b/src/test/resources/mockdata/receiving/revert-pe-mix-4-of-5-resources.json
@@ -1,0 +1,27 @@
+{
+  "toBeReceived": [
+    {
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "received": 4,
+      "receivedItems": [
+        {
+          "itemStatus": "On order",
+          "pieceId": "7802b94d-68b4-41e5-91ff-0cee8cd8f029"
+        },
+        {
+          "itemStatus": "On order",
+          "pieceId": "4d19a3ff-986f-4150-95a2-2f2da797591c"
+        },
+        {
+          "itemStatus": "On order",
+          "pieceId": "6a53eb3c-f9dd-46f5-bbf8-5768cf97ec6d"
+        },
+        {
+          "itemStatus": "On order",
+          "pieceId": "61437764-03e4-4c75-a743-d40f71ff9161"
+        }
+      ]
+    }
+  ],
+  "totalRecords": 4
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-175](https://issues.folio.org/browse/MODORDERS-175) Add ability to move a received piece back to "Expected"
## Approach
The logic extends functionality implemented in scope of PR #107:
* client sends request like following:
  ```json
  {
    "toBeReceived": [
      {
        "poLineId": "f217a5c2-2c56-4d05-9412-a96cfc8e52de",
        "received": 2,
        "receivedItems": [
          {
            "itemStatus": "On order",
            "pieceId": "56fbfde4-6335-4dd7-9a03-d100821f1d18"
          },
          {
            "itemStatus": "On order",
            "pieceId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
          }
        ]
      }
    ],
    "totalRecords": 2
  }
  ```
* retrieve piece records
* for those piece records which have an item id reference, retrieve items from inventory storage
  * ~~remove item's barcode~~ the item's barcode remains as is
  * update item's status to `On order`
  * update item record in inventory
* update each piece record removing received date and setting receiving status to `Expected`
* retrieve PO Line and calculate receipt status based on quantity of received and expected piece records. If the receipt status was `Fully Received` but the calculated one is either `Awaiting Receipt` or `Partially Received`, the receipt date is removed

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards - [sonarcloud PR#110](https://sonarcloud.io/project/issues?id=org.folio%3Amod-orders&pullRequest=110&resolved=false)?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] No
