### PR TITLE
MODORDERS-201 correct PO total estimated cost calculation

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -560,6 +560,23 @@ public class HelperUtils {
     return total.setScale(currency.getDefaultFractionDigits(), RoundingMode.HALF_UP).doubleValue();
   }
 
+  /**
+   * Calculates PO's estimated price by summing the Estimated Price of the associated PO Lines.
+   * See MODORDERS-181 for more details. At the moment assumption is that all prices are in the same currency.
+   * @param poLines list of composite PO Lines
+   * @return estimated purchase order's total price
+   */
+  public static double calculateTotalEstimatedPrice(List<CompositePoLine> poLines) {
+    return poLines
+      .stream()
+      .map(CompositePoLine::getCost)
+      .filter(Objects::nonNull)
+      .map(Cost::getPoLineEstimatedPrice)
+      .map(BigDecimal::valueOf)
+      .reduce(BigDecimal.ZERO, BigDecimal::add)
+      .doubleValue();
+  }
+
   public static List<Piece> constructPieces(List<String> itemIds, String poLineId, String locationId) {
     return itemIds.stream()
       .map(itemId -> constructPiece(locationId, poLineId, itemId))

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -22,6 +22,7 @@ import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.PENDING;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -233,8 +234,10 @@ public class PurchaseOrderHelper extends AbstractHelper {
       .stream()
       .map(CompositePoLine::getCost)
       .filter(Objects::nonNull)
-      .mapToDouble(Cost::getPoLineEstimatedPrice)
-      .sum();
+      .map(Cost::getPoLineEstimatedPrice)
+      .map(BigDecimal::valueOf)
+      .reduce(BigDecimal.ZERO, BigDecimal::add)
+      .doubleValue();
   }
 
   /**

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
+import static org.folio.orders.utils.HelperUtils.calculateTotalEstimatedPrice;
 import static org.folio.orders.utils.HelperUtils.deletePoLine;
 import static org.folio.orders.utils.HelperUtils.deletePoLines;
 import static org.folio.orders.utils.HelperUtils.getCompositePoLines;
@@ -22,13 +23,11 @@ import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.PENDING;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
@@ -42,7 +41,6 @@ import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
-import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Parameter;
@@ -221,23 +219,6 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
   private int calculateTotalItemsQuantity(List<CompositePoLine> poLines) {
     return poLines.stream().mapToInt(HelperUtils::calculateTotalQuantity).sum();
-  }
-
-  /**
-   * Calculates PO's estimated price by summing the Estimated Price of the associated PO Lines.
-   * See MODORDERS-181 for more details.
-   * @param poLines list of composite PO Lines
-   * @return estimated purchase order's total price
-   */
-  private Double calculateTotalEstimatedPrice(List<CompositePoLine> poLines) {
-    return poLines
-      .stream()
-      .map(CompositePoLine::getCost)
-      .filter(Objects::nonNull)
-      .map(Cost::getPoLineEstimatedPrice)
-      .map(BigDecimal::valueOf)
-      .reduce(BigDecimal.ZERO, BigDecimal::add)
-      .doubleValue();
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -33,6 +33,7 @@ import static org.folio.orders.utils.ErrorCodes.ZERO_COST_QTY;
 import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
 import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.calculateEstimatedPrice;
+import static org.folio.orders.utils.HelperUtils.calculateTotalEstimatedPrice;
 import static org.folio.orders.utils.HelperUtils.calculateTotalQuantity;
 import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
 import static org.folio.orders.utils.HelperUtils.convertIdsToCqlQuery;
@@ -926,14 +927,7 @@ public class OrdersImplTest {
       })
       .sum();
 
-    double expectedPrice = resp
-      .getCompositePoLines()
-      .stream()
-      .map(CompositePoLine::getCost)
-      .map(Cost::getPoLineEstimatedPrice)
-      .map(BigDecimal::valueOf)
-      .reduce(BigDecimal.ZERO, BigDecimal::add)
-      .doubleValue();
+    double expectedPrice = calculateTotalEstimatedPrice(resp.getCompositePoLines());
 
     assertThat(resp.getTotalItems(), equalTo(expectedQuantity));
     assertThat(resp.getTotalEstimatedPrice(), equalTo(expectedPrice));

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -68,6 +68,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -327,12 +328,12 @@ public class OrdersImplTest {
     // Prepare cost details for the second PO Line (see MODORDERS-180 and MODORDERS-181)
     cost = reqData.getCompositePoLines().get(1).getCost();
     cost.setAdditionalCost(2d);
-    cost.setDiscount(5d);
+    cost.setDiscount(4.99d);
     cost.setDiscountType(Cost.DiscountType.AMOUNT);
     cost.setQuantityElectronic(3);
     cost.setListUnitPriceElectronic(11.99d);
     cost.setPoLineEstimatedPrice(null);
-    double expectedTotalPoLine2 = 32.97d;
+    double expectedTotalPoLine2 = 32.98d;
 
     final CompositePurchaseOrder resp = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).encodePrettily(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
@@ -363,7 +364,12 @@ public class OrdersImplTest {
     CompositePoLine compositePoLine2 = resp.getCompositePoLines().get(1);
     assertThat(compositePoLine1.getCost().getPoLineEstimatedPrice(), equalTo(expectedTotalPoLine1));
     assertThat(compositePoLine2.getCost().getPoLineEstimatedPrice(), equalTo(expectedTotalPoLine2));
-    assertThat(resp.getTotalEstimatedPrice(), equalTo(expectedTotalPoLine1 + expectedTotalPoLine2));
+
+    // the sum might be wrong if using regular double e.g. 44.41d + 32.98d results to 77.38999999999999
+    double expectedTotal = BigDecimal.valueOf(expectedTotalPoLine1)
+                                     .add(BigDecimal.valueOf(expectedTotalPoLine2))
+                                     .doubleValue();
+    assertThat(resp.getTotalEstimatedPrice(), equalTo(expectedTotal));
 
     List<JsonObject> poLines = MockServer.serverRqRs.get(PO_LINES, HttpMethod.POST);
     assertThat(poLines, hasSize(2));
@@ -924,8 +930,10 @@ public class OrdersImplTest {
       .getCompositePoLines()
       .stream()
       .map(CompositePoLine::getCost)
-      .mapToDouble(Cost::getPoLineEstimatedPrice)
-      .sum();
+      .map(Cost::getPoLineEstimatedPrice)
+      .map(BigDecimal::valueOf)
+      .reduce(BigDecimal.ZERO, BigDecimal::add)
+      .doubleValue();
 
     assertThat(resp.getTotalItems(), equalTo(expectedQuantity));
     assertThat(resp.getTotalEstimatedPrice(), equalTo(expectedPrice));


### PR DESCRIPTION
## Purpose
[MODORDERS-201](https://issues.folio.org/browse/MODORDERS-201) Incorrect PO total estimated cost in some cases

## Approach
Replacing sum of regular `double` values by operation with `BigDecimal`

## Learning
[Why You Should Never Use Float and Double for Monetary Calculations](https://dzone.com/articles/never-use-float-and-double-for-monetary-calculatio)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
