### PR TITLE
MODORDERS-194 Piece and receiving-history: piece format

### DIFF
--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -18,6 +18,7 @@ public enum ErrorCodes {
   PIECE_NOT_FOUND("pieceNotFound", "The piece record is not found"),
   PIECE_NOT_RETRIEVED("pieceNotRetrieved", "The piece record is not retrieved"),
   PIECE_UPDATE_FAILED("pieceUpdateFailed", "The piece record failed to be updated"),
+  ITEM_CREATION_FAILED("itemCreationFailed", "The item record failed to be created"),
   ITEM_UPDATE_FAILED("itemUpdateFailed", "The item record failed to be updated"),
   ITEM_NOT_FOUND("itemNotFound", "The item record is not found"),
   ITEM_NOT_RETRIEVED("itemNotRetrieved", "The item record is not retrieved"),

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -499,15 +499,17 @@ public class HelperUtils {
   }
 
   /**
-   * Calculates pieces quantity for specified locations.
+   * Calculates pieces quantity for list of locations and return map where piece format is a key and corresponding quantity of pieces as value.
    *
    * @param compPOL composite PO Line
    * @param locations list of locations to calculate quantity for
-   * @return quantity of items expected in the inventory for PO Line
-   * @see #calculateInventoryItemsQuantity(CompositePoLine)
+   * @return quantity of pieces per piece format either required Inventory item or not (depending on {@code withItem} parameter) for PO Line
    */
   public static Map<Piece.Format, Integer> calculatePiecesQuantity(CompositePoLine compPOL, List<Location> locations, boolean withItem) {
-    if (compPOL.getCheckinItems() != null && compPOL.getCheckinItems()) return Collections.emptyMap();
+    // Piece records are not going to be created for PO Line which is going to be checked-in
+    if (compPOL.getCheckinItems() != null && compPOL.getCheckinItems()) {
+      return Collections.emptyMap();
+    }
 
     EnumMap<Piece.Format, Integer> quantities = new EnumMap<>(Piece.Format.class);
     switch (compPOL.getOrderFormat()) {
@@ -537,7 +539,7 @@ public class HelperUtils {
   }
 
   /**
-   * Calculates pieces quantity for specified locations.
+   * Calculates pieces quantity for specified locations based on piece format.
    *
    * @param format piece format
    * @param locations list of locations to calculate quantity for
@@ -545,10 +547,9 @@ public class HelperUtils {
    */
   public static int calculatePiecesQuantity(Piece.Format format, List<Location> locations) {
     switch (format) {
-      case PHYSICAL:
-        return getPhysicalQuantity(locations);
       case ELECTRONIC:
         return getElectronicQuantity(locations);
+      case PHYSICAL:
       case OTHER:
         return getPhysicalQuantity(locations);
       default:
@@ -556,6 +557,14 @@ public class HelperUtils {
     }
   }
 
+  /**
+   * Calculates quantity of pieces for specified locations which do not require item records in Inventory.
+   *
+   * @param compPOL composite PO Line
+   * @param locations list of locations to calculate quantity for
+   * @return quantity of pieces without items in the inventory for PO Line
+   * @see #calculatePiecesQuantity(CompositePoLine, List, boolean)
+   */
   public static int calculateExpectedQuantityOfPiecesWithoutItemCreation(CompositePoLine compPOL, List<Location> locations) {
     return IntStreamEx.of(calculatePiecesQuantity(compPOL, locations, false).values()).sum();
   }

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -3,6 +3,9 @@ package org.folio.rest.impl;
 import io.vertx.core.Context;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import one.util.streamex.IntStreamEx;
+import one.util.streamex.StreamEx;
+
 import org.apache.commons.collections4.ListUtils;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.apache.commons.lang3.StringUtils;
@@ -29,8 +32,10 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static me.escoffier.vertx.completablefuture.VertxCompletableFuture.allOf;
+import static org.folio.orders.utils.ErrorCodes.ITEM_CREATION_FAILED;
 import static org.folio.orders.utils.ErrorCodes.MISSING_MATERIAL_TYPE;
 import static org.folio.orders.utils.HelperUtils.*;
+import static org.folio.rest.acq.model.Piece.Format.ELECTRONIC;
 
 public class InventoryHelper extends AbstractHelper {
 
@@ -101,20 +106,21 @@ public class InventoryHelper extends AbstractHelper {
     // Group all locations by location id because the holding should be unique for different locations
     if (HelperUtils.isHoldingsUpdateRequired(compPOL)) {
       groupLocationsById(compPOL)
-        .forEach((locationId, locations) -> itemsPerHolding.add(
-          // Search for or create a new holding and then create items for this holding
-          getOrCreateHoldingsRecord(compPOL, locationId)
-            .thenCompose(holdingId -> {
-                int expectedQuantity = isItemsUpdateRequired ? calculateInventoryItemsQuantity(compPOL, locations) : 0;
-                if (expectedQuantity > 0) {
-                  // For some cases items might not be created e.g. resources with create inventory set to "None"
-                  return handleItemRecords(compPOL, holdingId, expectedQuantity)
-                    .thenApply(itemIds -> constructPieces(itemIds, compPOL.getId(), locationId));
-                } else {
-                  return completedFuture(Collections.emptyList());
+        .forEach((locationId, locations) ->
+          itemsPerHolding.add(
+            // Search for or create a new holding and then create items for this holding
+            getOrCreateHoldingsRecord(compPOL, locationId)
+              .thenCompose(holdingId -> {
+                  if (isItemsUpdateRequired) {
+                    // For some cases items might not be created e.g. resources with create inventory set to "None"
+                    return handleItemRecords(compPOL, holdingId, locations);
+                  } else {
+                    return completedFuture(Collections.emptyList());
+                  }
                 }
-              }
-            )));
+              )
+          )
+        );
     }
     return collectResultsOnSuccess(itemsPerHolding)
       .thenApply(results -> results.stream()
@@ -169,7 +175,7 @@ public class InventoryHelper extends AbstractHelper {
 
   /**
    * Checks if the {@link ReceivedItem} has item status as "On order"
-   * @param receivedItem item details specified by user upon receiving flow
+   * @param receivedItem details specified by user upon receiving flow
    * @return {@code true} if the item status is "On order"
    */
   public boolean isOnOrderItemStatus(ReceivedItem receivedItem) {
@@ -178,7 +184,7 @@ public class InventoryHelper extends AbstractHelper {
   
   /**
    * Checks if the {@link ReceivedItem} has item status as "On order"
-   * @param receivedItem item details specified by user upon receiving flow
+   * @param checkinPiece details specified by user upon check-in flow
    * @return {@code true} if the item status is "On order"
    */
   public boolean isOnOrderPieceStatus(CheckInPiece checkinPiece) {
@@ -213,28 +219,78 @@ public class InventoryHelper extends AbstractHelper {
    *
    * @param compPOL   PO line to retrieve/create Item Records for
    * @param holdingId holding uuid from the inventory
-   * @param expectedQuantity expected items quantity for the holding
+   * @param locations list of locations holdingId is associated with
    * @return future with list of item id's
    */
-  private CompletableFuture<List<String>> handleItemRecords(CompositePoLine compPOL, String holdingId, int expectedQuantity) {
-    // Search for already existing items
-    return searchForExistingItems(compPOL, holdingId, expectedQuantity)
-      .thenCompose(existingItemIds -> {
-        // Create only missing items
-        int remainingItemsQuantity = expectedQuantity - existingItemIds.size();
-        return createMissingItems(compPOL, holdingId, remainingItemsQuantity)
-          .thenApply(createdItemIds -> {
-            List<String> allItemIds = ListUtils.union(existingItemIds, createdItemIds);
+  private CompletableFuture<List<Piece>> handleItemRecords(CompositePoLine compPOL, String holdingId, List<Location> locations) {
+    Map<Piece.Format, Integer> piecesWithItems = calculatePiecesQuantity(compPOL, locations, true);
+    int piecesWithItemsQty = IntStreamEx.of(piecesWithItems.values()).sum();
+    String polId = compPOL.getId();
 
-            // In case no items created, return an exception because nothing can be done at this stage
-            if (allItemIds.isEmpty()) {
-              throw new InventoryException(String.format("No items created for PO Line with %s id", compPOL.getId()));
+    logger.debug("Handling {} items for PO Line with id={} and holdings with id={}", piecesWithItemsQty, polId, holdingId);
+    if (piecesWithItemsQty == 0) {
+      return completedFuture(Collections.emptyList());
+    }
+
+    // Search for already existing items
+    return searchForExistingItems(compPOL, holdingId, piecesWithItemsQty)
+      .thenCompose(existingItems -> {
+        String locationId = locations.get(0).getLocationId();
+        List<CompletableFuture<List<Piece>>> pieces = new ArrayList<>(Piece.Format.values().length);
+
+        piecesWithItems.forEach((pieceFormat, expectedQuantity) -> {
+          if (expectedQuantity > 0) {
+            List<String> items;
+            CompletableFuture<List<String>> newItems;
+
+            // Depending on piece format get already existing items and send requests to create missing items
+            if (pieceFormat == ELECTRONIC) {
+              items = getElectronicItems(compPOL, existingItems);
+              newItems = createMissingElectronicItems(compPOL, holdingId, expectedQuantity - items.size());
+            } else {
+              items = getPhysicalItems(compPOL, existingItems);
+              newItems = createMissingPhysicalItems(compPOL, holdingId, expectedQuantity - items.size());
             }
 
-            return allItemIds;
-          });
+            // Build piece records once new items are created
+            pieces.add(newItems.thenApply(createdItemIds -> {
+              List<String> itemIds = ListUtils.union(createdItemIds, items);
+              logger.debug("Building {} {} piece(s) for PO Line with id={}", itemIds.size(), pieceFormat, polId);
+              return StreamEx.of(itemIds)
+                .map(itemId -> new Piece().withFormat(pieceFormat)
+                                          .withItemId(itemId)
+                                          .withPoLineId(polId)
+                                          .withLocationId(locationId))
+                .toList();
+            }));
+          }
+        });
+
+        // Wait for all items to be created and corresponding pieces are built
+        return collectResultsOnSuccess(pieces)
+          .thenApply(results -> results
+            .stream()
+            .flatMap(List::stream)
+            .collect(toList())
+          );
         }
       );
+  }
+
+  private List<String> getPhysicalItems(CompositePoLine compPOL, List<JsonObject> existingItems) {
+    return getItemsByMaterialType(existingItems, getPhysicalMaterialTypeId(compPOL));
+  }
+
+  private List<String> getElectronicItems(CompositePoLine compPOL, List<JsonObject> existingItems) {
+    return getItemsByMaterialType(existingItems, getElectronicMaterialTypeId(compPOL));
+  }
+
+  private List<String> getItemsByMaterialType(List<JsonObject> existingItems, String materialTypeId) {
+    return existingItems
+      .stream()
+      .filter(item -> materialTypeId.equals(item.getString(ITEM_MATERIAL_TYPE_ID)))
+      .map(this::extractId)
+      .collect(toList());
   }
 
   /**
@@ -392,14 +448,14 @@ public class InventoryHelper extends AbstractHelper {
    * @param expectedQuantity expected quantity of the items for combination of the holding and PO Line uuid's from the inventory
    * @return future with list of item id's
    */
-  private CompletableFuture<List<String>> searchForExistingItems(CompositePoLine compPOL, String holdingId, int expectedQuantity) {
+  private CompletableFuture<List<JsonObject>> searchForExistingItems(CompositePoLine compPOL, String holdingId, int expectedQuantity) {
     String query = encodeQuery(String.format(LOOKUP_ITEM_STOR_QUERY, compPOL.getId(), holdingId), logger);
     String endpoint = String.format(LOOKUP_ITEM_STOR_ENDPOINT, query, expectedQuantity, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
-      .thenApply(items -> {
-        List<String> itemIds = collectItemIds(items);
-        logger.debug("{} existing items found out of {} for PO Line with '{}' id", itemIds.size(), expectedQuantity, compPOL.getId());
-        return itemIds;
+      .thenApply(itemsCollection -> {
+        List<JsonObject> items = extractItems(itemsCollection);
+        logger.debug("{} existing items found out of {} for PO Line with '{}' id", items.size(), expectedQuantity, compPOL.getId());
+        return items;
       });
   }
 
@@ -417,18 +473,22 @@ public class InventoryHelper extends AbstractHelper {
   }
 
   /**
-   * Validates if the json object contains items and extracts ids or returns empty list
-   * @param itemEntries {@link JsonObject} representing item storage response
-   * @return list of the item ids if any item returned
+   * Creates Items in the inventory based on the PO line data.
+   *
+   * @param compPOL PO line to create Instance Record for
+   * @param holdingId holding id
+   * @param quantity expected number of items to create
+   * @return id of newly created Instance Record
    */
-  private List<String> collectItemIds(JsonObject itemEntries) {
-    List<JsonObject> jsonObjects = extractItems(itemEntries);
-    if (jsonObjects.isEmpty()) {
-      return Collections.emptyList();
+  private CompletableFuture<List<String>> createMissingElectronicItems(CompositePoLine compPOL, String holdingId, int quantity) {
+    if (quantity > 0) {
+      return buildElectronicItemRecordJsonObject(compPOL, holdingId)
+        .thenCompose(itemData -> {
+          logger.debug("Posting {} electronic item(s) for PO Line with '{}' id", quantity, compPOL.getId());
+          return createItemRecords(itemData, quantity);
+        });
     } else {
-      return jsonObjects.stream()
-                        .map(this::extractId)
-                        .collect(toList());
+      return completedFuture(Collections.emptyList());
     }
   }
 
@@ -440,11 +500,11 @@ public class InventoryHelper extends AbstractHelper {
    * @param quantity expected number of items to create
    * @return id of newly created Instance Record
    */
-  private CompletableFuture<List<String>> createMissingItems(CompositePoLine compPOL, String holdingId, int quantity) {
+  private CompletableFuture<List<String>> createMissingPhysicalItems(CompositePoLine compPOL, String holdingId, int quantity) {
     if (quantity > 0) {
-      return buildItemRecordJsonObject(compPOL, holdingId)
+      return buildPhysicalItemRecordJsonObject(compPOL, holdingId)
         .thenCompose(itemData -> {
-          logger.debug("Creating {} items for PO Line with '{}' id", quantity, compPOL.getId());
+          logger.debug("Posting {} physical item(s) for PO Line with '{}' id", quantity, compPOL.getId());
           return createItemRecords(itemData, quantity);
         });
     } else {
@@ -476,7 +536,10 @@ public class InventoryHelper extends AbstractHelper {
   private CompletableFuture<String> createItemInInventory(JsonObject itemData) {
     return createRecordInStorage(itemData, String.format(CREATE_ITEM_STOR_ENDPOINT, lang))
       // In case item creation failed, return null instead of id
-      .exceptionally(throwable -> null);
+      .exceptionally(throwable -> {
+        addProcessingError(ITEM_CREATION_FAILED.toError());
+        return null;
+      });
   }
 
   /**
@@ -486,21 +549,49 @@ public class InventoryHelper extends AbstractHelper {
    * @param holdingId holding uuid from the inventory
    * @return item data to be used as request body for POST operation
    */
-  private CompletableFuture<JsonObject> buildItemRecordJsonObject(CompositePoLine compPOL, String holdingId) {
-    String materialTypeId = getMaterialTypeId(compPOL);
+  private CompletableFuture<JsonObject> buildBaseItemRecordJsonObject(CompositePoLine compPOL, String holdingId) {
     return getLoanTypeId(DEFAULT_LOAN_TYPE_NAME)
       .thenApply(loanTypeId -> {
         JsonObject itemRecord = new JsonObject();
         itemRecord.put(ITEM_HOLDINGS_RECORD_ID, holdingId);
         itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ITEM_STATUS_ON_ORDER));
-        itemRecord.put(ITEM_MATERIAL_TYPE_ID, materialTypeId);
         itemRecord.put(ITEM_PERMANENT_LOAN_TYPE_ID, loanTypeId);
         itemRecord.put(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER, compPOL.getId());
         return itemRecord;
       });
   }
 
-  private String getMaterialTypeId(CompositePoLine compPOL) {
+  /**
+   * Builds JsonObject representing inventory item minimal data. The schema is located directly in 'mod-inventory-storage' module.
+   *
+   * @param compPOL   PO line to create Item Records for
+   * @param holdingId holding uuid from the inventory
+   * @return item data to be used as request body for POST operation
+   */
+  private CompletableFuture<JsonObject> buildElectronicItemRecordJsonObject(CompositePoLine compPOL, String holdingId) {
+    return buildBaseItemRecordJsonObject(compPOL, holdingId)
+      .thenApply(itemRecord -> itemRecord.put(ITEM_MATERIAL_TYPE_ID, getElectronicMaterialTypeId(compPOL)));
+  }
+
+  /**
+   * Builds JsonObject representing inventory item minimal data. The schema is located directly in 'mod-inventory-storage' module.
+   *
+   * @param compPOL   PO line to create Item Records for
+   * @param holdingId holding uuid from the inventory
+   * @return item data to be used as request body for POST operation
+   */
+  private CompletableFuture<JsonObject> buildPhysicalItemRecordJsonObject(CompositePoLine compPOL, String holdingId) {
+    return buildBaseItemRecordJsonObject(compPOL, holdingId)
+      .thenApply(itemRecord -> itemRecord.put(ITEM_MATERIAL_TYPE_ID, getPhysicalMaterialTypeId(compPOL)));
+  }
+
+  private String getPhysicalMaterialTypeId(CompositePoLine compPOL) {
+    // the logic will be updated in scope of MODORDERS-195
+    return getElectronicMaterialTypeId(compPOL);
+  }
+
+  private String getElectronicMaterialTypeId(CompositePoLine compPOL) {
+    // the logic will be updated in scope of MODORDERS-195
     return Optional.ofNullable(compPOL.getDetails())
                    .map(Details::getMaterialTypes)
                    .flatMap(ids -> ids.stream().findFirst())

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -388,7 +388,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
             piecesToCreate.addAll(collectMissingPiecesWithItem(filteredExpectedPiecesWithItem, filteredExistingPieces));
 
             Map<Piece.Format, Integer> expectedQuantitiesWithoutItem = calculatePiecesQuantity(compPOL, locations, false);
-            Map<Piece.Format, Integer> quantityWithoutItem = calculateQuantityOfExistingPiecesWithoutItem(existingPieces);
+            Map<Piece.Format, Integer> quantityWithoutItem = calculateQuantityOfExistingPiecesWithoutItem(filteredExistingPieces);
             expectedQuantitiesWithoutItem.forEach((format, expectedQty) -> {
               int remainingPiecesQuantity = expectedQty - quantityWithoutItem.getOrDefault(format, 0);
               if (remainingPiecesQuantity > 0) {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -7,7 +7,6 @@ import static org.folio.orders.utils.ErrorCodes.COST_DISCOUNT_INVALID;
 import static org.folio.orders.utils.ErrorCodes.COST_UNIT_PRICE_ELECTRONIC_INVALID;
 import static org.folio.orders.utils.ErrorCodes.COST_UNIT_PRICE_INVALID;
 import static org.folio.orders.utils.ErrorCodes.ELECTRONIC_LOC_QTY_EXCEEDS_COST;
-import static org.folio.orders.utils.ErrorCodes.GENERIC_ERROR_CODE;
 import static org.folio.orders.utils.ErrorCodes.ITEM_NOT_FOUND;
 import static org.folio.orders.utils.ErrorCodes.ITEM_NOT_RETRIEVED;
 import static org.folio.orders.utils.ErrorCodes.ITEM_UPDATE_FAILED;
@@ -34,6 +33,8 @@ import static org.folio.orders.utils.ErrorCodes.ZERO_COST_QTY;
 import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
 import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.calculateEstimatedPrice;
+import static org.folio.orders.utils.HelperUtils.calculateExpectedQuantityOfPiecesWithoutItemCreation;
+import static org.folio.orders.utils.HelperUtils.calculatePiecesQuantity;
 import static org.folio.orders.utils.HelperUtils.calculateTotalEstimatedPrice;
 import static org.folio.orders.utils.HelperUtils.calculateTotalQuantity;
 import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
@@ -105,7 +106,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.ErrorCodes;
-import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.acq.model.Piece;
 import org.folio.rest.acq.model.PieceCollection;
@@ -458,7 +458,7 @@ public class OrdersImplTest {
       location.setQuantityPhysical(1);
     });
 
-    final Errors response = verifyPut(COMPOSITE_ORDERS_PATH + "/" + reqData.getId(), JsonObject.mapFrom(reqData).encode(),
+    final Errors response = verifyPut(COMPOSITE_ORDERS_PATH + "/" + reqData.getId(), JsonObject.mapFrom(reqData),
       APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(response.getErrors(), hasSize(3));
@@ -646,29 +646,30 @@ public class OrdersImplTest {
     CompositePurchaseOrder reqData = order.mapTo(CompositePurchaseOrder.class);
 
     reqData.setId(ID_FOR_PRINT_MONOGRAPH_ORDER);
-    // Make sure that mock PO has 1 po lines
+    // Make sure that mock PO has 1 po line
     assertEquals(1, reqData.getCompositePoLines().size());
 
     CompositePoLine compositePoLine = reqData.getCompositePoLines().get(0);
 
+    compositePoLine.setId(PO_LINE_ID_FOR_SUCCESS_CASE);
     compositePoLine.getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
     compositePoLine.getCost().setQuantityPhysical(3);
     compositePoLine.getCost().setQuantityElectronic(2);
     compositePoLine.setOrderFormat(OrderFormat.P_E_MIX);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
 
     List<JsonObject> createdPieces = MockServer.serverRqRs.get(PIECES, HttpMethod.POST);
     List<JsonObject> createdItems = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.POST);
-    int piecesSize = createdPieces != null ? createdPieces.size() : 0;
-    int itemSize = createdItems != null ? createdItems.size() : 0;
-    logger.debug("------------------- piecesSize, itemSize --------------------\n" + piecesSize + " " + itemSize);
+    assertThat(createdItems, notNullValue());
+    assertThat(createdPieces, notNullValue());
+
+    int piecesSize = createdPieces.size();
+    logger.debug("------------------- piecesSize, itemSize --------------------\n" + piecesSize + " " + createdItems.size());
     // Verify total number of pieces created should be equal to total quantity
     assertEquals(calculateTotalQuantity(compositePoLine), piecesSize);
 
-    if (createdItems != null) {
-      verifyPiecesCreated(createdItems, reqData.getCompositePoLines(), createdPieces);
-    }
+    verifyPiecesCreated(createdItems, reqData.getCompositePoLines(), createdPieces);
   }
 
   @Test
@@ -682,7 +683,7 @@ public class OrdersImplTest {
 
     reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
     List<JsonObject> items = joinExistingAndNewItems();
     List<JsonObject> createdPieces = MockServer.serverRqRs.get(PIECES, HttpMethod.POST);
     verifyPiecesQuantityForSuccessCase(reqData, createdPieces);
@@ -1112,7 +1113,7 @@ public class OrdersImplTest {
     JsonObject reqData = new JsonObject(getMockData(ORDER_WITH_PO_LINES_JSON));
     JsonObject storageData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, id);
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), "", 204);
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData, "", 204);
 
     storageData.put("workflowStatus", "Open");
     reqData.put("workflowStatus", "Open");
@@ -1150,8 +1151,7 @@ public class OrdersImplTest {
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.CLOSED);
 
     String url = COMPOSITE_ORDERS_PATH + "/" + reqData.getId();
-    String body = JsonObject.mapFrom(reqData).encode();
-    verifyPut(url, body, "", 204);
+    verifyPut(url, JsonObject.mapFrom(reqData), "", 204);
 
     List<JsonObject> orderRetrievals = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.GET);
     assertNotNull(orderRetrievals);
@@ -1179,7 +1179,7 @@ public class OrdersImplTest {
     logger.info(String.format("using mock datafile: %s%s.json", COMP_ORDER_MOCK_DATA_PATH, id));
     JsonObject reqData = new JsonObject(getMockData(ORDER_WITH_MISMATCH_ID_INT_PO_LINES_JSON));
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), APPLICATION_JSON, 422);
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData, APPLICATION_JSON, 422);
   }
 
   @Test
@@ -1194,7 +1194,7 @@ public class OrdersImplTest {
     reqData.put(PO_NUMBER, newPoNumber);
     Pattern poLinePattern = Pattern.compile(String.format("(%s)(-[0-9]{1,3})", newPoNumber));
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), "", 204);
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData, "", 204);
 
     assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
     assertEquals(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT).size(), storData.getJsonArray(COMPOSITE_PO_LINES).size());
@@ -1216,7 +1216,7 @@ public class OrdersImplTest {
     reqData.put(PO_NUMBER, newPoNumber);
     Pattern poLinePattern = Pattern.compile(String.format("(%s)(-[0-9]{1,3})", newPoNumber));
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), "", 204);
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData, "", 204);
     verifyPoWithPoLinesUpdate(reqData, storageData);
     MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT).forEach(poLine -> {
       Matcher matcher = poLinePattern.matcher(poLine.getString(PO_LINE_NUMBER));
@@ -1233,7 +1233,7 @@ public class OrdersImplTest {
     JsonObject reqData = new JsonObject(getMockData(ORDER_WITH_PO_LINES_JSON));
     reqData.remove(PO_NUMBER);
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), APPLICATION_JSON, 422);
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData, APPLICATION_JSON, 422);
   }
 
   @Test
@@ -1244,9 +1244,8 @@ public class OrdersImplTest {
 
     JsonObject request = new JsonObject();
     request.put("poNumber", "1234");
-    String body= request.toString();
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, body, APPLICATION_JSON, 422);
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, request, APPLICATION_JSON, 422);
 
   }
 
@@ -1259,10 +1258,8 @@ public class OrdersImplTest {
 
     JsonObject request = new JsonObject();
     request.put("poNumber", EXISTING_PO_NUMBER);
-    String body= request.toString();
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, body, APPLICATION_JSON, 400);
-
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, request, APPLICATION_JSON, 400);
   }
 
   @Test
@@ -1334,7 +1331,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
     reqData.getCompositePoLines().forEach(s -> s.setReceiptStatus(CompositePoLine.ReceiptStatus.PENDING));
 
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
 
     int polCount = reqData.getCompositePoLines().size();
 
@@ -1522,7 +1519,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(1).setCheckinItems(true);
     reqData.getCompositePoLines().forEach(s -> s.setReceiptStatus(CompositePoLine.ReceiptStatus.PENDING));
 
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
 
     int polCount = reqData.getCompositePoLines().size();
     verifyInstanceLinksForUpdatedOrder(reqData);
@@ -1539,7 +1536,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().clear();
     reqData.setId(ID_FOR_PRINT_MONOGRAPH_ORDER);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), "", 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
     verifyReceiptStatusChangedTo(CompositePoLine.ReceiptStatus.AWAITING_RECEIPT.value());
   }
 
@@ -1556,9 +1553,12 @@ public class OrdersImplTest {
   public void testUpdateOrderToOpenWithPartialItemsCreation() throws Exception {
     logger.info("=== Test Order update to Open status - Inventory items expected to be created partially ===");
 
+    // One item for each location will be found
     CompositePurchaseOrder reqData = getMockDraftOrder().mapTo(CompositePurchaseOrder.class);
     // Emulate items creation issue
-    reqData.getCompositePoLines().get(0).getDetails().getMaterialTypes().set(0, ID_FOR_INTERNAL_SERVER_ERROR);
+    assertThat(reqData.getCompositePoLines().get(0).getLocations(), hasSize(3));
+    // Second location has 2 physical resources
+    reqData.getCompositePoLines().get(0).getLocations().get(1).setLocationId(ID_FOR_INTERNAL_SERVER_ERROR);
     // Let's have only one PO Line
     reqData.getCompositePoLines().remove(1);
     // Set status to Open
@@ -1570,7 +1570,7 @@ public class OrdersImplTest {
     // Assert that only one PO line presents
     assertEquals(1, polCount);
 
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), APPLICATION_JSON, 500);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), APPLICATION_JSON, 500);
 
     // Verify inventory GET and POST requests for instance, holding and item records
     verifyInventoryInteraction(false);
@@ -1702,39 +1702,75 @@ public class OrdersImplTest {
     }
   }
 
-  private void verifyPiecesCreated(List<JsonObject> inventoryItems, List<CompositePoLine> compositePoLines,
-      List<JsonObject> pieces) {
+  private void verifyPiecesCreated(List<JsonObject> inventoryItems, List<CompositePoLine> compositePoLines, List<JsonObject> pieceJsons) {
     // Collect all item id's
     List<String> itemIds = inventoryItems.stream()
                                     .map(item -> item.getString(ID))
                                     .collect(Collectors.toList());
-
-    // Verify quantity of created pieces
-    int expectedPiecesQuantity = 0;
-    for (CompositePoLine poLine : compositePoLines) {
-      if (poLine.getCheckinItems() != null && poLine.getCheckinItems()) continue;
-      expectedPiecesQuantity += HelperUtils.calculateExpectedQuantityOfPiecesWithoutItemCreation(poLine, poLine.getLocations());
-      expectedPiecesQuantity += calculateInventoryItemsQuantity(poLine, poLine.getLocations());
-    }
-    assertEquals(expectedPiecesQuantity, pieces.size());
-
-    List<String> locationIds = compositePoLines.stream()
-      .flatMap(compositePoLine -> compositePoLine.getLocations().stream())
-      .map(Location::getLocationId)
-      .distinct()
+    List<Piece> pieces = pieceJsons
+      .stream()
+      .map(pieceObj -> pieceObj.mapTo(Piece.class))
       .collect(Collectors.toList());
 
-    for (JsonObject pieceObj : pieces) {
-      // Make sure piece data corresponds to schema content
-      Piece piece = pieceObj.mapTo(Piece.class);
+    // Verify quantity of created pieces
+    int totalForAllPoLines = 0;
+    for (CompositePoLine poLine : compositePoLines) {
+      List<Location> locations = poLine.getLocations();
 
-      // Check if itemId in inventoryItems match itemId in piece record
-      assertThat(locationIds, hasItem(piece.getLocationId()));
-      if(piece.getItemId()!=null)
-        assertThat(itemIds, hasItem(piece.getItemId()));
-      assertThat(piece.getReceivingStatus(), equalTo(Piece.ReceivingStatus.EXPECTED));
-    }
+      // Prepare data first
+
+      // Calculated quantities
+      int expectedElQty = 0;
+      int expectedPhysQty = 0;
+      int expectedOthQty = 0;
+      if (poLine.getCheckinItems() == null || !poLine.getCheckinItems()) {
+        if (poLine.getOrderFormat() == OrderFormat.OTHER) {
+          expectedOthQty += calculatePiecesQuantity(Piece.Format.OTHER, locations);
+        } else {
+          expectedPhysQty += calculatePiecesQuantity(Piece.Format.PHYSICAL, locations);
         }
+        expectedElQty = calculatePiecesQuantity(Piece.Format.ELECTRONIC, locations);
+      }
+
+      int expectedWithItemQty = calculateExpectedQuantityOfPiecesWithoutItemCreation(poLine, locations);
+      int expectedWithoutItemQty = calculateInventoryItemsQuantity(poLine, locations);
+
+      // Prepare pieces for PO Line
+      List<Piece> piecesByPoLine = pieces
+        .stream()
+        .filter(piece -> piece.getPoLineId().equals(poLine.getId()))
+        .collect(Collectors.toList());
+
+      // Get all PO Line's locations' ids
+      List<String> locationIds = locations
+        .stream()
+        .map(Location::getLocationId)
+        .distinct()
+        .collect(Collectors.toList());
+
+      // Make sure that quantities by piece type and by item presence are the same
+      assertThat(expectedPhysQty + expectedElQty + expectedOthQty, is(expectedWithItemQty + expectedWithoutItemQty));
+
+      int expectedTotal = expectedWithItemQty + expectedWithoutItemQty;
+      assertThat(piecesByPoLine, hasSize(expectedTotal));
+
+      // Verify each piece individually
+      piecesByPoLine.forEach(piece -> {
+        // Check if itemId in inventoryItems match itemId in piece record
+        assertThat(locationIds, hasItem(piece.getLocationId()));
+        assertThat(piece.getReceivingStatus(), equalTo(Piece.ReceivingStatus.EXPECTED));
+        if (piece.getItemId() != null) {
+          assertThat(itemIds, hasItem(piece.getItemId()));
+        }
+        assertThat(piece.getFormat(), notNullValue());
+      });
+
+      totalForAllPoLines += expectedTotal;
+    }
+
+    // Make sure that none of pieces missed
+    assertThat(pieceJsons, hasSize(totalForAllPoLines));
+  }
 
   private void verifyHoldingsCreated(List<JsonObject> holdings, CompositePoLine pol) {
     Map<String, List<Location>> groupedLocations = groupLocationsById(pol);
@@ -1804,11 +1840,8 @@ public class OrdersImplTest {
     CompositePurchaseOrder reqData = new JsonObject(getMockData(ORDER_FOR_FAILURE_CASE_MOCK_DATA_PATH)).mapTo(CompositePurchaseOrder.class);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
 
-    final Errors errors = verifyPut(
-      String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()),
-      JsonObject.mapFrom(reqData).toString(),
-      APPLICATION_JSON,
-      500)
+    final Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData),
+      APPLICATION_JSON, 500)
         .body()
           .as(Errors.class);
 
@@ -1837,15 +1870,15 @@ public class OrdersImplTest {
       assertTrue(calculateInventoryItemsQuantity(pol) > 0);
     }
 
-    // Set material type id to one which emulates item creation failure
-    reqData.getCompositePoLines().get(1).getDetails().getMaterialTypes().set(0, ID_FOR_INTERNAL_SERVER_ERROR);
+    // Set location ids to one which emulates item creation failure
+    reqData.getCompositePoLines().get(1).getLocations().forEach(location -> location.setLocationId(ID_FOR_INTERNAL_SERVER_ERROR));
 
     String path = String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId());
 
     /*==============  Assert result ==============*/
 
     // Server Error expected as a result because not all items created
-    verifyPut(path, JsonObject.mapFrom(reqData).toString(), APPLICATION_JSON, 500);
+    verifyPut(path, JsonObject.mapFrom(reqData), APPLICATION_JSON, 500);
 
     // Check that search of the existing instances and items was done for each PO line
     List<JsonObject> instancesSearches = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.GET);
@@ -1898,7 +1931,7 @@ public class OrdersImplTest {
     JsonObject reqData = getMockDraftOrder();
     String poNumber = reqData.getString(PO_NUMBER);
 
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, ORDER_ID_WITHOUT_PO_LINES), reqData.toString(), "", 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, ORDER_ID_WITHOUT_PO_LINES), reqData, "", 204);
 
     assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
     List<JsonObject> createdPoLines = MockServer.serverRqRs.get(PO_LINES, HttpMethod.POST);
@@ -1915,7 +1948,7 @@ public class OrdersImplTest {
     logger.info(String.format("using mock datafile: %s%s.json", COMP_ORDER_MOCK_DATA_PATH, id));
     JsonObject reqData = new JsonObject(getMockData(ORDER_WITHOUT_PO_LINES));
 
-    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData.toString(), "", 204);
+    verifyPut(COMPOSITE_ORDERS_PATH + "/" + id, reqData, "", 204);
 
     assertNotNull(MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.PUT));
     assertNull(MockServer.serverRqRs.get(PO_LINES, HttpMethod.DELETE));
@@ -1926,7 +1959,7 @@ public class OrdersImplTest {
     logger.info("=== Test Put Order By Id for 404 with Invalid Id or Order not found ===");
 
     JsonObject reqData = getMockAsJson(LISTED_PRINT_SERIAL_PATH);
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, "93f612a9-9a05-4eef-aac5-435be131454b"), reqData.encodePrettily(), APPLICATION_JSON, 404);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, "93f612a9-9a05-4eef-aac5-435be131454b"), reqData, APPLICATION_JSON, 404);
   }
 
   @Test
@@ -1937,7 +1970,7 @@ public class OrdersImplTest {
     reqData.setId(PO_ID);
 
     Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, PO_ID_FOR_FAILURE_CASE),
-      JsonObject.mapFrom(reqData).encodePrettily(), APPLICATION_JSON, 422).as(Errors.class);
+      JsonObject.mapFrom(reqData), APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(errors.getErrors(), hasSize(1));
     assertThat(errors.getErrors().get(0).getCode(), equalTo(MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY.getCode()));
@@ -1951,7 +1984,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().forEach(line -> line.setPurchaseOrderId(PO_ID_FOR_FAILURE_CASE));
 
     Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, PO_ID),
-      JsonObject.mapFrom(reqData).encodePrettily(), APPLICATION_JSON, 422).as(Errors.class);
+      JsonObject.mapFrom(reqData), APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(errors.getErrors(), hasSize(reqData.getCompositePoLines().size()));
     errors.getErrors().forEach(error -> {
@@ -1980,7 +2013,7 @@ public class OrdersImplTest {
     // Delete PO Line id emulating case when new PO Line is being added
     reqData.getCompositePoLines().forEach(line -> line.setId(null));
 
-    Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(), APPLICATION_JSON, 422).as(Errors.class);
+    Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), APPLICATION_JSON, 422).as(Errors.class);
     validatePoLineCreationErrorForNonPendingOrder(errorCode, errors);
   }
 
@@ -2338,7 +2371,7 @@ public class OrdersImplTest {
     cost.setDiscount(100.1d);
     reqData.getLocations().get(0).setQuantityElectronic(1);
 
-    final Errors response = verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encodePrettily(),
+    final Errors response = verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData),
       APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(response.getErrors(), hasSize(7));
@@ -2455,7 +2488,7 @@ public class OrdersImplTest {
 
     String url = String.format(LINE_BY_ID_PATH, lineId);
 
-    final Response resp = verifyPut(url, JsonObject.mapFrom(body).encodePrettily(), "", 204);
+    final Response resp = verifyPut(url, JsonObject.mapFrom(body), "", 204);
 
     assertTrue(StringUtils.isEmpty(resp.getBody().asString()));
 
@@ -3264,15 +3297,15 @@ public class OrdersImplTest {
     // Positive cases
     reqData.setVendor(ACTIVE_VENDOR_ID);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.PENDING);
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY, 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), EMPTY, 204);
 
     reqData.setVendor(INACTIVE_VENDOR_ID);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.PENDING);
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY, 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), EMPTY, 204);
 
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     reqData.setVendor(ACTIVE_VENDOR_ID);
-    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY, 204);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), EMPTY, 204);
 
     // Negative cases
     // Non-existed vendor
@@ -3281,7 +3314,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_A);
     reqData.getCompositePoLines().get(1).getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_A);
     Errors nonExistedVendorErrors
-      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY, 422).as(Errors.class);
+      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), EMPTY, 422).as(Errors.class);
     checkExpectedError(NON_EXIST_VENDOR_ID, nonExistedVendorErrors, 0, ORDER_VENDOR_NOT_FOUND);
 
     // Inactive access provider
@@ -3290,7 +3323,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_A);
     reqData.getCompositePoLines().get(1).getEresource().setAccessProvider(INACTIVE_ACCESS_PROVIDER_A);
     Errors inactiveAccessProviderErrors
-      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY, 422).as(Errors.class);
+      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), EMPTY, 422).as(Errors.class);
     checkExpectedError(INACTIVE_ACCESS_PROVIDER_A, inactiveAccessProviderErrors, 0, POL_ACCESS_PROVIDER_IS_INACTIVE);
 
     // Inactive vendor and inactive access providers
@@ -3299,7 +3332,7 @@ public class OrdersImplTest {
     reqData.getCompositePoLines().get(0).getEresource().setAccessProvider(INACTIVE_ACCESS_PROVIDER_A);
     reqData.getCompositePoLines().get(1).getEresource().setAccessProvider(INACTIVE_ACCESS_PROVIDER_B);
     Errors allInactiveErrors
-      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).toString(), EMPTY, 422).as(Errors.class);
+      = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), EMPTY, 422).as(Errors.class);
     checkExpectedError(INACTIVE_VENDOR_ID, allInactiveErrors, 0, ORDER_VENDOR_IS_INACTIVE);
     checkExpectedError(INACTIVE_ACCESS_PROVIDER_A, allInactiveErrors, 1, POL_ACCESS_PROVIDER_IS_INACTIVE);
     checkExpectedError(INACTIVE_ACCESS_PROVIDER_B, allInactiveErrors, 2, POL_ACCESS_PROVIDER_IS_INACTIVE);
@@ -3319,7 +3352,7 @@ public class OrdersImplTest {
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
 
     Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()),
-      JsonObject.mapFrom(reqData).toString(), EMPTY, 422).as(Errors.class);
+      JsonObject.mapFrom(reqData), EMPTY, 422).as(Errors.class);
 
     assertThat(errors.getErrors(), hasSize(2));
 
@@ -3529,6 +3562,10 @@ public class OrdersImplTest {
     return new JsonObject();
   }
 
+  private Response verifyPut(String url, JsonObject body, String expectedContentType, int expectedCode) {
+    return verifyPut(url, body.encodePrettily(), expectedContentType, expectedCode);
+  }
+
   private Response verifyPut(String url, String body, String expectedContentType, int expectedCode) {
     return RestAssured
       .with()
@@ -3676,10 +3713,15 @@ public class OrdersImplTest {
       JsonObject body = ctx.getBodyAsJson();
       addServerRqRsData(HttpMethod.POST, HOLDINGS_RECORD, body);
 
+      // the case when item creation is expected to fail for particular holding
+      String id = body.getString(HOLDING_PERMANENT_LOCATION_ID).equals(ID_FOR_INTERNAL_SERVER_ERROR)
+        ? ID_FOR_INTERNAL_SERVER_ERROR
+        : UUID.randomUUID().toString();
+
       ctx.response()
         .setStatusCode(201)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .putHeader(HttpHeaders.LOCATION, ctx.request().absoluteURI() + "/" + UUID.randomUUID().toString())
+        .putHeader(HttpHeaders.LOCATION, ctx.request().absoluteURI() + "/" + id)
         .end();
     }
 

--- a/src/test/resources/mockdata/pieces/pieceRecord.json
+++ b/src/test/resources/mockdata/pieces/pieceRecord.json
@@ -1,6 +1,7 @@
 {
   "caption": "Tutorial Volume 5",
   "comment": "Special Edition",
+  "format": "Physical",
   "itemId": "522a501a-56b5-48d9-b28a-3a8f02482d97",
   "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
   "poLineId": "d471d766-8dbb-4609-999a-02681dea6c22",

--- a/src/test/resources/mockdata/receivingHistory/receivingHistory.json
+++ b/src/test/resources/mockdata/receivingHistory/receivingHistory.json
@@ -12,7 +12,6 @@
         "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
         "poLineId": "c1498090-538a-4470-9525-27e4e0c74b07",
         "poLineNumber": "268758-03",
-        "poLineOrderFormat": "Physical Resource",
         "poLineReceiptStatus": "Partially Received",
         "purchaseOrderId": "0804ddec-6545-404a-b54d-a693f505681d",
         "receivedDate": "2018-10-09T00:00:00.000Z",

--- a/src/test/resources/mockdata/receivingHistory/receivingHistory.json
+++ b/src/test/resources/mockdata/receivingHistory/receivingHistory.json
@@ -10,15 +10,31 @@
         "dateOrdered": "2018-09-09T00:00:00.000",
         "itemId": "1c92433e-916d-452e-ac76-5268d0ec3f66",
         "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
+        "pieceFormat": "Physical",
         "poLineId": "c1498090-538a-4470-9525-27e4e0c74b07",
         "poLineNumber": "268758-03",
         "poLineReceiptStatus": "Partially Received",
         "purchaseOrderId": "0804ddec-6545-404a-b54d-a693f505681d",
-        "receivedDate": "2018-10-09T00:00:00.000Z",
         "receivingNote": "ASD FGH ABCDEFGHIJKLMNOPQ",
         "receivingStatus": "Expected",
         "supplement": true,
         "title": "Kayak Fishing in the Northern Gulf Coast"
+      },
+      {
+        "id": "2b9fc1d9-2a8a-48fa-9192-44c97964854c",
+        "checkin": false,
+        "instanceId": "e263278e-a464-4b1b-bba3-675074925a25",
+        "dateOrdered": "2018-09-09T00:00:00.000",
+        "itemId": "ed280cce-4354-4f01-a195-5d50189d6440",
+        "locationId": "b241764c-1466-4e1d-a028-1a3684a5da87",
+        "pieceFormat": "Electronic",
+        "poLineId": "ce1813c0-bdf2-4ab9-9e16-6fd497b825e7",
+        "poLineNumber": "12345678-1",
+        "poLineReceiptStatus": "Fully Received",
+        "purchaseOrderId": "6eee8eb9-db1a-46e2-a8ad-780f19974efa",
+        "receivedDate": "2018-10-09T00:00:00.000Z",
+        "receivingStatus": "Received",
+        "title": "Harry Potter and the Sorcerer's Stone"
       }
     ],
   "totalRecords": 1


### PR DESCRIPTION
## Purpose
[MODORDERS-194](https://issues.folio.org/browse/MODORDERS-194) Adjustments to piece and receiving-history regarding piece vs order type

## Approach
- Build piece record of corresponding format on item creation in InventoryHelper
- Build piece record of corresponding format without linked item in PurchaseOrderLineHelper
- Updating unit tests to verify piece format

#### TODOS and Open Questions
- [ ] The changes here conflicts with PR https://github.com/folio-org/mod-orders/pull/130. Clarify which approach should be used before merging to master
- [ ] Use merge commit once https://github.com/folio-org/acq-models/pull/107 is merged.
- [ ] Merge together with https://github.com/folio-org/mod-orders-storage/pull/99

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards ([sonar PR#131](https://sonarcloud.io/dashboard?id=org.folio%3Amod-orders&pullRequest=131))?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
