### PR TITLE
MODORDERS-209 fix for the hanging orders bug

### DIFF
--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -156,7 +156,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
           if (!config.isEmpty() && !config.getString(CREATE_INVENTORY).isEmpty()) {
             return future.complete(new JsonObject(config.getString(CREATE_INVENTORY)));
           } else {
-            return completedFuture(new JsonObject());
+            return future.complete(new JsonObject());
           }
         })
         .exceptionally(t -> future.complete(new JsonObject()));

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -153,7 +153,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
     if (isCreateInventoryNull(compPOL)) {
       getTenantConfiguration()
         .thenApply(config -> {
-          if (!config.isEmpty() && !config.getString(CREATE_INVENTORY).isEmpty()) {
+          if (StringUtils.isNotEmpty(config.getString(CREATE_INVENTORY))) {
             return future.complete(new JsonObject(config.getString(CREATE_INVENTORY)));
           } else {
             return future.complete(new JsonObject());

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -1572,6 +1572,34 @@ public class OrdersImplTest {
   }
 
   @Test
+  public void testPostOrdersWithEmptyCreateInventoryAndEmptyConfiguration() throws Exception {
+    JsonObject order = new JsonObject(getMockData(MONOGRAPH_FOR_CREATE_INVENTORY_TEST));
+    // Get Open Order
+    CompositePurchaseOrder reqData = order.mapTo(CompositePurchaseOrder.class);
+    // Make sure that Order moves to Open
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+
+    // Clear CreateInventory for setting default values
+    reqData.getCompositePoLines().get(0).getPhysical().setCreateInventory(null);
+    reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(null);
+
+    final CompositePurchaseOrder resp = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
+      prepareHeaders(EMPTY_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+
+    List<JsonObject> instancesSearches = MockServer.serverRqRs.get(INSTANCE_RECORD, HttpMethod.GET);
+    List<JsonObject> holdingsSearches = MockServer.serverRqRs.get(HOLDINGS_RECORD, HttpMethod.GET);
+    List<JsonObject> itemsSearches = MockServer.serverRqRs.get(ITEM_RECORDS, HttpMethod.GET);
+    List<JsonObject> createdPieces = MockServer.serverRqRs.get(PIECES, HttpMethod.POST);
+
+    assertNotNull(instancesSearches);
+    assertNotNull(holdingsSearches);
+    assertNotNull(itemsSearches);
+    verifyInventoryInteraction(resp, 1);
+
+    assertNotNull(createdPieces);
+  }
+
+  @Test
   public void testPutOrdersByIdToChangeStatusToOpenWithCheckinItems() throws Exception {
     logger.info("=== Test Put Order By Id to change status of Order to Open ===");
 


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDERS-209
## Purpose
Bugfix needed for the case of order creation with `poLine.physical.createInventory/poLine.eresource.createInventory` not specified in the order and the tenant-specific settings are empty.
## Approach
* fixing future completion, adding unit test to cover this piece of code

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?