### PR TITLE
MODORDERS-211  Order Status: Align POL Payment and Receipt status with PO Status when opening order

### DIFF
--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -20,6 +20,7 @@ public class ResourcePathResolver {
   public static final String PIECES = "pieces";
   public static final String RECEIVING_HISTORY = "receiving-history";
   public static final String RECEIPT_STATUS = "receiptStatus";
+  public static final String PAYMENT_STATUS = "paymentStatus";
 
 
   private static final Map<String, String> SUB_OBJECT_ITEM_APIS;

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -227,7 +227,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
     return fetchCompositePoLines(compPO)
       .thenCompose(this::updateInventory)
       .thenCompose(v -> updateOrderSummary(compPO))
-      .thenAccept(v -> changePoLineReceiptStatuses(compPO))
+      .thenAccept(v -> changePoLineStatuses(compPO))
       .thenCompose(v -> updateCompositePoLines(compPO));
   }
 
@@ -394,12 +394,23 @@ public class PurchaseOrderHelper extends AbstractHelper {
     return completedFuture(compPO);
   }
 
-  private void changePoLineReceiptStatuses(CompositePurchaseOrder compPO) {
+  private void changePoLineStatuses(CompositePurchaseOrder compPO) {
     compPO.getCompositePoLines().forEach(poLine -> {
-      if (poLine.getReceiptStatus() == CompositePoLine.ReceiptStatus.PENDING) {
-        poLine.setReceiptStatus(CompositePoLine.ReceiptStatus.AWAITING_RECEIPT);
-      }
+      changeReceiptStatus(poLine);
+      changePaymentStatus(poLine);
     });
+  }
+
+  private void changePaymentStatus(CompositePoLine poLine) {
+    if (poLine.getPaymentStatus() == CompositePoLine.PaymentStatus.PENDING) {
+      poLine.setPaymentStatus(CompositePoLine.PaymentStatus.AWAITING_PAYMENT);
+    }
+  }
+
+  private void changeReceiptStatus(CompositePoLine poLine) {
+    if (poLine.getReceiptStatus() == CompositePoLine.ReceiptStatus.PENDING) {
+      poLine.setReceiptStatus(CompositePoLine.ReceiptStatus.AWAITING_RECEIPT);
+    }
   }
 
   private CompletionStage<Void> validatePoNumber(CompositePurchaseOrder poFromStorage, CompositePurchaseOrder updatedPo) {

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -482,6 +482,10 @@ public class OrdersImplTest {
 
     CompositePurchaseOrder reqData = getMockDraftOrder().mapTo(CompositePurchaseOrder.class);
     reqData.setId(ID_FOR_PRINT_MONOGRAPH_ORDER);
+    reqData.getCompositePoLines().forEach(poLine -> {
+      poLine.setPaymentStatus(CompositePoLine.PaymentStatus.PENDING);
+      poLine.setReceiptStatus(CompositePoLine.ReceiptStatus.PARTIALLY_RECEIVED);
+    });
     CompositePoLine firstPoLine = reqData.getCompositePoLines().get(0);
     // remove productId from PO line to test scenario when it's not provided so there is no check for existing instance but new one will be created
     firstPoLine.getDetails().getProductIds().clear();
@@ -547,6 +551,8 @@ public class OrdersImplTest {
 
     verifyInventoryInteraction(resp, polCount);
     verifyCalculatedData(resp);
+    verifyReceiptStatusChangedTo(CompositePoLine.ReceiptStatus.PARTIALLY_RECEIVED.value(), reqData.getCompositePoLines().size());
+    verifyPaymentStatusChangedTo(CompositePoLine.PaymentStatus.AWAITING_PAYMENT.value(), reqData.getCompositePoLines().size());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[MODORDERS-211](https://issues.folio.org/browse/MODORDERS-211) POL paymentStatus should be updated when opening an order

## Approach
When order is opened, paymentStatus of POLs transitions as follows:
  - if "Pending" -> "Awaiting Payment"
  - If not "Pending", leave as-is.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.