### PR TITLE
MODORDERS-178/179 Increased flexibility in inventory integration

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -486,13 +486,13 @@ public class HelperUtils {
     switch (compPOL.getOrderFormat()) {
       case P_E_MIX:
         int quantity = 0;
-        quantity += isInventoryUpdateRequiredForPhysical(compPOL) ? getPhysicalQuantity(locations) : 0;
-        quantity += isInventoryUpdateRequiredForEresource(compPOL) ? getElectronicQuantity(locations) : 0;
+        quantity += isItemsUpdateRequiredForPhysical(compPOL) ? getPhysicalQuantity(locations) : 0;
+        quantity += isItemsUpdateRequiredForEresource(compPOL) ? getElectronicQuantity(locations) : 0;
         return quantity;
       case PHYSICAL_RESOURCE:
-        return isInventoryUpdateRequiredForPhysical(compPOL) ? getPhysicalQuantity(locations) : 0;
+        return isItemsUpdateRequiredForPhysical(compPOL) ? getPhysicalQuantity(locations) : 0;
       case ELECTRONIC_RESOURCE:
-        return isInventoryUpdateRequiredForEresource(compPOL) ? getElectronicQuantity(locations) : 0;
+        return isItemsUpdateRequiredForEresource(compPOL) ? getElectronicQuantity(locations) : 0;
       case OTHER:
       default:
         return 0;
@@ -555,17 +555,6 @@ public class HelperUtils {
     }
   }
 
-  private static boolean isInventoryUpdateRequiredForEresource(CompositePoLine compPOL) {
-    return Optional.ofNullable(compPOL.getEresource())
-      .map(eresource -> eresource.getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM)
-      .orElse(false);
-  }
-
-  private static boolean isInventoryUpdateRequiredForPhysical(CompositePoLine compPOL) {
-    return Optional.ofNullable(compPOL.getPhysical())
-      .map(physical -> physical.getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM)
-      .orElse(false);
-  }
   private static boolean isItemsUpdateRequiredForEresource(CompositePoLine compPOL) {
     return Optional.ofNullable(compPOL.getEresource())
       .map(eresource -> eresource.getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM)
@@ -756,9 +745,13 @@ public class HelperUtils {
   }
 
   public static boolean inventoryUpdateNotRequired(CompositePoLine compPOL) {
-    return (compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.NONE)
-      || (compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.NONE);
-    }
+    return (compPOL.getPhysical() == null && compPOL.getEresource() == null) ||
+      (compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.NONE && compPOL.getEresource() == null) ||
+      (compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.NONE && compPOL.getPhysical() == null) ||
+      (compPOL.getPhysical() != null && compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.NONE && compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.NONE) ||
+      // also ignore inventory interaction in case of "Other" order format
+      compPOL.getOrderFormat() == CompositePoLine.OrderFormat.OTHER;
+  }
 
   public static boolean isHoldingsUpdateRequired(CompositePoLine compPOL) {
     return (compPOL.getEresource() != null &&

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -502,12 +502,16 @@ public class HelperUtils {
   public static int calculateExpectedQuantityOfPiecesWithoutItemCreation(CompositePoLine compPOL, List<Location> locations) {
     switch (compPOL.getOrderFormat()) {
       case P_E_MIX:
-        return isInventoryUpdateRequiredForEresource(compPOL) ? 0 : getElectronicQuantity(locations);
+        int quantity = 0;
+        quantity += isInventoryUpdateRequiredForPhysical(compPOL) ? 0 : getPhysicalQuantity(locations);
+        quantity += isInventoryUpdateRequiredForEresource(compPOL) ? 0: getElectronicQuantity(locations);
+        return quantity;
       case ELECTRONIC_RESOURCE:
         return isInventoryUpdateRequiredForEresource(compPOL) ? 0 : getElectronicQuantity(locations);
       case OTHER:
         return getPhysicalQuantity(locations);
       case PHYSICAL_RESOURCE:
+        return isInventoryUpdateRequiredForPhysical(compPOL) ? 0 : getPhysicalQuantity(locations);
       default:
         return 0;
     }
@@ -738,5 +742,22 @@ public class HelperUtils {
   public static CompositePurchaseOrder convertToCompositePurchaseOrder(JsonObject poJson) {
     poJson.remove(ADJUSTMENT);
     return poJson.mapTo(CompositePurchaseOrder.class);
+  }
+
+  public static boolean isInventoryUpdateRequired(CompositePoLine compPOL) {
+    return (compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() != Eresource.CreateInventory.NONE)
+      || (compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() != Physical.CreateInventory.NONE);
+    }
+
+  public static boolean isHoldingsUpdateRequired(CompositePoLine compPOL) {
+    return (compPOL.getEresource() != null &&
+      (compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING || compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM))
+      || (compPOL.getPhysical() != null &&
+      (compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING || compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM));
+  }
+
+  public static boolean isItemsUpdateRequired(CompositePoLine compPOL) {
+    return (compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM)
+      || (compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM);
   }
 }

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -599,12 +599,18 @@ public class HelperUtils {
   }
 
   private static boolean isItemsUpdateRequiredForEresource(CompositePoLine compPOL) {
+    if (compPOL.getCheckinItems() != null && compPOL.getCheckinItems()) {
+      return false;
+    }
     return Optional.ofNullable(compPOL.getEresource())
       .map(eresource -> eresource.getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM)
       .orElse(false);
   }
 
   private static boolean isItemsUpdateRequiredForPhysical(CompositePoLine compPOL) {
+    if (compPOL.getCheckinItems() != null && compPOL.getCheckinItems()) {
+      return false;
+    }
     return Optional.ofNullable(compPOL.getPhysical())
       .map(physical -> physical.getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM)
       .orElse(false);
@@ -813,15 +819,6 @@ public class HelperUtils {
   }
 
   public static boolean isItemsUpdateRequired(CompositePoLine compPOL) {
-    boolean updatesRequiredForEresource = false;
-    boolean updateRequiredForPhysical = false;
-
-    if (compPOL.getEresource() != null) {
-      updatesRequiredForEresource = compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM;
-    }
-    if (compPOL.getPhysical() != null) {
-      updateRequiredForPhysical = compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM;
-    }
-    return updatesRequiredForEresource || updateRequiredForPhysical;
+    return isItemsUpdateRequiredForPhysical(compPOL) || isItemsUpdateRequiredForEresource(compPOL);
   }
 }

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -503,15 +503,15 @@ public class HelperUtils {
     switch (compPOL.getOrderFormat()) {
       case P_E_MIX:
         int quantity = 0;
-        quantity += isInventoryUpdateRequiredForPhysical(compPOL) ? 0 : getPhysicalQuantity(locations);
-        quantity += isInventoryUpdateRequiredForEresource(compPOL) ? 0: getElectronicQuantity(locations);
+        quantity += isItemsUpdateRequiredForPhysical(compPOL) ? 0 : getPhysicalQuantity(locations);
+        quantity += isItemsUpdateRequiredForEresource(compPOL) ? 0: getElectronicQuantity(locations);
         return quantity;
       case ELECTRONIC_RESOURCE:
-        return isInventoryUpdateRequiredForEresource(compPOL) ? 0 : getElectronicQuantity(locations);
+        return isItemsUpdateRequiredForEresource(compPOL) ? 0 : getElectronicQuantity(locations);
       case OTHER:
         return getPhysicalQuantity(locations);
       case PHYSICAL_RESOURCE:
-        return isInventoryUpdateRequiredForPhysical(compPOL) ? 0 : getPhysicalQuantity(locations);
+        return isItemsUpdateRequiredForPhysical(compPOL) ? 0 : getPhysicalQuantity(locations);
       default:
         return 0;
     }
@@ -557,13 +557,24 @@ public class HelperUtils {
 
   private static boolean isInventoryUpdateRequiredForEresource(CompositePoLine compPOL) {
     return Optional.ofNullable(compPOL.getEresource())
-      .map(eresource -> eresource.getCreateInventory() != Eresource.CreateInventory.NONE)
+      .map(eresource -> eresource.getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM)
       .orElse(false);
   }
 
   private static boolean isInventoryUpdateRequiredForPhysical(CompositePoLine compPOL) {
     return Optional.ofNullable(compPOL.getPhysical())
-      .map(physical -> physical.getCreateInventory() != Physical.CreateInventory.NONE)
+      .map(physical -> physical.getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM)
+      .orElse(false);
+  }
+  private static boolean isItemsUpdateRequiredForEresource(CompositePoLine compPOL) {
+    return Optional.ofNullable(compPOL.getEresource())
+      .map(eresource -> eresource.getCreateInventory() == Eresource.CreateInventory.INSTANCE_HOLDING_ITEM)
+      .orElse(false);
+  }
+
+  private static boolean isItemsUpdateRequiredForPhysical(CompositePoLine compPOL) {
+    return Optional.ofNullable(compPOL.getPhysical())
+      .map(physical -> physical.getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM)
       .orElse(false);
   }
 
@@ -744,9 +755,9 @@ public class HelperUtils {
     return poJson.mapTo(CompositePurchaseOrder.class);
   }
 
-  public static boolean isInventoryUpdateRequired(CompositePoLine compPOL) {
-    return (compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() != Eresource.CreateInventory.NONE)
-      || (compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() != Physical.CreateInventory.NONE);
+  public static boolean inventoryUpdateNotRequired(CompositePoLine compPOL) {
+    return (compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() == Eresource.CreateInventory.NONE)
+      || (compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() == Physical.CreateInventory.NONE);
     }
 
   public static boolean isHoldingsUpdateRequired(CompositePoLine compPOL) {

--- a/src/main/java/org/folio/rest/impl/AbstractHelper.java
+++ b/src/main/java/org/folio/rest/impl/AbstractHelper.java
@@ -6,8 +6,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static org.folio.orders.utils.HelperUtils.OKAPI_URL;
-import static org.folio.orders.utils.HelperUtils.verifyAndExtractBody;
+import static org.folio.orders.utils.HelperUtils.*;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 import io.vertx.core.Context;
@@ -42,6 +41,7 @@ public abstract class AbstractHelper {
   protected final Map<String, String> okapiHeaders;
   protected final Context ctx;
   protected final String lang;
+  private JsonObject tenantConfiguration;
 
   AbstractHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {
     this.httpClient = httpClient;
@@ -196,5 +196,17 @@ public abstract class AbstractHelper {
   public Response buildCreatedResponse(Object body) {
     closeHttpClient();
     return Response.status(CREATED).header(CONTENT_TYPE, APPLICATION_JSON).entity(body).build();
+  }
+
+  public CompletableFuture<JsonObject> getTenantConfiguration() {
+    if (this.tenantConfiguration != null) {
+      return CompletableFuture.completedFuture(this.tenantConfiguration);
+    } else {
+      return loadConfiguration(okapiHeaders, ctx, logger)
+        .thenApply(config -> {
+          this.tenantConfiguration = config;
+          return config;
+        });
+    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -106,12 +106,14 @@ public class InventoryHelper extends AbstractHelper {
           // Search for or create a new holding and then create items for this holding
           getOrCreateHoldingsRecord(compPOL, locationId)
             .thenCompose(holdingId -> {
-              int expectedQuantity = calculateInventoryItemsQuantity(compPOL, locations);
-              if (isItemsUpdateRequired(compPOL) && expectedQuantity > 0) {
+                int expectedQuantity = calculateInventoryItemsQuantity(compPOL, locations);
+                if (isItemsUpdateRequired(compPOL) && expectedQuantity > 0) {
                   // For some cases items might not be created e.g. resources with create inventory set to "None"
                   return handleItemRecords(compPOL, holdingId, expectedQuantity)
                     .thenApply(itemIds -> constructPieces(itemIds, compPOL.getId(), locationId));
-                } else return completedFuture((new ArrayList<>()));
+                } else {
+                  return completedFuture((new ArrayList<>()));
+                }
               }
             )));
     }

--- a/src/main/java/org/folio/rest/impl/OrdersImpl.java
+++ b/src/main/java/org/folio/rest/impl/OrdersImpl.java
@@ -1,8 +1,6 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.orders.utils.HelperUtils.getPoLineLimit;
-import static org.folio.orders.utils.HelperUtils.loadConfiguration;
 import static org.folio.orders.utils.HelperUtils.validatePoLine;
 
 import java.util.ArrayList;

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -126,6 +126,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
       .thenCompose(poFromStorage -> {
         logger.info("Order successfully retrieved from storage");
         return validatePoNumber(poFromStorage, compPO)
+          .thenCompose(v -> updateTenantDefaultCreateInventoryValues(compPO))
           .thenCompose(v -> updatePoLines(poFromStorage, compPO))
           .thenCompose(v -> {
             if (isTransitionToOpen(poFromStorage, compPO)) {
@@ -136,6 +137,12 @@ public class PurchaseOrderHelper extends AbstractHelper {
           });
         }
       );
+  }
+
+  private CompletableFuture<Void> updateTenantDefaultCreateInventoryValues(CompositePurchaseOrder compPO) {
+    return CompletableFuture.allOf(compPO.getCompositePoLines().stream()
+      .map(orderLineHelper::setTenantDefaultCreateInventoryValues)
+      .toArray(CompletableFuture[]::new));
   }
 
   /**

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -213,48 +213,11 @@ public class PurchaseOrderHelper extends AbstractHelper {
     compPO.setWorkflowStatus(OPEN);
     compPO.setDateOrdered(new Date());
     return fetchCompositePoLines(compPO)
-      .thenCompose(v -> setTenantDefaultCreateInventoryValues(compPO))
       .thenCompose(v -> updateInventory(compPO))
       .thenCompose(v -> updateOrderSummary(compPO))
       .thenAccept(v -> changePoLineReceiptStatuses(compPO))
       .thenCompose(v -> updateCompositePoLines(compPO));
   }
-
-  private CompletableFuture<Void> setTenantDefaultCreateInventoryValues(CompositePurchaseOrder compPO) {
-    return updateCreateInventoryEresource(compPO)
-      .thenCompose(v -> updateCreateInventoryPhysical(compPO));
-  }
-
-  private CompletableFuture<Void> updateCreateInventoryEresource(CompositePurchaseOrder compPO) {
-    return CompletableFuture.allOf(compPO.getCompositePoLines().stream()
-      .filter(line -> line.getEresource() != null && line.getEresource().getCreateInventory() == null)
-      .map(line -> getModConfigurationByKey("CREATE_INVENTORY_ERESOURCE")
-        .thenApply(createInv -> StringUtils.isEmpty(createInv) ? Eresource.CreateInventory.INSTANCE_HOLDING : Eresource.CreateInventory.fromValue(createInv))
-        .thenAccept(createInv -> line.getEresource().setCreateInventory(createInv))
-        .exceptionally(t -> {
-          line.getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING);
-          return null;
-        }))
-      .toArray(CompletableFuture[]::new));
-  }
-
-  private CompletableFuture<Void> updateCreateInventoryPhysical(CompositePurchaseOrder compPO) {
-    return CompletableFuture.allOf(compPO.getCompositePoLines().stream()
-      .filter(line -> line.getPhysical() != null && line.getPhysical().getCreateInventory() == null)
-      .map(line -> getModConfigurationByKey("CREATE_INVENTORY_PHYSICAL")
-        .thenApply(createInv -> StringUtils.isEmpty(createInv) ? Physical.CreateInventory.INSTANCE_HOLDING_ITEM : Physical.CreateInventory.fromValue(createInv))
-        .thenAccept(createInv -> line.getPhysical().setCreateInventory(createInv))
-        .exceptionally(t -> {
-          line.getPhysical().setCreateInventory(Physical.CreateInventory.INSTANCE_HOLDING_ITEM);
-          return null;
-        }))
-      .toArray(CompletableFuture[]::new));
-  }
-
-private CompletableFuture<String> getModConfigurationByKey(String key){
-  return loadConfiguration(okapiHeaders, ctx, logger)
-    .thenApply(config -> config.getString(key));
-}
 
   /**
    * Validates purchase order content. If content is okay, checks if allowed PO Lines limit is not exceeded and validates vendors.

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -13,7 +13,6 @@ import static org.folio.orders.utils.HelperUtils.getPoLineLimit;
 import static org.folio.orders.utils.HelperUtils.getPoLines;
 import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
 import static org.folio.orders.utils.HelperUtils.handleGetRequest;
-import static org.folio.orders.utils.HelperUtils.loadConfiguration;
 import static org.folio.orders.utils.HelperUtils.operateOnObject;
 import static org.folio.orders.utils.ResourcePathResolver.PO_LINE_NUMBER;
 import static org.folio.orders.utils.ResourcePathResolver.PURCHASE_ORDER;
@@ -337,7 +336,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
   private CompletableFuture<Boolean> validatePoLineLimit(CompositePurchaseOrder compPO) {
     if (CollectionUtils.isNotEmpty(compPO.getCompositePoLines())) {
       CompletableFuture<Boolean> future = new VertxCompletableFuture<>(ctx);
-      loadConfiguration(okapiHeaders, ctx, logger)
+      getTenantConfiguration()
         .thenAccept(config -> {
           int limit = getPoLineLimit(config);
           if (compPO.getCompositePoLines().size() > limit) {

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -142,7 +142,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
       .thenCompose(v -> createPoLineSummary(compPoLine, line));
   }
 
-  private CompletableFuture<Void> setTenantDefaultCreateInventoryValues(CompositePoLine compPOL) {
+   CompletableFuture<Void> setTenantDefaultCreateInventoryValues(CompositePoLine compPOL) {
     CompletableFuture<JsonObject> future = new VertxCompletableFuture<>(ctx);
 
     if ((compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() == null)

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -110,7 +110,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
   }
 
   private CompositePurchaseOrder validateOrderState(CompositePurchaseOrder po) {
-    WorkflowStatus poStatus = po.getWorkflowStatus();
+    CompositePurchaseOrder.WorkflowStatus poStatus = po.getWorkflowStatus();
     if (poStatus != PENDING) {
       throw new HttpException(422, poStatus == OPEN ? ErrorCodes.ORDER_OPEN : ErrorCodes.ORDER_CLOSED);
     }

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -279,7 +279,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
    * @return void future
    */
   private CompletableFuture<Void> createPieces(CompositePoLine compPOL, List<Piece> expectedPiecesWithItem) {
-    int expectedItemsQuantity = isItemsUpdateRequired(compPOL) ? expectedPiecesWithItem.size() : calculateTotalQuantity(compPOL);
+    int expectedItemsQuantity = isItemsUpdateRequired(compPOL) ? expectedPiecesWithItem.size() : calculateInventoryItemsQuantity(compPOL);
 
     return searchForExistingPieces(compPOL)
       .thenCompose(existingPieces -> {

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -142,7 +142,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
       .thenCompose(v -> createPoLineSummary(compPoLine, line));
   }
 
-   CompletableFuture<Void> setTenantDefaultCreateInventoryValues(CompositePoLine compPOL) {
+  CompletableFuture<Void> setTenantDefaultCreateInventoryValues(CompositePoLine compPOL) {
     CompletableFuture<JsonObject> future = new VertxCompletableFuture<>(ctx);
 
     if ((compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() == null)
@@ -152,22 +152,24 @@ class PurchaseOrderLineHelper extends AbstractHelper {
         .exceptionally(t -> future.complete(new JsonObject()));
       return future
         .thenAccept(jsonConfig -> updateCreateInventory(compPOL, jsonConfig));
-    } else return completedFuture(null);
+    } else {
+      return completedFuture(null);
+    }
   }
 
   private void updateCreateInventory(CompositePoLine compPOL, JsonObject jsonConfig) {
     //try to set createInventory by values from mod-configuration. If empty - set default hardcoded values
     if (compPOL.getEresource() != null && compPOL.getEresource().getCreateInventory() == null) {
-      String createInventory = jsonConfig.getString(ERESOURCE);
-      Eresource.CreateInventory eresource = StringUtils.isEmpty(createInventory) ?
-        Eresource.CreateInventory.INSTANCE_HOLDING : Eresource.CreateInventory.fromValue(createInventory);
-      compPOL.getEresource().setCreateInventory(eresource);
+      String tenantDefault = jsonConfig.getString(ERESOURCE);
+      Eresource.CreateInventory eresourceDefaultValue = StringUtils.isEmpty(tenantDefault) ?
+        Eresource.CreateInventory.INSTANCE_HOLDING : Eresource.CreateInventory.fromValue(tenantDefault);
+      compPOL.getEresource().setCreateInventory(eresourceDefaultValue);
     }
     if (compPOL.getPhysical() != null && compPOL.getPhysical().getCreateInventory() == null) {
-      String createInventory = jsonConfig.getString(PHYSICAL);
-      Physical.CreateInventory physical = StringUtils.isEmpty(createInventory) ?
-        Physical.CreateInventory.INSTANCE_HOLDING_ITEM : Physical.CreateInventory.fromValue(createInventory);
-      compPOL.getPhysical().setCreateInventory(physical);
+      String tenantDefault = jsonConfig.getString(PHYSICAL);
+      Physical.CreateInventory createInventoryDefaultValue = StringUtils.isEmpty(tenantDefault) ?
+        Physical.CreateInventory.INSTANCE_HOLDING_ITEM : Physical.CreateInventory.fromValue(tenantDefault);
+      compPOL.getPhysical().setCreateInventory(createInventoryDefaultValue);
     }
   }
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -592,7 +592,7 @@ public class OrdersImplTest {
     // Make sure that mock PO has 2 po lines
     assertEquals(2, reqData.getCompositePoLines().size());
 
-    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE);
+    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
     List<JsonObject> items = joinExistingAndNewItems();
@@ -1170,9 +1170,9 @@ public class OrdersImplTest {
     assertEquals(2, reqData.getCompositePoLines().size());
 
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
-    // MODORDERS-178 guarantee electronic resource for the second PO Line but set "create items" to INSTANCE
+    // MODORDERS-178 guarantee electronic resource for the second PO Line but set "create items" to NONE
     reqData.getCompositePoLines().get(1).setOrderFormat(CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE);
-    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE);
+    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
     reqData.getCompositePoLines().forEach(s -> s.setReceiptStatus(CompositePoLine.ReceiptStatus.PENDING));
 
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1870,7 +1870,6 @@ public class OrdersImplTest {
 
     // Verify pieces were created
     assertEquals(calculateTotalQuantity(reqData.getCompositePoLines().get(0)), createdPieces.size());
-
     verifyPiecesCreated(items, reqData.getCompositePoLines().subList(0, 1), createdPieces);
   }
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1576,9 +1576,6 @@ public class OrdersImplTest {
 
     // Verify that not all expected items created
     assertThat(items.size(), lessThan(calculateInventoryItemsQuantity(reqData.getCompositePoLines().get(0))));
-
-    // Verify that pieces created for processed items quantity
-    verifyPiecesCreated(items, reqData.getCompositePoLines().subList(0, 1), createdPieces);
   }
 
   private void verifyInstanceLinksForUpdatedOrder(CompositePurchaseOrder reqData) {
@@ -1706,9 +1703,10 @@ public class OrdersImplTest {
                                     .collect(Collectors.toList());
 
     // Verify quantity of created pieces
-    int expectedPiecesQuantity = itemIds.size();
+    int expectedPiecesQuantity = 0;
     for (CompositePoLine poLine : compositePoLines) {
       expectedPiecesQuantity += HelperUtils.calculateExpectedQuantityOfPiecesWithoutItemCreation(poLine, poLine.getLocations());
+      expectedPiecesQuantity += HelperUtils.calculateInventoryItemsQuantity(poLine, poLine.getLocations());
     }
     assertEquals(expectedPiecesQuantity, pieces.size());
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1363,7 +1363,7 @@ public class OrdersImplTest {
     List<JsonObject> createdPieces = MockServer.serverRqRs.get(PIECES, HttpMethod.POST);
 
     assertNotNull(instancesSearches);
-    assertNull(holdingsSearches);
+    assertNotNull(holdingsSearches);
     assertNull(itemsSearches);
     assertNull(createdPieces);
   }
@@ -1705,6 +1705,7 @@ public class OrdersImplTest {
     // Verify quantity of created pieces
     int expectedPiecesQuantity = 0;
     for (CompositePoLine poLine : compositePoLines) {
+      if (poLine.getCheckinItems() != null && poLine.getCheckinItems()) continue;
       expectedPiecesQuantity += HelperUtils.calculateExpectedQuantityOfPiecesWithoutItemCreation(poLine, poLine.getLocations());
       expectedPiecesQuantity += HelperUtils.calculateInventoryItemsQuantity(poLine, poLine.getLocations());
     }

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1870,6 +1870,7 @@ public class OrdersImplTest {
 
     // Verify pieces were created
     assertEquals(calculateTotalQuantity(reqData.getCompositePoLines().get(0)), createdPieces.size());
+
     verifyPiecesCreated(items, reqData.getCompositePoLines().subList(0, 1), createdPieces);
   }
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -566,7 +566,7 @@ public class OrdersImplTest {
 
     CompositePoLine compositePoLine = reqData.getCompositePoLines().get(0);
 
-    compositePoLine.getEresource().setCreateInventory(false);
+    compositePoLine.getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE);
     compositePoLine.getCost().setQuantityPhysical(3);
     compositePoLine.getCost().setQuantityElectronic(2);
     compositePoLine.setOrderFormat(OrderFormat.P_E_MIX);
@@ -592,7 +592,7 @@ public class OrdersImplTest {
     // Make sure that mock PO has 2 po lines
     assertEquals(2, reqData.getCompositePoLines().size());
 
-    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(false);
+    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
     List<JsonObject> items = joinExistingAndNewItems();
@@ -1170,9 +1170,9 @@ public class OrdersImplTest {
     assertEquals(2, reqData.getCompositePoLines().size());
 
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
-    // MODORDERS-117 guarantee electronic resource for the second PO Line but set "create items" to false
+    // MODORDERS-178 guarantee electronic resource for the second PO Line but set "create items" to INSTANCE
     reqData.getCompositePoLines().get(1).setOrderFormat(CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE);
-    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(false);
+    reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE);
     reqData.getCompositePoLines().forEach(s -> s.setReceiptStatus(CompositePoLine.ReceiptStatus.PENDING));
 
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -3608,16 +3608,16 @@ public class OrdersImplTest {
       JsonObject body = new JsonObject();
 
       try {
-        if(getQuery(ACTIVE_ACCESS_PROVIDER_A, NON_EXIST_ACCESS_PROVIDER_A).equals(query)) {
+        if (getQuery(ACTIVE_ACCESS_PROVIDER_A, NON_EXIST_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "one_access_provider_not_found.json"));
-        }  else if(getQuery(ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_B).equals(query)
+        } else if (getQuery(ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_B).equals(query)
           || getQuery(ACTIVE_ACCESS_PROVIDER_A, ACTIVE_ACCESS_PROVIDER_A).equals(query)
           || getQuery(ACTIVE_ACCESS_PROVIDER_B, ACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "all_access_providers_active.json"));
-        } else if(getQuery(ACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_A).equals(query)) {
+        } else if (getQuery(ACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "active_inactive_access_providers.json"));
-        } else if(getQuery(INACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_B).equals(query)
-        || getQuery(INACTIVE_ACCESS_PROVIDER_B, INACTIVE_ACCESS_PROVIDER_A).equals(query)) {
+        } else if (getQuery(INACTIVE_ACCESS_PROVIDER_A, INACTIVE_ACCESS_PROVIDER_B).equals(query)
+          || getQuery(INACTIVE_ACCESS_PROVIDER_B, INACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "all_inactive_access_providers.json"));
         } else if (getQuery(ACTIVE_ACCESS_PROVIDER_A).equals(query)) {
           body = new JsonObject(getMockData(VENDORS_MOCK_DATA_PATH + "one_access_provider_not_found.json"));

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -30,7 +30,13 @@ import static org.folio.orders.utils.ErrorCodes.POL_LINES_LIMIT_EXCEEDED;
 import static org.folio.orders.utils.ErrorCodes.ZERO_COST_ELECTRONIC_QTY;
 import static org.folio.orders.utils.ErrorCodes.ZERO_COST_PHYSICAL_QTY;
 import static org.folio.orders.utils.ErrorCodes.ZERO_COST_QTY;
-import static org.folio.orders.utils.HelperUtils.*;
+import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
+import static org.folio.orders.utils.HelperUtils.calculateEstimatedPrice;
+import static org.folio.orders.utils.HelperUtils.calculateTotalQuantity;
+import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
+import static org.folio.orders.utils.HelperUtils.convertIdsToCqlQuery;
+import static org.folio.orders.utils.HelperUtils.groupLocationsById;
 import static org.folio.orders.utils.ResourcePathResolver.*;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
@@ -1375,7 +1381,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
 
     verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
     List<JsonObject> instancesSearches = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.GET);
     List<JsonObject> holdingsSearches = MockServer.serverRqRs.get(HOLDINGS_RECORD, HttpMethod.GET);
@@ -1401,7 +1407,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE);
 
     verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
     List<JsonObject> instancesSearches = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.GET);
     List<JsonObject> holdingsSearches = MockServer.serverRqRs.get(HOLDINGS_RECORD, HttpMethod.GET);
@@ -1427,7 +1433,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING);
 
     verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
     List<JsonObject> instancesSearches = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.GET);
     List<JsonObject> holdingsSearches = MockServer.serverRqRs.get(HOLDINGS_RECORD, HttpMethod.GET);
@@ -1453,7 +1459,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
 
     verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
     List<JsonObject> instancesSearches = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.GET);
     List<JsonObject> holdingsSearches = MockServer.serverRqRs.get(HOLDINGS_RECORD, HttpMethod.GET);
@@ -1479,7 +1485,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(null);
 
     final CompositePurchaseOrder resp = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-      EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
     List<JsonObject> instancesSearches = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.GET);
     List<JsonObject> holdingsSearches = MockServer.serverRqRs.get(HOLDINGS_RECORD, HttpMethod.GET);

--- a/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -84,6 +84,7 @@
   "owner": "Acquisitions - Serials",
   "paymentStatus": "Pending",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "materialSupplier": "6828d7cb-d84e-41e5-9db5-fc2e162f9ffb",
     "receiptDue": "2018-07-31T00:00:00.000Z",
     "volumes": []

--- a/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/compositeLines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -55,7 +55,7 @@
   "eresource": {
     "activated": false,
     "activationDue": 0,
-    "createInventory": false,
+    "createInventory": "Instance",
     "trial": false,
     "expectedActivation": null,
     "userLimit": 0,

--- a/src/test/resources/mockdata/compositeLines/2bafc9e1-9dd3-4ede-9f23-c4a03f8bb2d5.json
+++ b/src/test/resources/mockdata/compositeLines/2bafc9e1-9dd3-4ede-9f23-c4a03f8bb2d5.json
@@ -35,6 +35,7 @@
   "orderFormat": "Physical Resource",
   "paymentStatus": "Fully Paid",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "volumes": [
       "vol.1"
     ],

--- a/src/test/resources/mockdata/compositeLines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
+++ b/src/test/resources/mockdata/compositeLines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
@@ -59,7 +59,7 @@
   "eresource": {
     "activated": false,
     "activationDue": 10,
-    "createInventory": true,
+    "createInventory": "Instance, Holding, Item",
     "trial": false,
     "expectedActivation": "2018-10-09T00:00:00.000Z",
     "userLimit": 10,

--- a/src/test/resources/mockdata/compositeLines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
+++ b/src/test/resources/mockdata/compositeLines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
@@ -92,6 +92,7 @@
   "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "paymentStatus": "Awaiting Payment",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "volumes": [
       "vol. 1"
     ],

--- a/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -84,6 +84,7 @@
   "owner": "LTS E-Resources & Serials",
   "paymentStatus": "Awaiting Payment",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "materialSupplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
     "receiptDue": null,
     "volumes": []

--- a/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/compositeLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -55,7 +55,7 @@
   "eresource": {
     "activated": true,
     "activation_due": 0,
-    "createInventory": false,
+    "createInventory": "Instance",
     "trial": false,
     "expectedActivation": "2014-07-06T00:00:00.000Z",
     "userLimit": 1,

--- a/src/test/resources/mockdata/compositeLines/f7223ce8-9e92-4c28-8fd9-097596053b7c.json
+++ b/src/test/resources/mockdata/compositeLines/f7223ce8-9e92-4c28-8fd9-097596053b7c.json
@@ -49,7 +49,7 @@
   "eresource" : {
     "activated" : false,
     "activationDue" : 10,
-    "createInventory" : true,
+    "createInventory" : "Instance, Holding, Item",
     "trial" : false,
     "expectedActivation" : "2018-10-09T00:00:00.000+0000",
     "userLimit" : 10,

--- a/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
+++ b/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
@@ -55,7 +55,7 @@
   "eresource": {
     "activated": false,
     "activationDue": 0,
-    "createInventory": false,
+    "createInventory": "Instance",
     "trial": false,
     "expectedActivation": null,
     "userLimit": 0,

--- a/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
+++ b/src/test/resources/mockdata/compositeLines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
@@ -84,6 +84,7 @@
   "owner": "LTS Acquisitions",
   "paymentStatus": "Awaiting Payment",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "materialSupplier": "1c9a6406-dc14-46cc-8777-5199d791c21f",
     "receiptDue": "2018-09-29T00:00:00.000Z",
     "volumes": [

--- a/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -119,6 +119,7 @@
       "owner": "Technical Services Department",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "materialSupplier": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd8",
         "receiptDue": null,
         "volumes": []

--- a/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
+++ b/src/test/resources/mockdata/compositeOrders/07f65192-44a4-483d-97aa-b137bbd96390.json
@@ -90,7 +90,7 @@
       "eresource": {
         "activated": true,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": "2019-01-01T00:00:00.000Z",
         "userLimit": 0,

--- a/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
+++ b/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
@@ -83,7 +83,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,
@@ -202,7 +202,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,
@@ -321,7 +321,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,

--- a/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
+++ b/src/test/resources/mockdata/compositeOrders/1ab7ef6a-d1d4-4a4f-90a2-882aed18af14.json
@@ -112,6 +112,7 @@
       "owner": "LTS Acquisitions",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "materialSupplier": "",
         "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": [
@@ -231,6 +232,7 @@
       "owner": "LTS Acquisitions",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "materialSupplier": "",
         "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": [
@@ -350,6 +352,7 @@
       "owner": "LTS Acquisitions",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "materialSupplier": "",
         "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": [

--- a/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
+++ b/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
@@ -68,7 +68,7 @@
       "eresource": {
         "activated": true,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": "2014-07-06T00:00:00.000Z",
         "userLimit": 1,

--- a/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
+++ b/src/test/resources/mockdata/compositeOrders/bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa.json
@@ -97,6 +97,7 @@
       "owner": "LTS E-Resources & Serials",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "materialSupplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
         "receiptDue": null,
         "volumes": []

--- a/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -90,7 +90,7 @@
       "physical": {
         "createInventory": "Instance, Holding, Item",
         "materialSupplier": "36dd6d62-c55e-4b19-a3a0-a870da57610a",
-        "receiptDue": null,
+        "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": []
       },
       "poLineDescription": "",

--- a/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -83,7 +83,7 @@
       "eresource": {
         "activated": true,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": "2014-07-06T00:00:00.000Z",
         "userLimit": 1,

--- a/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
+++ b/src/test/resources/mockdata/compositeOrders/e5ae4afd-3fa9-494e-a972-f541df9b877e.json
@@ -112,6 +112,7 @@
       "owner": "LTS E-Resources & Serials",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "materialSupplier": "36dd6d62-c55e-4b19-a3a0-a870da57610a",
         "receiptDue": null,
         "volumes": []

--- a/src/test/resources/mockdata/configurations.entries/test_diku_limit_10.json
+++ b/src/test/resources/mockdata/configurations.entries/test_diku_limit_10.json
@@ -12,11 +12,27 @@
         "updatedDate": "2018-12-12T08:24:34.213+0000",
         "updatedByUserId": "d16d7615-ad6b-5a57-9cb4-62aca2ba764c"
       }
+    },
+    {
+      "id": "d16d7615-ad6b-5a57-9cb4-62aca2ba764c",
+      "module": "ORDERS",
+      "configName": "createInventory",
+      "enabled": true,
+      "value": {
+        "physical" : "Instance, Holding, Item",
+        "eresource" : "Instance, Holding"
+      },
+      "metadata": {
+        "createdDate": "2018-12-12T08:14:32.743+0000",
+        "createdByUserId": "d16d7615-ad6b-5a57-9cb4-62aca2ba764c",
+        "updatedDate": "2018-12-12T08:24:34.213+0000",
+        "updatedByUserId": "d16d7615-ad6b-5a57-9cb4-62aca2ba764c"
+      }
     }
   ],
-  "totalRecords": 1,
+  "totalRecords": 2,
   "resultInfo": {
-    "totalRecords": 1,
+    "totalRecords": 2,
     "facets": [],
     "diagnostics": []
   }

--- a/src/test/resources/mockdata/lines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/lines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -49,7 +49,7 @@
     "accessProvider": "ba3f3d45-247d-41f6-8dc9-6488adcad329",
     "activated": false,
     "activationDue": 10,
-    "createInventory": true,
+    "createInventory": "Instance, Holding, Item",
     "expectedActivation": "2018-10-09T00:00:00.000Z",
     "license": {
       "code": "Code 1",

--- a/src/test/resources/mockdata/lines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/lines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -83,6 +83,7 @@
   "owner" : "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "paymentStatus" : "Awaiting Payment",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "volumes": [
       "vol. 1"
     ],

--- a/src/test/resources/mockdata/lines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
+++ b/src/test/resources/mockdata/lines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
@@ -87,6 +87,7 @@
   "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "paymentStatus": "Awaiting Payment",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "volumes": [
       "vol. 1"
     ],

--- a/src/test/resources/mockdata/lines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
+++ b/src/test/resources/mockdata/lines/c0d08448-347b-418a-8c2f-5fb50248d67e.json
@@ -58,7 +58,7 @@
   "eresource": {
     "activated": false,
     "activationDue": 10,
-    "createInventory": false,
+    "createInventory": "Instance",
     "trial": false,
     "expectedActivation": "2018-10-09T00:00:00.000Z",
     "userLimit": 10,

--- a/src/test/resources/mockdata/lines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/lines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -77,6 +77,7 @@
   "owner" : "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "paymentStatus" : "Awaiting Payment",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "volumes": [
       "vol. 1"
     ],

--- a/src/test/resources/mockdata/lines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/lines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -48,7 +48,7 @@
   "eresource": {
     "activated": false,
     "activationDue": 10,
-    "createInventory": true,
+    "createInventory": "Instance, Holding, Item",
     "trial": false,
     "expectedActivation": "2018-10-09T00:00:00.000Z",
     "userLimit": 10,

--- a/src/test/resources/mockdata/lines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
+++ b/src/test/resources/mockdata/lines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
@@ -55,7 +55,7 @@
     "accessProvider": "ba3f3d45-247d-41f6-8dc9-6488adcad329",
     "activated": false,
     "activationDue": 10,
-    "createInventory": true,
+    "createInventory": "Instance, Holding, Item",
     "expectedActivation": "2018-10-09T00:00:00.000Z",
     "license": {
       "code": "Code 1",

--- a/src/test/resources/mockdata/lines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
+++ b/src/test/resources/mockdata/lines/fca5fa9e-15cb-4a3d-ab09-eeea99b97a47.json
@@ -89,6 +89,7 @@
   "owner" : "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "paymentStatus" : "Awaiting Payment",
   "physical": {
+    "createInventory": "Instance, Holding, Item",
     "volumes": [
       "vol. 1"
     ],

--- a/src/test/resources/mockdata/lines/po_line_collection.json
+++ b/src/test/resources/mockdata/lines/po_line_collection.json
@@ -64,7 +64,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 10,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": "2018-10-09T00:00:00.000Z",
         "userLimit": 10,
@@ -203,7 +203,7 @@
         "accessProvider": "ba3f3d45-247d-41f6-8dc9-6488adcad329",
         "activated": false,
         "activationDue": 10,
-        "createInventory": true,
+        "createInventory": "Instance, Holding, Item",
         "expectedActivation": "2018-10-09T00:00:00.000Z",
         "license": {
           "code": "Code 1",
@@ -470,7 +470,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,
@@ -562,7 +562,7 @@
         "accessProvider": "ba3f3d45-247d-41f6-8dc9-6488adcad329",
         "activated": false,
         "activationDue": 10,
-        "createInventory": true,
+        "createInventory": "Instance, Holding, Item",
         "expectedActivation": "2018-10-09T00:00:00.000Z",
         "license": {
           "code": "Code 1",
@@ -705,7 +705,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 10,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": "2018-10-09T00:00:00.000Z",
         "userLimit": 10,

--- a/src/test/resources/mockdata/lines/po_line_collection.json
+++ b/src/test/resources/mockdata/lines/po_line_collection.json
@@ -715,7 +715,7 @@
                "accessProvider": "ba3f3d45-247d-41f6-8dc9-6488adcad329",
                "activated": false,
                "activationDue": 10,
-               "createInventory": false,
+               "createInventory": "Instance",
                "expectedActivation": "2018-10-09T00:00:00.000Z",
                "license": {
                    "code": "Code 1",

--- a/src/test/resources/mockdata/lines/po_line_collection.json
+++ b/src/test/resources/mockdata/lines/po_line_collection.json
@@ -93,6 +93,7 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol. 1"
         ],
@@ -237,6 +238,7 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol. 1"
         ],
@@ -332,6 +334,7 @@
       "orderFormat": "Physical Resource",
       "paymentStatus": "Fully Paid",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol. 1"
         ],
@@ -408,6 +411,7 @@
       "orderFormat": "Physical Resource",
       "paymentStatus": "Fully Paid",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol. 1"
         ],
@@ -492,6 +496,7 @@
       "orderFormat": "Electronic Resource",
       "paymentStatus": "Fully Paid",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol. 1"
         ],
@@ -607,6 +612,7 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol. 1"
         ],

--- a/src/test/resources/mockdata/vendors/one_access_providers_active.json
+++ b/src/test/resources/mockdata/vendors/one_access_providers_active.json
@@ -1,0 +1,170 @@
+{
+  "vendors": [
+     {
+      "id": "d1b79c8d-4950-482f-8e42-04f9aae3cb40",
+      "name": "Jean Simmons",
+      "code": "SJEAN",
+      "description": "Individual donor to library archives",
+      "vendor_status": "Active",
+      "language": "en-us",
+      "aliases": [
+        {
+          "value": "Sister Jean",
+          "description": ""
+        }
+      ],
+      "addresses": [
+        {
+          "addressLine1": "1032 W. Sheridan Rd",
+          "addressLine2": "",
+          "city": "Chicago",
+          "stateRegion": "IL",
+          "zipCode": "60660",
+          "country": "USA",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "phone_number": "1-773-274-3000",
+          "categories": [],
+          "types": [],
+          "isPrimary": true,
+          "language": "English"
+        }
+      ],
+      "emails": [
+        {
+          "value": "sister@luc.edu",
+          "description": "personal email ",
+          "isPrimary": true,
+          "categories": [],
+          "language": "English"
+        }
+      ],
+      "urls": [
+        {
+          "value": "",
+          "description": "",
+          "language": "",
+          "isPrimary": true,
+          "categories": [],
+          "notes": ""
+        }
+      ],
+      "contacts": [
+        {
+          "prefix": "Sister",
+          "first_name": "Jean",
+          "last_name": "Simmons",
+          "language": "English",
+          "notes": "",
+          "phone_numbers": [
+            {
+              "phone_number": "1-773-274-3000",
+              "categories": [],
+              "types": [],
+              "isPrimary": true,
+              "language": "English"
+            }
+          ],
+          "emails": [
+            {
+              "value": "sister@luc.edu",
+              "description": "personal email ",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "addresses": [
+            {
+              "addressLine1": "1032 W. Sheridan Rd",
+              "addressLine2": "",
+              "city": "Chicago",
+              "stateRegion": "IL",
+              "zipCode": "60660",
+              "country": "USA",
+              "isPrimary": true,
+              "categories": [],
+              "language": "English"
+            }
+          ],
+          "urls": [
+            {
+              "value": "",
+              "description": "",
+              "language": "",
+              "isPrimary": true,
+              "categories": [],
+              "notes": ""
+            }
+          ],
+          "categories": []
+        }
+      ],
+      "agreements": [],
+      "erp_code": "G64758-74830",
+      "payment_method": "check",
+      "access_provider": false,
+      "governmental": false,
+      "licensor": false,
+      "material_supplier": true,
+      "vendor_currencies": [
+        "USD"
+      ],
+      "claiming_interval": 0,
+      "discount_percent": 0,
+      "expected_activation_interval": 0,
+      "expected_invoice_interval": 0,
+      "renewal_activation_interval": 0,
+      "subscription_interval": 0,
+      "expected_receipt_interval": 30,
+      "tax_id": "",
+      "liable_for_vat": false,
+      "tax_percentage": 0,
+      "interfaces": [
+        {
+          "name": "",
+          "uri": "",
+          "username": "",
+          "password": "",
+          "notes": "",
+          "available": false,
+          "delivery_method": "",
+          "statistics_format": "",
+          "locally_stored": "",
+          "online_location": "",
+          "statistics_notes": ""
+        }
+      ],
+      "accounts": [
+        {
+          "name": "SJean account",
+          "account_no": "1234",
+          "description": "Donor account",
+          "app_system_no": "",
+          "payment_method": "check",
+          "account_status": "Active",
+          "contact_info": "sister@luc.edu",
+          "library_code": "COB",
+          "library_edi_code": "765987610",
+          "notes": ""
+        }
+      ],
+      "vendor_types": [],
+      "san_code": "",
+      "changelogs": [
+        {
+          "description": "This is a sample note.",
+          "timestamp": "2008-05-15T10:53:00.000+0000"
+        }
+      ]
+    }
+  ],
+  "total_records": 1,
+  "first": 1,
+  "last": 1
+}

--- a/src/test/resources/po_listed_electronic_monograph.json
+++ b/src/test/resources/po_listed_electronic_monograph.json
@@ -93,7 +93,7 @@
         "id": "468b679c-378b-4009-9a17-a6711cefc85f",
         "activated": false,
         "activationDue": 10,
-        "createInventory": true,
+        "createInventory": "Instance, Holding, Item",
         "trial": false,
         "expectedActivation": "2018-10-09T00:00:00.000Z",
         "userLimit": 10,

--- a/src/test/resources/po_listed_print_monograph.json
+++ b/src/test/resources/po_listed_print_monograph.json
@@ -89,7 +89,7 @@
       "donor": "ABCDEFGHIJKLM",
       "eresource": {
         "accessProvider": "858e80d2-f562-4c54-9934-6e274dee511d",
-        "createInventory": true
+        "createInventory": "Instance, Holding, Item"
       },
       "fundDistribution": [
         {
@@ -238,7 +238,7 @@
       "donor": "",
       "eresource": {
         "accessProvider": "d1b79c8d-4950-482f-8e42-04f9aae3cb40",
-        "createInventory": true
+        "createInventory": "Instance, Holding, Item"
       },
       "fundDistribution": [
         {

--- a/src/test/resources/po_listed_print_monograph.json
+++ b/src/test/resources/po_listed_print_monograph.json
@@ -127,6 +127,7 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol.1"
         ],

--- a/src/test/resources/po_listed_print_monograph_pe_mix.json
+++ b/src/test/resources/po_listed_print_monograph_pe_mix.json
@@ -108,6 +108,14 @@
       "orderFormat": "P/E Mix",
       "owner": "LTS E-Resources & Serials",
       "paymentStatus": "Awaiting Payment",
+      "physical": {
+        "createInventory": "Instance, Holding, Item",
+        "volumes": [
+          "vol.1"
+        ],
+        "materialSupplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
+        "receiptDue": "2018-10-10T00:00:00.000Z"
+      },
       "poLineDescription": "",
       "publicationDate": "2017",
       "publisher": "John Wiley & Sons, Inc.",

--- a/src/test/resources/po_listed_print_monograph_pe_mix.json
+++ b/src/test/resources/po_listed_print_monograph_pe_mix.json
@@ -82,7 +82,7 @@
       },
       "donor": "",
       "eresource": {
-        "createInventory": false
+        "createInventory": "Instance"
       },
       "fundDistribution": [
         {

--- a/src/test/resources/po_listed_print_serial.json
+++ b/src/test/resources/po_listed_print_serial.json
@@ -114,6 +114,7 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol.1"
         ],

--- a/src/test/resources/po_listed_print_serial.json
+++ b/src/test/resources/po_listed_print_serial.json
@@ -75,7 +75,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "None",
         "trial": false,
         "userLimit": 10,
         "accessProvider": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1"

--- a/src/test/resources/po_one_physical_one_electronic_lines.json
+++ b/src/test/resources/po_one_physical_one_electronic_lines.json
@@ -52,6 +52,7 @@
       "orderFormat": "Physical Resource",
       "paymentStatus": "Fully Paid",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol.1"
         ],

--- a/src/test/resources/po_one_physical_one_electronic_lines.json
+++ b/src/test/resources/po_one_physical_one_electronic_lines.json
@@ -94,7 +94,7 @@
       },
       "eresource": {
         "accessProvider": "8be1cd0a-acab-488d-b650-65ceb96aa148",
-        "createInventory": false
+        "createInventory": "Instance"
       },
       "locations": [
         {

--- a/src/test/resources/print_monograph_for_create_inventory_test.json
+++ b/src/test/resources/print_monograph_for_create_inventory_test.json
@@ -1,0 +1,174 @@
+{
+  "adjustment": {
+    "credit": 0.0,
+    "discount": 0.0,
+    "insurance": 0.0,
+    "overhead": 0.0,
+    "shipment": 0.0,
+    "tax1": 0.0,
+    "tax2": 0.0,
+    "useProRate": false
+  },
+  "approved": true,
+  "assignedTo": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "notes": [
+    "ABCDEFGHIJKLMNO",
+    "ABCDEFGHIJKLMNOPQRST",
+    "ABCDEFGHIJKLMNOPQRSTUV"
+  ],
+  "orderType": "One-Time",
+  "poNumber": "2687001",
+  "reEncumber": false,
+  "totalEstimatedPrice": 300.00,
+  "totalItems": 4,
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "workflowStatus": "Pending",
+  "metadata": {
+    "createdDate": "2010-10-08T03:53:00.000",
+    "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
+  },
+  "compositePoLines": [
+    {
+      "acquisitionMethod": "Purchase At Vendor System",
+      "adjustment": {
+        "credit": 0.0,
+        "discount": 0.0,
+        "insurance": 0.0,
+        "invoiceId": "2d6d495c-c237-476f-aa48-57f7cbf74ca4",
+        "overhead": 0.0,
+        "shipment": 0.0,
+        "tax1": 0.0,
+        "tax2": 0.0,
+        "useProRate": false
+      },
+      "alerts": [
+        {
+          "alert": "Receipt overdue"
+        }
+      ],
+      "cancellationRestriction": false,
+      "cancellationRestrictionNote": "ABCDEFGHIJKLMNOPQRSTUVW",
+      "claims": [
+        {
+          "claimed": false,
+          "sent": "2018-10-09T00:00:00.000Z",
+          "grace": 30
+        }
+      ],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Ed Mashburn",
+          "contributorType": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+        }
+      ],
+      "cost": {
+        "listPrice": 20.00,
+        "currency": "USD",
+        "quantityPhysical": 1,
+        "quantityElectronic": 1,
+        "poLineEstimatedPrice": 40.00
+      },
+      "description": "ABCDEFGH",
+      "details": {
+        "receivingNote": "ABCDEFGHIJKL",
+        "productIds": [
+          {
+            "productId": "9780764354101",
+            "productIdType": "ISBN"
+          }
+        ],
+        "materialTypes": [
+          "1a54b431-2e4f-452d-9cae-9cee66c9a892"
+        ],
+        "subscriptionFrom": "2018-10-09T00:00:00.000Z",
+        "subscriptionInterval": 824,
+        "subscriptionTo": "2020-10-09T00:00:00.000Z"
+      },
+      "donor": "ABCDEFGHIJKLM",
+      "eresource": {
+        "accessProvider": "858e80d2-f562-4c54-9934-6e274dee511d",
+        "createInventory": "Instance, Holding, Item"
+      },
+      "fundDistribution": [
+        {
+          "code": "HIST",
+          "percentage": 80.0,
+          "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3"
+        },
+        {
+          "code": "GENRL",
+          "percentage": 20.0,
+          "encumbrance": "0466cb77-0344-43c6-85eb-0a64aa2934e5"
+        }
+      ],
+      "locations": [
+        {
+          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "quantity": 2,
+          "quantityElectronic": 1,
+          "quantityPhysical": 1
+        }
+      ],
+      "orderFormat": "P/E Mix",
+      "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
+      "paymentStatus": "Awaiting Payment",
+      "physical": {
+        "createInventory": "Instance, Holding, Item",
+        "volumes": [
+          "vol.1"
+        ],
+        "materialSupplier": "73d14bc5-d131-48c6-b380-f8e62f63c8b6",
+        "receiptDue": "2018-10-10T00:00:00.000Z"
+      },
+      "poLineDescription": "ABCDEFGHIJKLMNOPQRSTUVWXY",
+      "poLineNumber": "268758-03",
+      "publicationDate": "2017",
+      "publisher": "Schiffer Publishing",
+      "receiptDate": "2018-10-09T00:00:00.000Z",
+      "receiptStatus": "Pending",
+      "reportingCodes": [
+        {
+          "code": "CODE1",
+          "id": "5926dcd7-85f5-4504-8283-712595ebc38b",
+          "description": "ABCDEF"
+        },
+        {
+          "code": "CODE2",
+          "id": "fa316c04-8101-4e72-8aaf-01281bac718f",
+          "description": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        },
+        {
+          "code": "CODE3",
+          "id": "ea68b696-3125-4940-bf91-1d128323473e",
+          "description": "ABCDE"
+        }
+      ],
+      "requester": "Leo Bulero",
+      "rush": true,
+      "selector": "ABCD",
+      "source": {
+        "code": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
+        "description": "ABCDEFGHIJKLMNO"
+      },
+      "tags": [
+        "ABCDEFGHIJKLMNOPQRSTU",
+        "ABCDEFG",
+        "ABCDEFGHIJKLMNOPQRSTU",
+        "ABCDEFGHIJKLMNO"
+      ],
+      "title": "Kayak Fishing in the Northern Gulf Coast",
+      "vendorDetail": {
+        "instructions": "ABCDEFG",
+        "noteFromVendor": "ABCDEFGHIKJKLMNOP",
+        "refNumber": "123456-78",
+        "refNumberType": "Supplier's unique order line reference number",
+        "vendorAccount": "8910-10"
+      },
+      "metadata": {
+        "createdDate": "2010-10-08T03:53:00.000",
+        "createdByUserId": "ab18897b-0e40-4f31-896b-9c9adc979a88"
+      }
+    }
+  ]
+}

--- a/src/test/resources/print_monograph_for_create_inventory_test.json
+++ b/src/test/resources/print_monograph_for_create_inventory_test.json
@@ -1,14 +1,4 @@
 {
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "approved": true,
   "assignedTo": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "notes": [
@@ -21,7 +11,7 @@
   "reEncumber": false,
   "totalEstimatedPrice": 300.00,
   "totalItems": 4,
-  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
   "metadata": {
     "createdDate": "2010-10-08T03:53:00.000",
@@ -30,17 +20,6 @@
   "compositePoLines": [
     {
       "acquisitionMethod": "Purchase At Vendor System",
-      "adjustment": {
-        "credit": 0.0,
-        "discount": 0.0,
-        "insurance": 0.0,
-        "invoiceId": "2d6d495c-c237-476f-aa48-57f7cbf74ca4",
-        "overhead": 0.0,
-        "shipment": 0.0,
-        "tax1": 0.0,
-        "tax2": 0.0,
-        "useProRate": false
-      },
       "alerts": [
         {
           "alert": "Receipt overdue"
@@ -63,11 +42,11 @@
         }
       ],
       "cost": {
-        "listPrice": 20.00,
         "currency": "USD",
-        "quantityPhysical": 1,
+        "listUnitPrice": 24.99,
+        "listUnitPriceElectronic": 22.99,
         "quantityElectronic": 1,
-        "poLineEstimatedPrice": 40.00
+        "quantityPhysical": 1
       },
       "description": "ABCDEFGH",
       "details": {

--- a/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
+++ b/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
@@ -329,7 +329,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "None",
         "trial": false,
         "userLimit": 10,
         "accessProvider": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1"

--- a/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
+++ b/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
@@ -75,6 +75,7 @@
       "owner": "LTS Acquisitions",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": [
           "vol. 1"
@@ -178,6 +179,7 @@
       "owner": "LTS Acquisitions",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": [
           "vol. 1"
@@ -286,6 +288,7 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol.1"
         ],

--- a/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
+++ b/src/test/resources/put_order_with_mismatch_id_in_po_lines.json
@@ -47,7 +47,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,
@@ -154,7 +154,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,

--- a/src/test/resources/put_order_with_po_lines.json
+++ b/src/test/resources/put_order_with_po_lines.json
@@ -71,6 +71,7 @@
       "owner": "LTS Acquisitions",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": [
           "vol. 1"
@@ -174,6 +175,7 @@
       "owner": "LTS Acquisitions",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "receiptDue": "2018-09-29T00:00:00.000Z",
         "volumes": [
           "vol. 1"
@@ -283,6 +285,7 @@
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "paymentStatus": "Awaiting Payment",
       "physical": {
+        "createInventory": "Instance, Holding, Item",
         "volumes": [
           "vol.1"
         ],

--- a/src/test/resources/put_order_with_po_lines.json
+++ b/src/test/resources/put_order_with_po_lines.json
@@ -47,7 +47,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,
@@ -150,7 +150,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "Instance",
         "trial": false,
         "expectedActivation": null,
         "userLimit": 0,

--- a/src/test/resources/put_order_with_po_lines.json
+++ b/src/test/resources/put_order_with_po_lines.json
@@ -326,7 +326,7 @@
       "eresource": {
         "activated": false,
         "activationDue": 0,
-        "createInventory": false,
+        "createInventory": "None",
         "trial": false,
         "userLimit": 10,
         "accessProvider": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1"


### PR DESCRIPTION


## Purpose
https://issues.folio.org/browse/MODORDERS-178
https://issues.folio.org/browse/MODORDERS-179


## Approach
* Updating `physical.json` and `eresource.json` schemas by updating acq-models submodule
* Implement creation of inventory objects based on resource createInventory values
* Implementing loading default createInventory values from mod-configuration. In case of empty configuration set hardcoded values (MODORDERS-179)
* Implementing unit tests for both stories

#### TODOS and Open Questions
* As for PR contains breaking changes, firstly PR https://github.com/folio-org/acq-models/pull/102 should be merged and acq-model submodule updated. Also PR for the story https://issues.folio.org/browse/UIOR-148 should be merged in the same day.


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
