### PR TITLE
MODORDERS-197 Allow 0.0 for unit price in Cost for Orders

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -355,18 +355,19 @@ public class HelperUtils {
   }
 
   private static void validateCostPrices(Cost cost, CompositePoLine.OrderFormat orderFormat, List<ErrorCodes> errors) {
-    double unitPrice = defaultIfNull(cost.getListUnitPrice(), 0d);
+    // Using default value as -1 to avoid null checks
+    double unitPrice = defaultIfNull(cost.getListUnitPrice(), -1d);
     if (orderFormat == ELECTRONIC_RESOURCE) {
       if (unitPrice > 0d) {
         errors.add(ErrorCodes.COST_UNIT_PRICE_INVALID);
       }
-    } else if (unitPrice <= 0d) {
+    } else if (unitPrice < 0d) {
       errors.add(ErrorCodes.COST_UNIT_PRICE_INVALID);
     }
 
-    double unitPriceElectronic = defaultIfNull(cost.getListUnitPriceElectronic(), 0d);
+    double unitPriceElectronic = defaultIfNull(cost.getListUnitPriceElectronic(), -1d);
     if (orderFormat == ELECTRONIC_RESOURCE || orderFormat == P_E_MIX) {
-      if (unitPriceElectronic <= 0d) {
+      if (unitPriceElectronic < 0d) {
         errors.add(ErrorCodes.COST_UNIT_PRICE_ELECTRONIC_INVALID);
       }
     } else if (unitPriceElectronic > 0d) {

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -380,7 +380,9 @@ public class HelperUtils {
     }
 
     double discount = defaultIfNull(cost.getDiscount(), 0d);
-    if (discount < 0d || (cost.getDiscountType() == Cost.DiscountType.PERCENTAGE && discount > 100d)) {
+    if (discount < 0d || (cost.getDiscountType() == Cost.DiscountType.PERCENTAGE && discount > 100d)
+      // validate that discount does not exceed total price
+      || (discount > 0d && cost.getDiscountType() == Cost.DiscountType.AMOUNT && calculateEstimatedPrice(cost) < 0d)) {
       errors.add(ErrorCodes.COST_DISCOUNT_INVALID);
     }
   }
@@ -532,12 +534,12 @@ public class HelperUtils {
    */
   public static double calculateEstimatedPrice(Cost cost) {
     BigDecimal total = BigDecimal.ZERO;
-    if (cost.getListUnitPrice() != null) {
+    if (cost.getListUnitPrice() != null && cost.getQuantityPhysical() != null) {
       BigDecimal pPrice = BigDecimal.valueOf(cost.getListUnitPrice())
                                     .multiply(BigDecimal.valueOf(cost.getQuantityPhysical()));
       total = total.add(pPrice);
     }
-    if (cost.getListUnitPriceElectronic() != null) {
+    if (cost.getListUnitPriceElectronic() != null && cost.getQuantityElectronic() != null) {
       BigDecimal ePrice = BigDecimal.valueOf(cost.getListUnitPriceElectronic())
                                     .multiply(BigDecimal.valueOf(cost.getQuantityElectronic()));
       total = total.add(ePrice);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -389,8 +389,8 @@ public class OrdersImplTest {
     firstPoLine.setOrderFormat(CompositePoLine.OrderFormat.P_E_MIX);
     firstPoLine.getCost().setQuantityPhysical(1);
     firstPoLine.getCost().setQuantityElectronic(0);
-    firstPoLine.getCost().setListUnitPrice(0d);
-    firstPoLine.getCost().setListUnitPriceElectronic(0d);
+    firstPoLine.getCost().setListUnitPrice(-10d);
+    firstPoLine.getCost().setListUnitPriceElectronic(-5d);
     firstPoLine.getLocations().forEach(location -> {
       location.setQuantityElectronic(1);
       location.setQuantityPhysical(2);
@@ -401,7 +401,7 @@ public class OrdersImplTest {
     secondPoLine.setOrderFormat(CompositePoLine.OrderFormat.OTHER);
     secondPoLine.getCost().setQuantityPhysical(0);
     secondPoLine.getCost().setQuantityElectronic(1);
-    secondPoLine.getCost().setListUnitPrice(0d);
+    secondPoLine.getCost().setListUnitPrice(-1d);
     secondPoLine.getCost().setListUnitPriceElectronic(10d);
     secondPoLine.getLocations().forEach(location -> {
       location.setQuantityElectronic(0);


### PR DESCRIPTION
## Purpose
[MODORDERS-197](https://issues.folio.org/browse/MODORDERS-197) Allow 0.0 for unit price in Cost for Orders

## Approach
Update validation to allow zero prices and verify that discount amount does not exceed total estimated price

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.