### PR TITLE
MODORDERS-170 - Prevent ordering from Inactive vendors/access provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,16 @@
               <targetPackage>org.folio.rest.acq.model</targetPackage>
             </configuration>
           </execution>
+          <execution>
+            <id>mod-vendors</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${basedir}/ramls/acq-models/mod-vendors/schemas</sourceDirectory>
+              <targetPackage>org.folio.rest.acq.model</targetPackage>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
+++ b/src/main/java/org/folio/orders/rest/exceptions/HttpException.java
@@ -5,14 +5,13 @@ import org.folio.orders.utils.ErrorCodes;
 public class HttpException extends RuntimeException {
   private static final long serialVersionUID = 8109197948434861504L;
 
-  private static final String GENERIC_ERROR_CODE = "genericError";
   private final int code;
   private final String errorCode;
 
   public HttpException(int code, String message) {
     super(message);
     this.code = code;
-    this.errorCode = GENERIC_ERROR_CODE;
+    this.errorCode = ErrorCodes.GENERIC_ERROR_CODE.getDescription();
   }
 
   public HttpException(int code, ErrorCodes errCodes) {

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -4,6 +4,7 @@ import org.folio.rest.jaxrs.model.Error;
 
 public enum ErrorCodes {
 
+  GENERIC_ERROR_CODE("genericError", "Generic error"),
   PO_NUMBER_ALREADY_EXISTS("poNumberNotUnique", "PO Number already exists"),
   PO_NUMBER_REQUIRED("poNumberRequired", "PO Number is missing"),
   MISSING_ORDER_ID_IN_POL("orderIdRequired", "Purchase order id is missing in PoLine object"),
@@ -26,7 +27,11 @@ public enum ErrorCodes {
   NON_ZERO_COST_ELECTRONIC_QTY("nonZeroCostQtyElectronic", "Electronic cost quantity must not be specified"),
   PHYSICAL_LOC_QTY_EXCEEDS_COST("locQtyPhysicalExceedsCost", "Locations physical quantity exceeds cost physical quantity"),
   PHYSICAL_COST_QTY_EXCEEDS_LOC("costQtyPhysicalExceedsLoc", "Cost's physical quantity exceeds locations' physical quantity"),
-  ELECTRONIC_LOC_QTY_EXCEEDS_COST("locQtyElectronicExceedsCost", "Locations electronic quantity exceeds cost electronic quantity");
+  ELECTRONIC_LOC_QTY_EXCEEDS_COST("locQtyElectronicExceedsCost", "Locations electronic quantity exceeds cost electronic quantity"),
+  ORDER_VENDOR_IS_INACTIVE("vendorIsInactive", "Order cannot be open as the associated vendor is inactive"),
+  POL_ACCESS_PROVIDER_IS_INACTIVE("accessProviderIsInactive", "Order cannot be open as the associated access provider is inactive"),
+  ORDER_VENDOR_NOT_FOUND("vendorNotFound", "Order cannot be open as the associated vendor not found"),
+  POL_ACCESS_PROVIDER_NOT_FOUND("accessProviderNotFound", "Order cannot be open as the associated access provider not found");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -743,16 +743,4 @@ public class HelperUtils {
     }
     return future;
   }
-
-  /**
-   * Returns list of access providers ids
-   *
-   * @param compPO composite purchase order
-   * @return list of access providers id
-   */
-  public static List<String> getAccessProvidersList(CompositePurchaseOrder compPO) {
-    return compPO.getCompositePoLines().stream()
-      .filter(p -> (p.getEresource() != null && p.getEresource().getAccessProvider() != null))
-      .map(p -> p.getEresource().getAccessProvider()).collect(Collectors.toList());
-  }
 }

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -744,4 +744,15 @@ public class HelperUtils {
     return future;
   }
 
+  /**
+   * Returns list of access providers ids
+   *
+   * @param compPO composite purchase order
+   * @return list of access providers id
+   */
+  public static List<String> getAccessProvidersList(CompositePurchaseOrder compPO) {
+    return compPO.getCompositePoLines().stream()
+      .filter(p -> (p.getEresource() != null && p.getEresource().getAccessProvider() != null))
+      .map(p -> p.getEresource().getAccessProvider()).collect(Collectors.toList());
+  }
 }

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -44,14 +44,6 @@ public class OrdersImpl implements Orders {
   private static final String ORDERS_LOCATION_PREFIX = "/orders/composite-orders/%s";
   private static final String ORDER_LINE_LOCATION_PREFIX = "/orders/order-lines/%s";
 
-  private static int getPoLineLimit(JsonObject config) {
-    try {
-      return Integer.parseInt(config.getString(PO_LINES_LIMIT_PROPERTY, DEFAULT_POLINE_LIMIT));
-    } catch (NumberFormatException e) {
-      throw new NumberFormatException("Invalid limit value in configuration.");
-    }
-  }
-
   @Override
   @Validate
   public void deleteOrdersCompositeOrdersById(String id, String lang, Map<String, String> okapiHeaders,
@@ -337,6 +329,14 @@ public class OrdersImpl implements Orders {
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     // Return 501 (Not Implemented) for now
     asyncResultHandler.handle(succeededFuture(Response.status(501).build()));
+  }
+
+  private static int getPoLineLimit(JsonObject config) {
+    try {
+      return Integer.parseInt(config.getString(PO_LINES_LIMIT_PROPERTY, DEFAULT_POLINE_LIMIT));
+    } catch (NumberFormatException e) {
+      throw new NumberFormatException("Invalid limit value in configuration.");
+    }
   }
 
   private void validatePoLinesQuantity(CompositePurchaseOrder compPO, JsonObject config) {

--- a/src/main/java/org/folio/rest/impl/VendorHelper.java
+++ b/src/main/java/org/folio/rest/impl/VendorHelper.java
@@ -43,7 +43,6 @@ public class VendorHelper {
 
   private static final String ID = "id";
   private static final String VENDORS = "vendors";
-  private static final String VENDOR_STATUS = "vendor_status";
   private static final String VENDOR_STORAGE_VENDORS = "/vendor-storage/vendors/";
   private static final String VENDORS_WITH_QUERY_ENDPOINT = "/vendor-storage/vendors?limit=%d&lang=%s&query=%s";
 

--- a/src/main/java/org/folio/rest/impl/VendorHelper.java
+++ b/src/main/java/org/folio/rest/impl/VendorHelper.java
@@ -1,0 +1,178 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.Context;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.folio.HttpStatus;
+import org.folio.orders.rest.exceptions.HttpException;
+import org.folio.orders.utils.ErrorCodes;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.stream.Collectors.toList;
+import static org.folio.orders.utils.ErrorCodes.GENERIC_ERROR_CODE;
+import static org.folio.orders.utils.ErrorCodes.ORDER_VENDOR_IS_INACTIVE;
+import static org.folio.orders.utils.ErrorCodes.ORDER_VENDOR_NOT_FOUND;
+import static org.folio.orders.utils.ErrorCodes.POL_ACCESS_PROVIDER_IS_INACTIVE;
+import static org.folio.orders.utils.ErrorCodes.POL_ACCESS_PROVIDER_NOT_FOUND;
+import static org.folio.orders.utils.HelperUtils.convertIdsToCqlQuery;
+import static org.folio.orders.utils.HelperUtils.encodeQuery;
+import static org.folio.orders.utils.HelperUtils.getAccessProvidersList;
+import static org.folio.orders.utils.HelperUtils.handleGetRequest;
+
+
+public class VendorHelper {
+
+  private static final Logger logger = LoggerFactory.getLogger(VendorHelper.class);
+
+  private final HttpClientInterface httpClient;
+  private final Map<String, String> okapiHeaders;
+  private final Context ctx;
+  private final String lang;
+
+  private static final String ID = "id";
+  private static final String VENDORS = "vendors";
+  private static final String VENDOR_STATUS = "vendor_status";
+  private static final String VENDOR_STORAGE_VENDORS = "/vendor-storage/vendors/";
+  private static final String VENDORS_WITH_QUERY_ENDPOINT = "/vendor-storage/vendors?limit=%d&lang=%s&query=%s";
+
+  public VendorHelper(String lang, HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx) {
+    this.lang = lang;
+    this.httpClient = httpClient;
+    this.okapiHeaders = okapiHeaders;
+    this.ctx = ctx;
+  }
+
+  /**
+   * Checks if vendor in {@link CompositePurchaseOrder} exists and has status Active.
+   * If any false, adds corresponding error to {@link Errors} object.
+   *
+   * @param compPO composite purchase order
+   * @return CompletableFuture with {@link Errors} object
+   */
+  public CompletableFuture<Errors> validateVendor(CompositePurchaseOrder compPO) {
+    String id = compPO.getVendor();
+    CompletableFuture<Errors> future = new VertxCompletableFuture<>(ctx);
+    List<Error> errors = new ArrayList<>();
+    getVendorJsonById(id)
+      .thenApply(vendorJson -> {
+        VendorStatus status = VendorStatus.valueOf(vendorJson.getString(VENDOR_STATUS).toUpperCase());
+
+        if(status != VendorStatus.ACTIVE) {
+          errors.add(createErrorWithId(ORDER_VENDOR_IS_INACTIVE, id));
+        }
+        return buildErrorsObject(errors);
+      })
+      .thenAccept(future::complete)
+      .exceptionally(t -> {
+        if(HttpStatus.HTTP_NOT_FOUND.toInt() == (((HttpException) t.getCause()).getCode())) {
+          errors.add(createErrorWithId(ORDER_VENDOR_NOT_FOUND, id));
+        } else {
+          logger.error("Failed to validate vendor's status", t);
+          errors.add(GENERIC_ERROR_CODE.toError());
+        }
+        future.complete(buildErrorsObject(errors));
+        return null;
+      });
+    return future;
+  }
+
+  /**
+   * Checks if access providers in exist and have status Active. If any false, adds corresponding error to {@link Errors} object.
+   * @param compPO composite purchase order
+   * @return CompletableFuture with {@link Errors} object
+   */
+  public CompletableFuture<Errors> validateAccessProviders(CompositePurchaseOrder compPO) {
+    CompletableFuture<Errors> future = new VertxCompletableFuture<>(ctx);
+    List<String> ids = getAccessProvidersList(compPO);
+    List<Error> errors = new ArrayList<>();
+    getAccessProvidersByIds(ids).thenApply(vendors -> {
+      // Validate access provider status Active
+      vendors.forEach(vendorJson -> {
+        if(VendorStatus.valueOf(vendorJson.getString(VENDOR_STATUS).toUpperCase()) != VendorStatus.ACTIVE) {
+          errors.add(createErrorWithId(POL_ACCESS_PROVIDER_IS_INACTIVE, vendorJson.getString(ID)));
+        }
+      });
+
+      // Validate access provider existence
+      List<String> vendorsIds = vendors.stream()
+        .map(jsonObject -> jsonObject.getString(ID))
+        .collect(toList());
+
+      ids.stream()
+        .filter(id -> !vendorsIds.contains(id))
+        .forEach(id -> errors.add(POL_ACCESS_PROVIDER_NOT_FOUND.toError().withAdditionalProperty(ID, id)));
+
+      return buildErrorsObject(errors);
+    }).thenAccept(future::complete)
+      .exceptionally(t -> {
+        logger.error("Failed to validate access provider's status", t);
+        future.completeExceptionally(t);
+        return null;
+      });
+    return future;
+  }
+
+  /**
+   * Builds {@link Errors} object based on list of {@link Error}
+   *
+   * @param errors list of {@link Error}
+   * @return {@link Errors} object with list of {@link Error}
+   */
+  private Errors buildErrorsObject(List<Error> errors) {
+    return new Errors()
+      .withErrors(errors)
+      .withTotalRecords(errors.size());
+  }
+
+  /**
+   * Creates {@link Error} with id of corresponding vendor/access provider
+   *
+   * @param id vendor's/access provider's identifier
+   * @param errorCodes error code
+   * @return {@link Error} with id of failed vendor/access provider
+   */
+  private Error createErrorWithId(ErrorCodes errorCodes, String id) {
+    return errorCodes.toError()
+      .withAdditionalProperty(ID, id);
+  }
+
+  /**
+   * Retrieves vendor as json file
+   *
+   * @param vendorId vendor's id
+   * @return CompletableFuture with {@link JsonObject} representation of vendor
+   */
+  private CompletableFuture<JsonObject> getVendorJsonById(String vendorId) {
+    return handleGetRequest(VENDOR_STORAGE_VENDORS + vendorId, httpClient, ctx, okapiHeaders, logger);
+  }
+
+  /**
+   * Retrieves list of access providers
+   *
+   * @param accessProviderIds - list of access providers id
+   * @return CompletableFuture with {@link List<JsonObject>} representation of vendor
+   */
+  private CompletableFuture<List<JsonObject>> getAccessProvidersByIds(List<String> accessProviderIds) {
+    CompletableFuture<List<JsonObject>> future = new CompletableFuture<>();
+    String query = convertIdsToCqlQuery(accessProviderIds);
+    String endpoint = String.format(VENDORS_WITH_QUERY_ENDPOINT, accessProviderIds.size(), lang, encodeQuery(query, logger));
+    handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+      .thenApply(vendors -> vendors.getJsonArray(VENDORS).stream().map(obj -> (JsonObject) obj).collect(toList())).thenAccept(future::complete);
+    return future;
+  }
+
+  public enum VendorStatus {
+    INACTIVE, ACTIVE, PENDING,
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -6,6 +6,7 @@ import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
 import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
 import static org.folio.orders.utils.HelperUtils.calculateTotalQuantity;
+import static org.folio.orders.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.orders.utils.HelperUtils.groupLocationsById;
 import static org.folio.orders.utils.ResourcePathResolver.*;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
@@ -15,6 +16,7 @@ import static org.folio.rest.impl.InventoryHelper.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
@@ -43,6 +45,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -64,7 +67,9 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.HttpStatus;
 import org.folio.orders.rest.exceptions.HttpException;
+import org.folio.orders.utils.ErrorCodes;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.acq.model.Piece;
@@ -118,6 +123,18 @@ public class OrdersImplTest {
   private static final String ORDER_WITH_MISMATCH_ID_INT_PO_LINES_JSON = "put_order_with_mismatch_id_in_po_lines.json";
   private static final String PO_NUMBER_VALUE = "228D126";
   private static final String PO_LINE_NUMBER_VALUE = "1";
+
+  private static final String ACTIVE_VENDOR_ID = "2acdf60c-835f-41c1-963b-f87c4ee3fa08";
+  private static final String INACTIVE_VENDOR_ID = "b1ef7e96-98f3-4f0d-9820-98c322c989d2";
+  private static final String PENDING_VENDOR_ID = "160501b3-52dd-41ec-a0ce-17762e7a9b47";
+  private static final String NON_EXIST_VENDOR_ID = "bba87500-6e71-4057-a2a9-a091bac7e0c1";
+
+  private static final String ACTIVE_ACCESS_PROVIDER_A = "858e80d2-f562-4c54-9934-6e274dee511d";
+  private static final String ACTIVE_ACCESS_PROVIDER_B = "d1b79c8d-4950-482f-8e42-04f9aae3cb40";
+  private static final String INACTIVE_ACCESS_PROVIDER_A = "f6cd1850-2587-4f6c-b680-9b27ff26d619";
+  private static final String INACTIVE_ACCESS_PROVIDER_B = "f64bbcae-e5ea-42b6-8236-55fefed0fb8f";
+  private static final String NON_EXIST_ACCESS_PROVIDER_A = "160501b3-52dd-31ec-a0ce-17762e6a9b47";
+  public static final String EMPTY_STR = "";
 
   static {
     System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME, "io.vertx.core.logging.Log4j2LogDelegateFactory");
@@ -190,6 +207,7 @@ public class OrdersImplTest {
   private static final String LOAN_TYPES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "loanTypes/";
   private static final String COMP_ORDER_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeOrders/";
   private static final String PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "lines/";
+  private static final String VENDORS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "vendors/";
   private static final String ORDERS_MOCK_DATA_PATH = COMP_ORDER_MOCK_DATA_PATH + "getOrders.json";
   private static final String ORDER_FOR_FAILURE_CASE_MOCK_DATA_PATH = COMP_ORDER_MOCK_DATA_PATH + PO_ID_FOR_FAILURE_CASE + ".json";
   private static final String COMP_PO_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeLines/";
@@ -2696,6 +2714,111 @@ public class OrdersImplTest {
     return pieceIdsByPol;
   }
 
+  @Test
+  public void testCreatePoWithDifferentVendorStatus() throws Exception {
+
+    logger.info("=== Test POST PO with vendor's status ===");
+
+    // Purchase order is OK
+    Errors activeVendorActiveAccessProviderErrors = verifyPostResponse(COMPOSITE_ORDERS_PATH, getPoWithVendorId(ACTIVE_VENDOR_ID, ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_B),
+      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 201).as(Errors.class);
+    assertThat(activeVendorActiveAccessProviderErrors.getErrors(), empty());
+
+    // Non-existed vendor
+    Errors nonExistedVendorError = verifyPostResponseErrors(1, NON_EXIST_VENDOR_ID, ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_B);
+    checkExpectedError(NON_EXIST_VENDOR_ID, nonExistedVendorError, 0, ORDER_VENDOR_NOT_FOUND);
+
+    // Active vendor and non-existed access provider
+    Errors inactiveAccessProviderErrors = verifyPostResponseErrors(1, ACTIVE_VENDOR_ID, ACTIVE_ACCESS_PROVIDER_A, NON_EXIST_ACCESS_PROVIDER_A);
+    checkExpectedError(NON_EXIST_ACCESS_PROVIDER_A, inactiveAccessProviderErrors, 0, POL_ACCESS_PROVIDER_NOT_FOUND);
+
+    // Inactive access provider
+    Errors nonExistedAccessProviderErrors = verifyPostResponseErrors(1, ACTIVE_VENDOR_ID, ACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_A);
+    checkExpectedError(INACTIVE_ACCESS_PROVIDER_A, nonExistedAccessProviderErrors, 0, POL_ACCESS_PROVIDER_IS_INACTIVE);
+
+    // Inactive vendor and inactive access providers
+    Errors allInactiveErrors = verifyPostResponseErrors(3, INACTIVE_VENDOR_ID, INACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_B);
+    checkExpectedError(INACTIVE_VENDOR_ID, allInactiveErrors, 0, ORDER_VENDOR_IS_INACTIVE);
+    checkExpectedError(INACTIVE_ACCESS_PROVIDER_A, allInactiveErrors, 1, POL_ACCESS_PROVIDER_IS_INACTIVE);
+    checkExpectedError(INACTIVE_ACCESS_PROVIDER_B, allInactiveErrors, 2, POL_ACCESS_PROVIDER_IS_INACTIVE);
+
+  }
+
+  @Test
+  public void testPutOrdersByIdToChangeStatusToOpenInactiveVendor() throws Exception {
+
+    logger.info("=== Test Put Order By Id to change status of Order to Open for different vendor's status ===");
+
+    CompositePurchaseOrder reqData = getMockDraftOrder().mapTo(CompositePurchaseOrder.class);
+    reqData.setId(ID_FOR_PRINT_MONOGRAPH_ORDER);
+
+    // Positive cases
+    reqData.setVendor(ACTIVE_VENDOR_ID);
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.PENDING);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY_STR, 204);
+
+    reqData.setVendor(INACTIVE_VENDOR_ID);
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.PENDING);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY_STR, 204);
+
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    reqData.setVendor(ACTIVE_VENDOR_ID);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY_STR, 204);
+
+    // Negative cases
+    // Non-existed vendor
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    reqData.setVendor(NON_EXIST_VENDOR_ID);
+    reqData.getCompositePoLines().get(0).getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_A);
+    reqData.getCompositePoLines().get(1).getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_A);
+    Errors nonExistedVendorErrors
+      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY_STR, 422).as(Errors.class);
+    checkExpectedError(NON_EXIST_VENDOR_ID, nonExistedVendorErrors, 0, ORDER_VENDOR_NOT_FOUND);
+
+    // Inactive access provider
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    reqData.setVendor(ACTIVE_VENDOR_ID);
+    reqData.getCompositePoLines().get(0).getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_A);
+    reqData.getCompositePoLines().get(1).getEresource().setAccessProvider(INACTIVE_ACCESS_PROVIDER_A);
+    Errors inactiveAccessProviderErrors
+      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY_STR, 422).as(Errors.class);
+    checkExpectedError(INACTIVE_ACCESS_PROVIDER_A, inactiveAccessProviderErrors, 0, POL_ACCESS_PROVIDER_IS_INACTIVE);
+
+    // Inactive vendor and inactive access providers
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    reqData.setVendor(INACTIVE_VENDOR_ID);
+    reqData.getCompositePoLines().get(0).getEresource().setAccessProvider(INACTIVE_ACCESS_PROVIDER_A);
+    reqData.getCompositePoLines().get(1).getEresource().setAccessProvider(INACTIVE_ACCESS_PROVIDER_B);
+    Errors allInactiveErrors
+      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY_STR, 422).as(Errors.class);
+    checkExpectedError(INACTIVE_VENDOR_ID, allInactiveErrors, 0, ORDER_VENDOR_IS_INACTIVE);
+    checkExpectedError(INACTIVE_ACCESS_PROVIDER_A, allInactiveErrors, 1, POL_ACCESS_PROVIDER_IS_INACTIVE);
+    checkExpectedError(INACTIVE_ACCESS_PROVIDER_B, allInactiveErrors, 2, POL_ACCESS_PROVIDER_IS_INACTIVE);
+  }
+
+  private Errors verifyPostResponseErrors(int expectedErrorsNumber, String vendorId, String... accessProviderIds) throws Exception {
+    Errors errors = verifyPostResponse(COMPOSITE_ORDERS_PATH, getPoWithVendorId(vendorId, accessProviderIds),
+      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 422).as(Errors.class);
+    assertEquals(errors.getTotalRecords(), new Integer(expectedErrorsNumber));
+    assertThat(errors.getErrors(), hasSize(expectedErrorsNumber));
+    return errors;
+  }
+
+  private String getPoWithVendorId(String vendorId, String... accessProviderIds) throws Exception {
+    CompositePurchaseOrder comPo = getMockDraftOrder().mapTo(CompositePurchaseOrder.class);
+    comPo.setVendor(vendorId);
+    for(int i = 0; i < accessProviderIds.length; i++) {
+      comPo.getCompositePoLines().get(i).getEresource().setAccessProvider(accessProviderIds[i]);
+    }
+    return JsonObject.mapFrom(comPo).toString();
+  }
+
+  private void checkExpectedError(String id, Errors errors, int index, ErrorCodes expectedErrorCodes) {
+    assertEquals(id, errors.getErrors().get(index).getAdditionalProperties().get(ID));
+    assertEquals(expectedErrorCodes.getCode(), errors.getErrors().get(index).getCode());
+    assertEquals(expectedErrorCodes.getDescription(), errors.getErrors().get(index).getMessage());
+  }
+
   private org.folio.rest.acq.model.PoLine getMockLine(String id) {
     return getMockAsJson(PO_LINES_MOCK_DATA_PATH, id).mapTo(org.folio.rest.acq.model.PoLine.class);
   }
@@ -2809,6 +2932,8 @@ public class OrdersImplTest {
       router.route(HttpMethod.GET, "/inventory/items").handler(this::handleGetInventoryItemRecords);
       router.route(HttpMethod.GET, "/holdings-storage/holdings").handler(this::handleGetHoldingRecord);
       router.route(HttpMethod.GET, "/loan-types").handler(this::handleGetLoanType);
+      router.route(HttpMethod.GET, "/vendor-storage/vendors/:id").handler(this::handleGetVendorById);
+      router.route(HttpMethod.GET, "/vendor-storage/vendors").handler(this::handleGetAccessProviders);
       router.route(HttpMethod.GET, resourcesPath(PO_LINES)).handler(this::handleGetPoLines);
       router.route(HttpMethod.GET, resourcePath(PO_LINES)).handler(this::handleGetPoLineById);
       router.route(HttpMethod.GET, resourcePath(ADJUSTMENT)).handler(this::handleGetAdjustment);
@@ -3017,6 +3142,67 @@ public class OrdersImplTest {
            .setStatusCode(404)
            .end();
       }
+    }
+
+    private void handleGetAccessProviders(RoutingContext ctx) {
+      logger.info("handleGetAccessProviders got: " + ctx.request().path());
+      String query = ctx.request().getParam("query");
+      JsonObject body;
+      try {
+        if(getQuery(ACTIVE_ACCESS_PROVIDER_A, NON_EXIST_ACCESS_PROVIDER_A).equals(query)) {
+          body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "one_access_provider_not_found.json"));
+        }  else if(getQuery(ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_B).equals(query)) {
+          body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "all_access_providers_active.json"));
+        } else if(getQuery(ACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_A).equals(query)) {
+          body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "active_inactive_access_providers.json"));
+        } else if(getQuery(INACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_B).equals(query)) {
+          body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "all_inactive_access_providers.json"));
+        } else {
+          // To ensure compatibility with already existing tests
+          body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "all_access_providers_active.json"));
+        }
+        serverResponse(ctx, HttpStatus.HTTP_OK.toInt(), APPLICATION_JSON, body.encodePrettily());
+
+      } catch(IOException e) {
+        ctx.response()
+          .setStatusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())
+          .end();
+      }
+    }
+
+    private void handleGetVendorById(RoutingContext ctx) {
+      logger.info("handleGetVendorById got: " + ctx.request().path());
+      String vendorId = ctx.request().getParam(ID);
+      JsonObject body;
+      try {
+        if(NON_EXIST_VENDOR_ID.equals(vendorId)) {
+          serverResponse(ctx, HttpStatus.HTTP_NOT_FOUND.toInt(), APPLICATION_JSON, "vendor not found");
+        } else {
+          switch (vendorId) {
+            case ACTIVE_VENDOR_ID:
+              body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "active_vendor.json"));
+              break;
+            case INACTIVE_VENDOR_ID:
+              body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "inactive_vendor.json"));
+              break;
+            case PENDING_VENDOR_ID:
+              body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "pending_vendor.json"));
+              break;
+            default :
+              // To ensure compatibility with existing tests - return active existing vendor.
+              body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "active_vendor.json"));
+          }
+          serverResponse(ctx, HttpStatus.HTTP_OK.toInt(), APPLICATION_JSON, body.encodePrettily());
+        }
+      } catch (IOException e) {
+        ctx.response()
+          .setStatusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())
+          .end();
+      }
+    }
+
+    private String getQuery(String... accessProviders) {
+      return convertIdsToCqlQuery(Arrays.asList(accessProviders));
     }
 
     private void handleGetIdentifierType(RoutingContext ctx) {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -3158,11 +3158,13 @@ public class OrdersImplTest {
         if(getQuery(ACTIVE_ACCESS_PROVIDER_A, NON_EXIST_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "one_access_provider_not_found.json"));
         }  else if(getQuery(ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_B).equals(query)
-          || getQuery(ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_A).equals(query)) {
+          || getQuery(ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_A).equals(query)
+          || getQuery(ACTIVE_ACCESS_PROVIDER_B, ACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "all_access_providers_active.json"));
         } else if(getQuery(ACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "active_inactive_access_providers.json"));
-        } else if(getQuery(INACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_B).equals(query)) {
+        } else if(getQuery(INACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_B).equals(query)
+        || getQuery(INACTIVE_ACCESS_PROVIDER_B, INACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "all_inactive_access_providers.json"));
         } else if(getQuery(ACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "one_access_provider_not_found.json"));

--- a/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
+++ b/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
@@ -81,7 +81,6 @@
         "trial": false,
         "expected_activation": "2014-07-06T00:00:00.000Z",
         "user_limit": 1,
-        "access_provider": "7e1841d9-c0a4-4ae0-8521-b7e08fdcbc8a",
         "po_line_id": "c2755a78-2f8d-47d0-a218-059a9b7391b4",
         "license": "b0ef584b-a960-4c4e-83b1-2ca048cb4ebb"
       },

--- a/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
+++ b/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
@@ -8,7 +8,7 @@
   "re_encumber": false,
   "total_estimated_price": 127.94,
   "total_items": 3,
-  "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "workflow_status": "Pending",
   "compositePoLines": [
     {
@@ -81,6 +81,7 @@
         "trial": false,
         "expected_activation": "2014-07-06T00:00:00.000Z",
         "user_limit": 1,
+        "access_provider": "858e80d2-f562-4c54-9934-6e274dee511d",
         "po_line_id": "c2755a78-2f8d-47d0-a218-059a9b7391b4",
         "license": "b0ef584b-a960-4c4e-83b1-2ca048cb4ebb"
       },

--- a/src/test/resources/mockdata/vendors/active_inactive_access_providers.json
+++ b/src/test/resources/mockdata/vendors/active_inactive_access_providers.json
@@ -1,0 +1,347 @@
+{
+  "vendors": [
+    {
+      "id": "858e80d2-f562-4c54-9934-6e274dee511d",
+      "name": "Alexander Street Press",
+      "code": "ALEXS",
+      "description": "AV streaming services",
+      "vendor_status": "Active",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "Alexander Street",
+          "description": ""
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "3212 Duke Street",
+          "addressLine2": "",
+          "city": "Alexandria",
+          "stateRegion": "VA",
+          "zipCode": "22314",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "1-800-889-5937",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "customerservice@alexanderstreet.com",
+          "description": "main customer service email",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "https://alexanderstreet.com/",
+          "description": "main website",
+          "language": "en-us",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Mr.",
+          "first_name": "David",
+          "last_name": "Grohl",
+          "language": "English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "1-800-889-5937",
+              "categories": [],
+              "types": [],
+              "isPrimary": true,
+              "language": "English"
+            }
+          ],
+          "emails": [
+            {
+              "value": "customerservice@alexanderstreet.com",
+              "description": "main customer service email",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "3212 Duke Street",
+              "addressLine2": "",
+              "city": "Alexandria",
+              "stateRegion": "VA",
+              "zipCode": "22314",
+              "country": "USA",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "urls": [
+            {
+              "value": "https://alexanderstreet.com/",
+              "description": "main website",
+              "language": "en-us",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [
+        {
+          "name": "library access",
+          "discount": 0,
+          "reference_url": "",
+          "notes": ""
+        }
+      ],
+      "erp_code": "G64758-74828",
+      "payment_method": "check",
+      "access_provider": true,
+      "governmental": false,
+      "licensor": true,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 0,
+      "discount_percent": 0,
+      "expected_activation_interval": 1,
+      "expected_invoice_interval": 30,
+      "renewal_activation_interval": 365,
+      "subscription_interval": 365,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "interfaces": [
+        {
+          "name": "Academic Video Online",
+          "uri": "https://search.alexanderstreet.com/avon",
+          "username": "****",
+          "password": "****",
+          "notes": "",
+          "available": false,
+          "delivery_method": "",
+          "statistics_format": "",
+          "locally_stored": "",
+          "online_location": "",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "Library account",
+          "account_no": "1234",
+          "description": "Main library account",
+          "app_system_no": "",
+          "payment_method": "check",
+          "account_status": "Active",
+          "contact_info": "customerservice@alexanderstreet.com",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": ""
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "1234567",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    },
+    {
+      "id": "f6cd1850-2587-4f6c-b680-9b27ff26d619",
+      "name": "United States Geological Survey",
+      "code": "USGS",
+      "description": "Maps and materials from the USGS",
+      "vendor_status": "Inactive",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "USGS",
+          "description": ""
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "12201 Sunrise Valley Drive",
+          "addressLine2": "P.O. Box 15550",
+          "city": "Reston",
+          "stateRegion": "VA",
+          "zipCode": "20192",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "1-888-ASK-USGS",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "usgsstore@usgs.gov",
+          "description": "main customer service email",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "https://www.usgs.gov/",
+          "description": "main website",
+          "language": "en-us",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Mr.",
+          "first_name": "Ryan",
+          "last_name": "Zinke",
+          "language": "English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "1-888-ASK-USGS",
+              "categories": [],
+              "types": [],
+              "isPrimary": true,
+              "language": "English"
+            }
+          ],
+          "emails": [
+            {
+              "value": "usgsstore@usgs.gov",
+              "description": "main customer service email",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "12201 Sunrise Valley Drive",
+              "addressLine2": "P.O. Box 15550",
+              "city": "Reston",
+              "stateRegion": "VA",
+              "zipCode": "20192",
+              "country": "USA",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "urls": [
+            {
+              "value": "https://www.usgs.gov/",
+              "description": "main website",
+              "language": "en-us",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [
+        {
+          "name": "",
+          "discount": 0,
+          "reference_url": "",
+          "notes": ""
+        }
+      ],
+      "erp_code": "G64758-74833",
+      "payment_method": "credit card",
+      "access_provider": false,
+      "governmental": true,
+      "licensor": false,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 45,
+      "discount_percent": 0,
+      "expected_activation_interval": 0,
+      "expected_invoice_interval": 0,
+      "renewal_activation_interval": 0,
+      "subscription_interval": 0,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "interfaces": [
+        {
+          "name": "USGS Store",
+          "uri": "https://store.usgs.gov/",
+          "username": "****",
+          "password": "****",
+          "notes": "",
+          "available": false,
+          "delivery_method": "",
+          "statistics_format": "",
+          "locally_stored": "false",
+          "online_location": "",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "Cartographic account",
+          "account_no": "1234",
+          "description": "Monographic ordering unit accountt",
+          "app_system_no": "",
+          "payment_method": "credit card",
+          "account_status": "Active",
+          "contact_info": "usgsstore@usgs.gov",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": ""
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    }
+  ],
+  "total_records": 2,
+  "first": 1,
+  "last": 2
+}

--- a/src/test/resources/mockdata/vendors/active_vendor.json
+++ b/src/test/resources/mockdata/vendors/active_vendor.json
@@ -1,5 +1,5 @@
 {
-  "id": "2acdf60c-835f-41c1-963b-f87c4ee3fa08",
+  "id": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "name": "GOBI Library Solutions",
   "code": "GOBI",
   "description": "Use for print and eBooks, approval plans, firm orders, standing orders, DDA",

--- a/src/test/resources/mockdata/vendors/active_vendor.json
+++ b/src/test/resources/mockdata/vendors/active_vendor.json
@@ -1,0 +1,211 @@
+{
+  "id": "2acdf60c-835f-41c1-963b-f87c4ee3fa08",
+  "name": "GOBI Library Solutions",
+  "code": "GOBI",
+  "description": "Use for print and eBooks, approval plans, firm orders, standing orders, DDA",
+  "vendor_status": "Active",
+  "language": "en-us",
+  "aliases": [{
+    "value": "YBP Library Services",
+    "description": "former name"
+  }
+  ],
+  "addresses": [{
+    "addressLine1": "999 Maple Street",
+    "addressLine2": "2",
+    "city": "Contoocook",
+    "stateRegion": "NH",
+    "zipCode": "03229",
+    "country": "USA",
+    "isPrimary": true,
+    "categories": [
+      "Customer",
+      "Service",
+      "Shipments"
+    ],
+    "language": "en"
+  }
+  ],
+  "phone_numbers": [{
+    "phone_number": "1-800-258-3774",
+    "categories": [
+      "Customer Service"
+    ],
+    "types": [],
+    "isPrimary": true,
+    "language": "en-us"
+  }
+  ],
+  "emails": [{
+    "value": "gobiserviceissue@ebsco.com",
+    "description": "for general questions",
+    "isPrimary": true,
+    "categories": [
+      "Customer Service"
+    ],
+    "language": "en-us"
+  }
+  ],
+  "urls": [{
+    "value": "https://gobi.ebsco.com/",
+    "description": "main website",
+    "language": "en-us",
+    "isPrimary": true,
+    "categories": [],
+    "notes": ""
+  }
+  ],
+  "contacts": [{
+    "prefix": "",
+    "first_name": "Sarah",
+    "last_name": "Silverman",
+    "language": "en-us",
+    "notes": "",
+    "phone_numbers": [{
+      "phone_number": "1-800-258-3774",
+      "categories": [
+        "Customer Service"
+      ],
+      "types": [],
+      "isPrimary": true,
+      "language": "en-us"
+    }
+    ],
+    "emails": [{
+      "value": "gobiserviceissue@ebsco.com",
+      "description": "for general questions",
+      "isPrimary": true,
+      "categories": [
+        "Customer Service"
+      ],
+      "language": "en-us"
+    }
+    ],
+    "addresses": [{
+      "addressLine1": "999 Maple Street",
+      "addressLine2": "2",
+      "city": "Contoocook",
+      "stateRegion": "NH",
+      "zipCode": "03229",
+      "country": "USA",
+      "isPrimary": true,
+      "categories": [
+        "Customer",
+        "Service",
+        "Shipments"
+      ],
+      "language": "en"
+    }
+    ],
+    "urls": [{
+      "value": "https://gobi.ebsco.com/",
+      "description": "main website",
+      "language": "en-us",
+      "isPrimary": true,
+      "categories": [],
+      "notes": ""
+    }
+    ],
+    "categories": []
+  }
+  ],
+  "agreements": [{
+    "name": "No formal agreement",
+    "discount": 10,
+    "reference_url": "",
+    "notes": "Review SLAs & fulfillment stats 2 months before end of FY"
+  }
+  ],
+  "erp_code": "G64758-74836",
+  "payment_method": "EFT",
+  "access_provider": false,
+  "governmental": false,
+  "licensor": false,
+  "material_supplier": true,
+  "vendor_currencies": [
+    "USD"
+  ],
+  "claiming_interval": 45,
+  "discount_percent": 10,
+  "expected_activation_interval": 3,
+  "expected_invoice_interval": 30,
+  "renewal_activation_interval": 0,
+  "subscription_interval": 0,
+  "expected_receipt_interval": 30,
+  "tax_id": "888888888",
+  "liable_for_vat": false,
+  "tax_percentage": 0,
+  "edi": {
+    "vendor_edi_code": "1694510",
+    "vendor_edi_type": "31B/US-SAN",
+    "lib_edi_code": "7659876",
+    "lib_edi_type": "31B/US-SAN",
+    "prorate_tax": true,
+    "prorate_fees": false,
+    "edi_naming_convention": "*.edi",
+    "send_acct_num": true,
+    "support_order": true,
+    "support_invoice": true,
+    "notes": "no EDI invoices for our tech services invoices",
+    "edi_ftp": {
+      "ftp_format": "SFTP",
+      "server_address": "ftps://ftp.ybp.com",
+      "username": "sample",
+      "password": "password",
+      "ftp_mode": "Binary",
+      "ftp_conn_mode": "Passive",
+      "ftp_port": 22,
+      "order_directory": "/dropoff",
+      "invoice_directory": "/invoices",
+      "notes": "separate directories for EOCRs and cat records"
+    },
+    "edi_job": {
+      "schedule_edi": true,
+      "is_monday": false,
+      "is_tuesday": false,
+      "is_wednesday": false,
+      "is_thursday": false,
+      "is_friday": false,
+      "is_saturday": false,
+      "is_sunday": false,
+      "send_to_emails": "bobbarker@priceisright.com",
+      "notify_all_edi": true,
+      "notify_invoice_only": false,
+      "notify_error_only": false
+    }
+  },
+  "interfaces": [{
+    "name": "GOBI",
+    "uri": "www.gobi3.com",
+    "username": "",
+    "password": "",
+    "notes": "all staff have different logons with different permissions",
+    "available": false,
+    "delivery_method": "",
+    "statistics_format": "",
+    "locally_stored": "false",
+    "online_location": "",
+    "statistics_notes": "get stats on demand from GOBI, or contact customers service"
+  }
+  ],
+  "accounts": [{
+    "name": "US print orders",
+    "account_no": "99999-10",
+    "description": "Main library orders for print books, shipped from US office",
+    "app_system_no": "",
+    "payment_method": "EFT",
+    "account_status": "Active",
+    "contact_info": "jlegier@ebsco.com",
+    "library_code": "COB",
+    "library_edi_code": "765987610",
+    "notes": "separate accounts for eBooks and UK orders"
+  }
+  ],
+  "vendor_types": [],
+  "san_code": "1234567",
+  "changelogs": [{
+    "description": "This is a sample note.",
+    "timestamp": "2008-05-15T10:53:00.000+0000"
+  }
+  ]
+}

--- a/src/test/resources/mockdata/vendors/all_access_providers_active.json
+++ b/src/test/resources/mockdata/vendors/all_access_providers_active.json
@@ -1,0 +1,340 @@
+{
+  "vendors": [
+    {
+      "id": "858e80d2-f562-4c54-9934-6e274dee511d",
+      "name": "Alexander Street Press",
+      "code": "ALEXS",
+      "description": "AV streaming services",
+      "vendor_status": "Active",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "Alexander Street",
+          "description": ""
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "3212 Duke Street",
+          "addressLine2": "",
+          "city": "Alexandria",
+          "stateRegion": "VA",
+          "zipCode": "22314",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "1-800-889-5937",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "customerservice@alexanderstreet.com",
+          "description": "main customer service email",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "https://alexanderstreet.com/",
+          "description": "main website",
+          "language": "en-us",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Mr.",
+          "first_name": "David",
+          "last_name": "Grohl",
+          "language": "English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "1-800-889-5937",
+              "categories": [],
+              "types": [],
+              "isPrimary": true,
+              "language": "English"
+            }
+          ],
+          "emails": [
+            {
+              "value": "customerservice@alexanderstreet.com",
+              "description": "main customer service email",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "3212 Duke Street",
+              "addressLine2": "",
+              "city": "Alexandria",
+              "stateRegion": "VA",
+              "zipCode": "22314",
+              "country": "USA",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "urls": [
+            {
+              "value": "https://alexanderstreet.com/",
+              "description": "main website",
+              "language": "en-us",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [
+        {
+          "name": "library access",
+          "discount": 0,
+          "reference_url": "",
+          "notes": ""
+        }
+      ],
+      "erp_code": "G64758-74828",
+      "payment_method": "check",
+      "access_provider": true,
+      "governmental": false,
+      "licensor": true,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 0,
+      "discount_percent": 0,
+      "expected_activation_interval": 1,
+      "expected_invoice_interval": 30,
+      "renewal_activation_interval": 365,
+      "subscription_interval": 365,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "interfaces": [
+        {
+          "name": "Academic Video Online",
+          "uri": "https://search.alexanderstreet.com/avon",
+          "username": "****",
+          "password": "****",
+          "notes": "",
+          "available": false,
+          "delivery_method": "",
+          "statistics_format": "",
+          "locally_stored": "",
+          "online_location": "",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "Library account",
+          "account_no": "1234",
+          "description": "Main library account",
+          "app_system_no": "",
+          "payment_method": "check",
+          "account_status": "Active",
+          "contact_info": "customerservice@alexanderstreet.com",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": ""
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "1234567",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    },
+    {
+      "id": "d1b79c8d-4950-482f-8e42-04f9aae3cb40",
+      "name": "Jean Simmons",
+      "code": "SJEAN",
+      "description": "Individual donor to library archives",
+      "vendor_status": "Active",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "Sister Jean",
+          "description": ""
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "1032 W. Sheridan Rd",
+          "addressLine2": "",
+          "city": "Chicago",
+          "stateRegion": "IL",
+          "zipCode": "60660",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "1-773-274-3000",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "sister@luc.edu",
+          "description": "personal email ",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "",
+          "description": "",
+          "language": "",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Sister",
+          "first_name": "Jean",
+          "last_name": "Simmons",
+          "language": "English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "1-773-274-3000",
+              "categories": [],
+              "types": [],
+              "isPrimary": true,
+              "language": "English"
+            }
+          ],
+          "emails": [
+            {
+              "value": "sister@luc.edu",
+              "description": "personal email ",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "1032 W. Sheridan Rd",
+              "addressLine2": "",
+              "city": "Chicago",
+              "stateRegion": "IL",
+              "zipCode": "60660",
+              "country": "USA",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "urls": [
+            {
+              "value": "",
+              "description": "",
+              "language": "",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [],
+      "erp_code": "G64758-74830",
+      "payment_method": "check",
+      "access_provider": false,
+      "governmental": false,
+      "licensor": false,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 0,
+      "discount_percent": 0,
+      "expected_activation_interval": 0,
+      "expected_invoice_interval": 0,
+      "renewal_activation_interval": 0,
+      "subscription_interval": 0,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "interfaces": [
+        {
+          "name": "",
+          "uri": "",
+          "username": "",
+          "password": "",
+          "notes": "",
+          "available": false,
+          "delivery_method": "",
+          "statistics_format": "",
+          "locally_stored": "",
+          "online_location": "",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "SJean account",
+          "account_no": "1234",
+          "description": "Donor account",
+          "app_system_no": "",
+          "payment_method": "check",
+          "account_status": "Active",
+          "contact_info": "sister@luc.edu",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": ""
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    }
+  ],
+  "total_records": 2,
+  "first": 1,
+  "last": 2
+}

--- a/src/test/resources/mockdata/vendors/all_access_providers_not_found.json
+++ b/src/test/resources/mockdata/vendors/all_access_providers_not_found.json
@@ -1,0 +1,6 @@
+{
+  "vendors": [],
+  "total_records": 0,
+  "first": 0,
+  "last": 0
+}

--- a/src/test/resources/mockdata/vendors/all_inactive_access_providers.json
+++ b/src/test/resources/mockdata/vendors/all_inactive_access_providers.json
@@ -1,0 +1,404 @@
+{
+  "vendors": [
+    {
+      "id": "f6cd1850-2587-4f6c-b680-9b27ff26d619",
+      "name": "United States Geological Survey",
+      "code": "USGS",
+      "description": "Maps and materials from the USGS",
+      "vendor_status": "Inactive",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "USGS",
+          "description": ""
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "12201 Sunrise Valley Drive",
+          "addressLine2": "P.O. Box 15550",
+          "city": "Reston",
+          "stateRegion": "VA",
+          "zipCode": "20192",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "1-888-ASK-USGS",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "usgsstore@usgs.gov",
+          "description": "main customer service email",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "https://www.usgs.gov/",
+          "description": "main website",
+          "language": "en-us",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Mr.",
+          "first_name": "Ryan",
+          "last_name": "Zinke",
+          "language": "English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "1-888-ASK-USGS",
+              "categories": [],
+              "types": [],
+              "isPrimary": true,
+              "language": "English"
+            }
+          ],
+          "emails": [
+            {
+              "value": "usgsstore@usgs.gov",
+              "description": "main customer service email",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "12201 Sunrise Valley Drive",
+              "addressLine2": "P.O. Box 15550",
+              "city": "Reston",
+              "stateRegion": "VA",
+              "zipCode": "20192",
+              "country": "USA",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "urls": [
+            {
+              "value": "https://www.usgs.gov/",
+              "description": "main website",
+              "language": "en-us",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [
+        {
+          "name": "",
+          "discount": 0,
+          "reference_url": "",
+          "notes": ""
+        }
+      ],
+      "erp_code": "G64758-74833",
+      "payment_method": "credit card",
+      "access_provider": false,
+      "governmental": true,
+      "licensor": false,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 45,
+      "discount_percent": 0,
+      "expected_activation_interval": 0,
+      "expected_invoice_interval": 0,
+      "renewal_activation_interval": 0,
+      "subscription_interval": 0,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "interfaces": [
+        {
+          "name": "USGS Store",
+          "uri": "https://store.usgs.gov/",
+          "username": "****",
+          "password": "****",
+          "notes": "",
+          "available": false,
+          "delivery_method": "",
+          "statistics_format": "",
+          "locally_stored": "false",
+          "online_location": "",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "Cartographic account",
+          "account_no": "1234",
+          "description": "Monographic ordering unit accountt",
+          "app_system_no": "",
+          "payment_method": "credit card",
+          "account_status": "Active",
+          "contact_info": "usgsstore@usgs.gov",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": ""
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    },
+    {
+      "id": "f64bbcae-e5ea-42b6-8236-55fefed0fb8f",
+      "name": "Otto Harrassowitz GmbH & Co. KG",
+      "code": "HARRA",
+      "description": "Use for monographs, approval plans, firms orders, and standing orders",
+      "vendor_status": "Inactive",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "Harrassowitz",
+          "description": "shorter name"
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "Kreuzberger Ring 6 b-d",
+          "addressLine2": "",
+          "city": "Wiesbaden",
+          "stateRegion": "",
+          "zipCode": "65205",
+          "country": "Germany",
+          "isPrimary": true,
+          "categories": [
+            "Customer Service",
+            "Payments",
+            "Returns",
+            "Shipments"
+          ],
+          "language": "German"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "49-611-530 ext. 0",
+          "categories": [
+            "Customer Service",
+            "Payments",
+            "Returns",
+            "Shipments"
+          ],
+          "types": [],
+          "isPrimary": true,
+          "language": "German"
+        }
+      ],
+      "emails": [
+        {
+          "value": "service@harrassowitz.de",
+          "description": "customer service",
+          "isPrimary": true,
+          "categories": [],
+          "language": "German and English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "https://www.harrassowitz.de/",
+          "description": "main website",
+          "language": "en-us",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Frau",
+          "first_name": "Gabriele",
+          "last_name": "Kerner",
+          "language": "German and English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "49-611-530 ext. 0",
+              "categories": [
+                "Customer Service",
+                "Payments",
+                "Returns",
+                "Shipments"
+              ],
+              "types": [],
+              "isPrimary": true,
+              "language": "German"
+            }
+          ],
+          "emails": [
+            {
+              "value": "service@harrassowitz.de",
+              "description": "customer service",
+              "isPrimary": true,
+              "categories": [],
+              "language": "German and English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "Kreuzberger Ring 6 b-d",
+              "addressLine2": "",
+              "city": "Wiesbaden",
+              "stateRegion": "",
+              "zipCode": "65205",
+              "country": "Germany",
+              "isPrimary": true,
+              "categories": [
+                "Customer Service",
+                "Payments",
+                "Returns",
+                "Shipments"
+              ],
+              "language": "German"
+            }
+          ],
+          "urls": [
+            {
+              "value": "https://www.harrassowitz.de/",
+              "description": "main website",
+              "language": "en-us",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [
+        {
+          "name": "No formal agreement",
+          "discount": 0,
+          "reference_url": "",
+          "notes": ""
+        }
+      ],
+      "erp_code": "G64758-74835",
+      "payment_method": "check",
+      "access_provider": false,
+      "governmental": false,
+      "licensor": false,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 75,
+      "discount_percent": 0,
+      "expected_activation_interval": 0,
+      "expected_invoice_interval": 30,
+      "renewal_activation_interval": 0,
+      "subscription_interval": 0,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "edi": {
+        "vendor_edi_code": "v10063",
+        "lib_edi_code": "COB",
+        "prorate_tax": false,
+        "prorate_fees": false,
+        "edi_naming_convention": "****.edu",
+        "send_acct_num": true,
+        "support_order": true,
+        "support_invoice": true,
+        "notes": "",
+        "edi_ftp": {
+          "ftp_format": "SFTP",
+          "server_address": "ftps://ftp.harrassowitz.de",
+          "username": "sample",
+          "password": "password",
+          "ftp_mode": "Binary",
+          "ftp_conn_mode": "Passive",
+          "ftp_port": 22,
+          "order_directory": "/orders",
+          "invoice_directory": "/invoices",
+          "notes": ""
+        },
+        "edi_job": {
+          "schedule_edi": true,
+          "is_monday": false,
+          "is_tuesday": false,
+          "is_wednesday": false,
+          "is_thursday": false,
+          "is_friday": false,
+          "is_saturday": false,
+          "is_sunday": false,
+          "send_to_emails": "",
+          "notify_all_edi": true,
+          "notify_invoice_only": false,
+          "notify_error_only": false
+        }
+      },
+      "interfaces": [
+        {
+          "name": "OttoEditions",
+          "uri": "https://www.harrassowitz.de/OttoEditions/servlet/OttoEdition?sc=sc_email&BTSubmit=searche&CBSpeedOrder=true&CBTitleId=0&TFTitleId=115003369&ID=009164240",
+          "username": "****",
+          "password": "****",
+          "notes": "all staff have different logons with different permissions",
+          "available": true,
+          "delivery_method": "email",
+          "statistics_format": "HTML",
+          "locally_stored": "false",
+          "online_location": "https://www.harrassowitz.de/",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "Main library account",
+          "account_no": "xxxx34",
+          "description": "Main library account",
+          "app_system_no": "",
+          "payment_method": "check",
+          "account_status": "Active",
+          "contact_info": "service@harrassowitz.de",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": "different account numbers for serials and standing orders"
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "1234567",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    }
+  ],
+  "total_records": 2,
+  "first": 1,
+  "last": 2
+}

--- a/src/test/resources/mockdata/vendors/inactive_vendor.json
+++ b/src/test/resources/mockdata/vendors/inactive_vendor.json
@@ -1,0 +1,170 @@
+{
+  "id": "b1ef7e96-98f3-4f0d-9820-98c322c989d2",
+  "name": "Amazon.com",
+  "code": "AMAZ",
+  "description": "Use for rush orders, replacement requests, and second hand market",
+  "vendor_status": "Inactive",
+  "language": "en-us",
+  "aliases": [
+    {
+      "value": "Amazon",
+      "description": ""
+    }
+  ],
+  "addresses": [
+    {
+      "addressLine1": "1 Centerpiece Blvd.",
+      "addressLine2": "P.O. Box 15550",
+      "city": "New Castle",
+      "stateRegion": "DE",
+      "zipCode": "19720-5550",
+      "country": "USA",
+      "isPrimary": true,
+      "categories": [],
+      "language": "English"
+    }
+  ],
+  "phone_numbers": [
+    {
+      "phone_number": "1-888-238-22090",
+      "categories": [],
+      "types": [],
+      "isPrimary": true,
+      "language": "English"
+    }
+  ],
+  "emails": [
+    {
+      "value": "cust.service03@amazon.com",
+      "description": "customer service",
+      "isPrimary": true,
+      "categories": [],
+      "language": "English"
+    }
+  ],
+  "urls": [
+    {
+      "value": "https://www.amazon.com",
+      "description": "main website",
+      "language": "en-us",
+      "isPrimary": true,
+      "categories": [],
+      "notes": ""
+    }
+  ],
+  "contacts": [
+    {
+      "prefix": "Ms.",
+      "first_name": "Carrie",
+      "last_name": "Brownstein",
+      "language": "English",
+      "notes": "",
+      "phone_numbers": [
+        {
+          "phone_number": "1-888-238-22090",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "cust.service03@amazon.com",
+          "description": "customer service",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "1 Centerpiece Blvd.",
+          "addressLine2": "P.O. Box 15550",
+          "city": "New Castle",
+          "stateRegion": "DE",
+          "zipCode": "19720-5550",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "https://www.amazon.com",
+          "description": "main website",
+          "language": "en-us",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "categories": []
+    }
+  ],
+  "agreements": [
+    {
+      "name": "",
+      "discount": 0,
+      "reference_url": "",
+      "notes": ""
+    }
+  ],
+  "erp_code": "G64758-74834",
+  "payment_method": "credit card",
+  "access_provider": false,
+  "governmental": false,
+  "licensor": false,
+  "material_supplier": true,
+  "vendor_currencies": [
+    "USD"
+  ],
+  "claiming_interval": 45,
+  "discount_percent": 0,
+  "expected_activation_interval": 0,
+  "expected_invoice_interval": 0,
+  "renewal_activation_interval": 0,
+  "subscription_interval": 0,
+  "expected_receipt_interval": 30,
+  "tax_id": "",
+  "liable_for_vat": false,
+  "tax_percentage": 0,
+  "interfaces": [
+    {
+      "name": "Amazon",
+      "uri": "www.amazon.com",
+      "username": "****",
+      "password": "****",
+      "notes": "",
+      "available": false,
+      "delivery_method": "",
+      "statistics_format": "",
+      "locally_stored": "false",
+      "online_location": "",
+      "statistics_notes": ""
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Monographic ordering unit account",
+      "account_no": "1234",
+      "description": "Monographic ordering unit account",
+      "app_system_no": "",
+      "payment_method": "credit card",
+      "account_status": "Active",
+      "contact_info": "cust.service03@amazon.com",
+      "library_code": "COB",
+      "library_edi_code": "765987610",
+      "notes": ""
+    }
+  ],
+  "vendor_types": [],
+  "san_code": "1234567",
+  "changelogs": [
+    {
+      "description": "This is a sample note.",
+      "timestamp": "2008-05-15T10:53:00.000+0000"
+    }
+  ]
+}

--- a/src/test/resources/mockdata/vendors/one_access_provider_not_found.json
+++ b/src/test/resources/mockdata/vendors/one_access_provider_not_found.json
@@ -1,0 +1,177 @@
+{
+  "vendors": [
+    {
+      "id": "858e80d2-f562-4c54-9934-6e274dee511d",
+      "name": "Alexander Street Press",
+      "code": "ALEXS",
+      "description": "AV streaming services",
+      "vendor_status": "Active",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "Alexander Street",
+          "description": ""
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "3212 Duke Street",
+          "addressLine2": "",
+          "city": "Alexandria",
+          "stateRegion": "VA",
+          "zipCode": "22314",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "1-800-889-5937",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "customerservice@alexanderstreet.com",
+          "description": "main customer service email",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "https://alexanderstreet.com/",
+          "description": "main website",
+          "language": "en-us",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Mr.",
+          "first_name": "David",
+          "last_name": "Grohl",
+          "language": "English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "1-800-889-5937",
+              "categories": [],
+              "types": [],
+              "isPrimary": true,
+              "language": "English"
+            }
+          ],
+          "emails": [
+            {
+              "value": "customerservice@alexanderstreet.com",
+              "description": "main customer service email",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "3212 Duke Street",
+              "addressLine2": "",
+              "city": "Alexandria",
+              "stateRegion": "VA",
+              "zipCode": "22314",
+              "country": "USA",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "urls": [
+            {
+              "value": "https://alexanderstreet.com/",
+              "description": "main website",
+              "language": "en-us",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [
+        {
+          "name": "library access",
+          "discount": 0,
+          "reference_url": "",
+          "notes": ""
+        }
+      ],
+      "erp_code": "G64758-74828",
+      "payment_method": "check",
+      "access_provider": true,
+      "governmental": false,
+      "licensor": true,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 0,
+      "discount_percent": 0,
+      "expected_activation_interval": 1,
+      "expected_invoice_interval": 30,
+      "renewal_activation_interval": 365,
+      "subscription_interval": 365,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "interfaces": [
+        {
+          "name": "Academic Video Online",
+          "uri": "https://search.alexanderstreet.com/avon",
+          "username": "****",
+          "password": "****",
+          "notes": "",
+          "available": false,
+          "delivery_method": "",
+          "statistics_format": "",
+          "locally_stored": "",
+          "online_location": "",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "Library account",
+          "account_no": "1234",
+          "description": "Main library account",
+          "app_system_no": "",
+          "payment_method": "check",
+          "account_status": "Active",
+          "contact_info": "customerservice@alexanderstreet.com",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": ""
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "1234567",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    }
+  ],
+  "total_records": 1,
+  "first": 1,
+  "last": 1
+}

--- a/src/test/resources/mockdata/vendors/pending_vendor.json
+++ b/src/test/resources/mockdata/vendors/pending_vendor.json
@@ -1,0 +1,156 @@
+{
+  "id": "160501b3-52dd-41ec-a0ce-17762e7a9b47",
+  "name": "Naxos of America, Inc.",
+  "code": "NAXO",
+  "description": "AV streaming services, other onilne content",
+  "vendor_status": "Pending",
+  "language": "en-us",
+  "aliases": [{
+    "value": "Naxos",
+    "description": ""
+  }
+  ],
+  "addresses": [{
+    "addressLine1": "416 Mary Lindsay Polk Dr.",
+    "addressLine2": "",
+    "city": "Franklin",
+    "stateRegion": "TN",
+    "zipCode": "37067",
+    "country": "USA",
+    "isPrimary": true,
+    "categories": [],
+    "language": "English"
+  }
+  ],
+  "phone_numbers": [{
+    "phone_number": "1-615-771-9393",
+    "categories": [],
+    "types": [],
+    "isPrimary": true,
+    "language": "English"
+  }
+  ],
+  "emails": [{
+    "value": "service@naxosusa.com",
+    "description": "Customer Service",
+    "isPrimary": true,
+    "categories": [],
+    "language": "English"
+  }
+  ],
+  "urls": [{
+    "value": "https://www.naxos.com/",
+    "description": "main website",
+    "language": "en-us",
+    "isPrimary": true,
+    "categories": [],
+    "notes": ""
+  }
+  ],
+  "contacts": [{
+    "prefix": "Prof.",
+    "first_name": "Marie",
+    "last_name": "Curie",
+    "language": "English",
+    "notes": "",
+    "phone_numbers": [{
+      "phone_number": "1-615-771-9393",
+      "categories": [],
+      "types": [],
+      "isPrimary": true,
+      "language": "English"
+    }
+    ],
+    "emails": [{
+      "value": "service@naxosusa.com",
+      "description": "Customer Service",
+      "isPrimary": true,
+      "categories": [],
+      "language": "English"
+    }
+    ],
+    "addresses": [{
+      "addressLine1": "416 Mary Lindsay Polk Dr.",
+      "addressLine2": "",
+      "city": "Franklin",
+      "stateRegion": "TN",
+      "zipCode": "37067",
+      "country": "USA",
+      "isPrimary": true,
+      "categories": [],
+      "language": "English"
+    }
+    ],
+    "urls": [{
+      "value": "https://www.naxos.com/",
+      "description": "main website",
+      "language": "en-us",
+      "isPrimary": true,
+      "categories": [],
+      "notes": ""
+    }
+    ],
+    "categories": []
+  }
+  ],
+  "agreements": [{
+    "name": "Naxos Music Library, Naxos Video Library",
+    "discount": 0,
+    "reference_url": "F:\\Serials\\Licensing\\License and Renewal Agreements\\Content Providers\\NAXOS",
+    "notes": ""
+  }
+  ],
+  "erp_code": "G64758-74827",
+  "payment_method": "EFT",
+  "access_provider": true,
+  "governmental": false,
+  "licensor": true,
+  "material_supplier": true,
+  "vendor_currencies": [
+    "USD"
+  ],
+  "claiming_interval": 0,
+  "discount_percent": 0,
+  "expected_activation_interval": 30,
+  "expected_invoice_interval": 30,
+  "renewal_activation_interval": 365,
+  "subscription_interval": 365,
+  "expected_receipt_interval": 30,
+  "tax_id": "",
+  "liable_for_vat": false,
+  "tax_percentage": 0,
+  "interfaces": [{
+    "name": "Naxos Digital Services, U.S.",
+    "uri": "https://www.naxosmusiclibrary.com",
+    "username": "",
+    "password": "",
+    "notes": "See also http://sample.naxosvideolibrary.com/ for Naxos Video Library",
+    "available": true,
+    "delivery_method": "online",
+    "statistics_format": "Non-COUNTER",
+    "locally_stored": "https://www.lib.sample.edu/staff/collectiondevelopment/",
+    "online_location": "http://www.naxosmusiclibrary.com/",
+    "statistics_notes": "Login on interface used to access content."
+  }
+  ],
+  "accounts": [{
+    "name": "Serials",
+    "account_no": "xxxx4367",
+    "description": "Libraries",
+    "app_system_no": "",
+    "payment_method": "EFT",
+    "account_status": "Active",
+    "contact_info": "service@naxosusa.com",
+    "library_code": "COB",
+    "library_edi_code": "765987610",
+    "notes": ""
+  }
+  ],
+  "vendor_types": [],
+  "san_code": "",
+  "changelogs": [{
+    "description": "This is a sample note.",
+    "timestamp": "2008-05-15T10:53:00.000+0000"
+  }
+  ]
+}

--- a/src/test/resources/po_listed_print_monograph.json
+++ b/src/test/resources/po_listed_print_monograph.json
@@ -88,6 +88,7 @@
       },
       "donor": "ABCDEFGHIJKLM",
       "eresource": {
+        "access_provider": "858e80d2-f562-4c54-9934-6e274dee511d",
         "create_inventory": true
       },
       "fund_distribution": [
@@ -241,6 +242,7 @@
       },
       "donor": "",
       "eresource": {
+        "access_provider": "d1b79c8d-4950-482f-8e42-04f9aae3cb40",
         "create_inventory": true
       },
       "fund_distribution": [


### PR DESCRIPTION
[MODORDERS-170](https://issues.folio.org/browse/MODORDERS-170) - Prevent ordering from Inactive vendors/access provider

## Purpose
To keep users from ordering from inappropriate Vendors/Access Providers

## Approach
In the case of an inactive or non-existent vendor/access provider during purchase order creation/updating client will receive a response containing the corresponding errors with vendor's id as an additional parameter.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?

1. **folio-api-tests** (as a result of vendor's id generation each time during sample data processing - vendors should have permanent id for passing validation + probably, inactive vendor can be added to sample data)

- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
