### PR TITLE
MODORDERS-193 Sum total quantity on PO retrieval

### DIFF
--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -191,6 +191,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
           .thenAccept(poLines -> {
             compPO.setCompositePoLines(poLines);
             compPO.setAdjustment(HelperUtils.calculateAdjustment(poLines));
+            compPO.setTotalItems(calculateTotalItemsQuantity(poLines));
             future.complete(compPO);
           })
           .exceptionally(t -> {
@@ -206,6 +207,10 @@ public class PurchaseOrderHelper extends AbstractHelper {
       });
 
     return future;
+  }
+
+  private int calculateTotalItemsQuantity(List<CompositePoLine> poLines) {
+    return poLines.stream().mapToInt(HelperUtils::calculateTotalQuantity).sum();
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -202,6 +202,7 @@ public class OrdersImplTest {
   private static final String PO_LINE_ID_WITH_SOME_SUB_OBJECTS_ALREADY_REMOVED = "0009662b-8b80-4001-b704-ca10971f175d";
   private static final String ORDER_ID_WITHOUT_PO_LINES = "50fb922c-3fa9-494e-a972-f2801f1b9fd1";
   private static final String ORDER_ID_WITH_PO_LINES = "ab18897b-0e40-4f31-896b-9c9adc979a87";
+  private static final String ORDER_ID_WITH_MINIMAL_PO_LINE = "11111111-dddd-4444-9999-ffffffffffff";
   private static final String ORDER_WITHOUT_WORKFLOW_STATUS = "41d56e59-46db-4d5e-a1ad-a178228913e5";
   private static final String RECEIVING_HISTORY_PURCHASE_ORDER_ID = "0804ddec-6545-404a-b54d-a693f505681d";
 
@@ -779,7 +780,7 @@ public class OrdersImplTest {
   }
 
   @Test
-  public void testDetailsCreationFailure() throws Exception {
+  public void testSubObjectCreationFailure() throws Exception {
     logger.info("=== Test Details creation failure ===");
 
     String body = getMockDraftOrder().toString();
@@ -829,6 +830,58 @@ public class OrdersImplTest {
     logger.info(JsonObject.mapFrom(resp).encodePrettily());
 
     assertEquals(id, resp.getId());
+    Integer expectedQuantity = resp.getCompositePoLines().stream()
+      .mapToInt(poLine -> poLine.getCost().getQuantityElectronic() + poLine.getCost().getQuantityPhysical())
+      .sum();
+    assertEquals(expectedQuantity, resp.getTotalItems());
+  }
+
+  @Test
+  public void testGetOrderByIdWithOnePoLineWithNullCost() throws Exception {
+    logger.info("=== Test Get Order By Id with one PO Line without cost totalItems value is 0 ===");
+
+    logger.info(String.format("using mock datafile: %s%s.json", COMP_ORDER_MOCK_DATA_PATH, ORDER_ID_WITH_MINIMAL_PO_LINE));
+
+    final CompositePurchaseOrder resp = RestAssured
+      .with()
+        .header(X_OKAPI_URL)
+        .header(NON_EXIST_CONFIG_X_OKAPI_TENANT)
+      .get(COMPOSITE_ORDERS_PATH + "/" + ORDER_ID_WITH_MINIMAL_PO_LINE)
+        .then()
+          .contentType(APPLICATION_JSON)
+          .statusCode(200)
+          .extract()
+            .response()
+              .as(CompositePurchaseOrder.class);
+
+    logger.info(JsonObject.mapFrom(resp).encodePrettily());
+
+    assertEquals(ORDER_ID_WITH_MINIMAL_PO_LINE, resp.getId());
+    assertEquals(0, resp.getTotalItems().intValue());
+  }
+
+  @Test
+  public void testGetPOByIdTotalItemsWithoutPOLines() throws Exception {
+    logger.info("=== Test Get Order By Id without PO Line totalItems value is 0 ===");
+
+    logger.info(String.format("using mock datafile: %s%s.json", COMP_ORDER_MOCK_DATA_PATH, ORDER_ID_WITHOUT_PO_LINES));
+
+    final CompositePurchaseOrder resp = RestAssured
+      .with()
+        .header(X_OKAPI_URL)
+        .header(NON_EXIST_CONFIG_X_OKAPI_TENANT)
+      .get(COMPOSITE_ORDERS_PATH + "/" + ORDER_ID_WITHOUT_PO_LINES)
+        .then()
+          .contentType(APPLICATION_JSON)
+          .statusCode(200)
+          .extract()
+            .response()
+              .as(CompositePurchaseOrder.class);
+
+    logger.info(JsonObject.mapFrom(resp).encodePrettily());
+
+    assertEquals(ORDER_ID_WITHOUT_PO_LINES, resp.getId());
+    assertEquals(0, resp.getTotalItems().intValue());
   }
 
   @Test
@@ -854,6 +907,7 @@ public class OrdersImplTest {
 
     assertEquals(id, resp.getId());
     assertEquals(1, resp.getCompositePoLines().size());
+    assertEquals(calculateTotalQuantity(resp.getCompositePoLines().get(0)), resp.getTotalItems().intValue());
   }
 
   @Test

--- a/src/test/resources/mockdata/compositeOrders/11111111-dddd-4444-9999-ffffffffffff.json
+++ b/src/test/resources/mockdata/compositeOrders/11111111-dddd-4444-9999-ffffffffffff.json
@@ -1,0 +1,42 @@
+{
+  "id": "11111111-dddd-4444-9999-ffffffffffff",
+  "adjustment": {
+    "credit": 0,
+    "discount": 0,
+    "insurance": 0,
+    "overhead": 0,
+    "shipment": 0,
+    "tax1": 0,
+    "tax2": 0,
+    "useProRate": false
+  },
+  "approved": true,
+  "assignedTo": "28d102a2-d137-11e8-a8d5-f2801f1b9fd1",
+  "notes": [],
+  "manualPo": false,
+  "poNumber": "S60402",
+  "orderType": "Ongoing",
+  "reEncumber": false,
+  "renewal": {
+    "cycle": "6 Months",
+    "interval": 182,
+    "manualRenewal": true,
+    "reviewPeriod": 30,
+    "renewalDate": "2019-04-09T00:00:00.000Z"
+  },
+  "totalEstimatedPrice": 200000.00,
+  "totalItems": 80,
+  "vendor": "50fb8b56-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflowStatus": "Closed",
+  "metadata": {
+    "createdDate": "2018-07-18T00:00:00.000",
+    "createdByUserId": "28d102a2-d137-11e8-a8d5-f2801f1b9fd1"
+  },
+  "compositePoLines": [
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "source": { "code": "FOLIO" },
+      "purchaseOrderId": "c79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB4bb"
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-193](https://issues.folio.org/browse/MODORDERS-193) totalItems should be calculated and returned from mod-orders when an order is retrieved.

## Approach
- added calculation totalItems quantity on purchaseOrder retrieval
- tests updated to check totalItems quantity

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.