### PR TITLE
MODORDERS-199 - VendorHelper refactoring in accordance with the general helpers structure

### DIFF
--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -321,7 +321,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
   private CompletableFuture<Boolean> validateVendor(CompositePurchaseOrder compPO) {
     if (compPO.getWorkflowStatus() == WorkflowStatus.OPEN) {
-      VendorHelper vendorHelper = new VendorHelper(lang, httpClient, okapiHeaders, ctx);
+      VendorHelper vendorHelper = new VendorHelper(okapiHeaders, ctx, lang);
       return vendorHelper
         .validateVendor(compPO)
         .thenCombine(vendorHelper.validateAccessProviders(compPO), (vendorErrors, accessProvidersErrors) -> {

--- a/src/main/java/org/folio/rest/impl/VendorHelper.java
+++ b/src/main/java/org/folio/rest/impl/VendorHelper.java
@@ -2,8 +2,6 @@ package org.folio.rest.impl;
 
 import io.vertx.core.Context;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import org.folio.HttpStatus;
 import org.folio.orders.rest.exceptions.HttpException;
@@ -32,25 +30,19 @@ import static org.folio.orders.utils.HelperUtils.encodeQuery;
 import static org.folio.orders.utils.HelperUtils.handleGetRequest;
 
 
-public class VendorHelper {
-
-  private static final Logger logger = LoggerFactory.getLogger(VendorHelper.class);
-
-  private final HttpClientInterface httpClient;
-  private final Map<String, String> okapiHeaders;
-  private final Context ctx;
-  private final String lang;
+public class VendorHelper extends AbstractHelper {
 
   private static final String ID = "id";
   private static final String VENDORS = "vendors";
   private static final String VENDOR_STORAGE_VENDORS = "/vendor-storage/vendors/";
   private static final String VENDORS_WITH_QUERY_ENDPOINT = "/vendor-storage/vendors?limit=%d&lang=%s&query=%s";
 
-  public VendorHelper(String lang, HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx) {
-    this.lang = lang;
-    this.httpClient = httpClient;
-    this.okapiHeaders = okapiHeaders;
-    this.ctx = ctx;
+  public VendorHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {
+    super(httpClient, okapiHeaders, ctx, lang);
+  }
+
+  public VendorHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
+    super(okapiHeaders, ctx, lang);
   }
 
   /**
@@ -71,7 +63,7 @@ public class VendorHelper {
           if(status != VendorStatus.ACTIVE) {
             errors.add(createErrorWithId(ORDER_VENDOR_IS_INACTIVE, id));
           }
-          return buildErrorsObject(errors);
+          return handleAndReturnErrors(errors);
         })
         .thenAccept(future::complete)
         .exceptionally(t -> {
@@ -81,11 +73,11 @@ public class VendorHelper {
             logger.error("Failed to validate vendor's status", t);
             errors.add(GENERIC_ERROR_CODE.toError());
           }
-          future.complete(buildErrorsObject(errors));
+          future.complete(handleAndReturnErrors(errors));
           return null;
         });
     } else {
-      future.complete(buildErrorsObject(errors));
+      future.complete(handleAndReturnErrors(errors));
     }
     return future;
   }
@@ -114,7 +106,7 @@ public class VendorHelper {
         ids.stream()
           .filter(id -> !vendorsIds.contains(id))
           .forEach(id -> errors.add(POL_ACCESS_PROVIDER_NOT_FOUND.toError().withAdditionalProperty(ID, id)));
-        return buildErrorsObject(errors);
+        return handleAndReturnErrors(errors);
       }).thenAccept(future::complete)
         .exceptionally(t -> {
           logger.error("Failed to validate access provider's status", t);
@@ -122,7 +114,7 @@ public class VendorHelper {
           return null;
         });
     } else {
-      future.complete(buildErrorsObject(errors));
+      future.complete(handleAndReturnErrors(errors));
     }
     return future;
   }
@@ -133,7 +125,9 @@ public class VendorHelper {
    * @param errors list of {@link Error}
    * @return {@link Errors} object with list of {@link Error}
    */
-  private Errors buildErrorsObject(List<Error> errors) {
+  private Errors handleAndReturnErrors(List<Error> errors) {
+    // Add errors to the helper processing errors
+    addProcessingErrors(errors);
     return new Errors()
       .withErrors(errors)
       .withTotalRecords(errors.size());

--- a/src/main/java/org/folio/rest/impl/VendorHelper.java
+++ b/src/main/java/org/folio/rest/impl/VendorHelper.java
@@ -36,11 +36,7 @@ public class VendorHelper extends AbstractHelper {
   private static final String VENDORS = "vendors";
   private static final String VENDOR_STORAGE_VENDORS = "/vendor-storage/vendors/";
   private static final String VENDORS_WITH_QUERY_ENDPOINT = "/vendor-storage/vendors?limit=%d&lang=%s&query=%s";
-
-  public VendorHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {
-    super(httpClient, okapiHeaders, ctx, lang);
-  }
-
+  
   public VendorHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(okapiHeaders, ctx, lang);
   }

--- a/src/main/java/org/folio/rest/impl/VendorHelper.java
+++ b/src/main/java/org/folio/rest/impl/VendorHelper.java
@@ -10,7 +10,6 @@ import org.folio.rest.acq.model.Vendor;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +35,7 @@ public class VendorHelper extends AbstractHelper {
   private static final String VENDORS = "vendors";
   private static final String VENDOR_STORAGE_VENDORS = "/vendor-storage/vendors/";
   private static final String VENDORS_WITH_QUERY_ENDPOINT = "/vendor-storage/vendors?limit=%d&lang=%s&query=%s";
-  
+
   public VendorHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(okapiHeaders, ctx, lang);
   }

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -3319,7 +3319,7 @@ public class OrdersImplTest {
   private Errors verifyPostResponseErrors(int expectedErrorsNumber, String vendorId, String... accessProviderIds) throws Exception {
     Errors errors = verifyPostResponse(COMPOSITE_ORDERS_PATH, getPoWithVendorId(vendorId, accessProviderIds),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 422).as(Errors.class);
-    assertEquals(errors.getTotalRecords(), new Integer(expectedErrorsNumber));
+    assertThat(errors.getTotalRecords(), equalTo(expectedErrorsNumber));
     assertThat(errors.getErrors(), hasSize(expectedErrorsNumber));
     return errors;
   }


### PR DESCRIPTION
[MODORDERS-199](https://issues.folio.org/browse/MODORDERS-199) - VendorHelper refactoring in accordance with the general helpers structure

## Purpose
Refactoring of an existing VendorHelper from PR [#111](https://github.com/folio-org/mod-orders/pull/111) in accordance with the general helper structure implemented in scope of [MODORDERS-141](https://issues.folio.org/browse/MODORDERS-141) .

## Approach
Implemented inheritance of the VendorHelper from the AbstractHelper.

#### TODOS and Open Questions
PR [#120](https://github.com/folio-org/mod-orders/pull/120) should be closed as duplicated.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.


