### PR TITLE
MODORDERS-210 - Make locationId as not required in Check-in flow

### DIFF
--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -39,7 +39,8 @@ public enum ErrorCodes {
   COST_UNIT_PRICE_INVALID("costUnitPriceInvalid", "Cost's list unit price is invalid"),
   COST_UNIT_PRICE_ELECTRONIC_INVALID("costUnitPriceElectronicInvalid", "Cost's list unit price for Electronic resource(s) is invalid"),
   COST_ADDITIONAL_COST_INVALID("costAdditionalCostInvalid", "Cost's additional cost must be positive number"),
-  COST_DISCOUNT_INVALID("costDiscountInvalid", "Cost's discount is invalid");
+  COST_DISCOUNT_INVALID("costDiscountInvalid", "Cost's discount is invalid"),
+  LOC_NOT_PROVIDED("locNotProvided", "Location not provided");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/rest/impl/CheckinHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinHelper.java
@@ -180,8 +180,8 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
   }
 
   @Override
-  String getLocationId(PoLine poLine, Piece piece) {
-    return checkinPieces.get(poLine.getId()).get(piece.getId()).getLocationId();
+  String getLocationId(Piece piece) {
+    return checkinPieces.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
@@ -582,7 +582,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
   private boolean isMissingLocation(PoLine poLine, Piece piece) {
     // Check if locationId doesn't presented in piece from request and retrieved from storage
     // Corresponding piece from collection
-    if (getLocationId(poLine, piece) == null && piece.getLocationId() == null && !isRevertToOnOrder(piece)) {
+    if (getLocationId(poLine, piece) == null && !isRevertToOnOrder(piece)) {
       if (piece.getFormat() == Piece.Format.ELECTRONIC) {
         // Check Eresource
         if (poLine.getEresource() != null && poLine.getEresource().getCreateInventory() != Eresource.CreateInventory.NONE

--- a/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
@@ -582,9 +582,9 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
   private boolean isMissingLocation(PoLine poLine, Piece piece) {
     // Check if locationId doesn't presented in piece from request and retrieved from storage
     // Corresponding piece from collection
-    if (getLocationId(poLine, piece) == null && !isRevertToOnOrder(piece)) {
+    if (getLocationId(piece) == null && !isRevertToOnOrder(piece)) {
       if (piece.getFormat() == Piece.Format.ELECTRONIC) {
-        // Check Eresource
+        // Check E-Resource
         if (poLine.getEresource() != null && poLine.getEresource().getCreateInventory() != Eresource.CreateInventory.NONE
           && poLine.getEresource().getCreateInventory() != Eresource.CreateInventory.INSTANCE) {
           addError(poLine.getId(), piece.getId(), LOC_NOT_PROVIDED.toError());
@@ -602,6 +602,6 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
     return false;
   }
 
-  abstract String getLocationId(PoLine poLine, Piece piece);
+  abstract String getLocationId(Piece piece);
 
 }

--- a/src/main/java/org/folio/rest/impl/ReceivingHelper.java
+++ b/src/main/java/org/folio/rest/impl/ReceivingHelper.java
@@ -55,15 +55,17 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
 
     // 1. Get piece records from storage
     return this.retrievePieceRecords(receivingItems)
-      // 2. Update items in the Inventory if required
+      // 2. Filter locationId
+      .thenCompose(this::filterMissingLocations)
+      // 3. Update items in the Inventory if required
       .thenCompose(this::updateInventoryItems)
-      // 3. Update piece records with receiving details which do not have associated item
+      // 4. Update piece records with receiving details which do not have associated item
       .thenApply(this::updatePieceRecordsWithoutItems)
-      // 4. Update received piece records in the storage
+      // 5. Update received piece records in the storage
       .thenCompose(this::storeUpdatedPieceRecords)
-      // 5. Update PO Line status
+      // 6. Update PO Line status
       .thenCompose(this::updatePoLinesStatus)
-      // 6. Return results to the client
+      // 7. Return results to the client
       .thenApply(piecesGroupedByPoLine -> prepareResponseBody(receivingCollection, piecesGroupedByPoLine));
   }
 
@@ -202,6 +204,11 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
       piece.setReceivedDate(new Date());
       piece.setReceivingStatus(ReceivingStatus.RECEIVED);
     }
+  }
+
+  @Override
+  String getLocationId(PoLine poLine, Piece piece) {
+    return receivingItems.get(poLine.getId()).get(piece.getId()).getLocationId();
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/ReceivingHelper.java
+++ b/src/main/java/org/folio/rest/impl/ReceivingHelper.java
@@ -207,8 +207,8 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
   }
 
   @Override
-  String getLocationId(PoLine poLine, Piece piece) {
-    return receivingItems.get(poLine.getId()).get(piece.getId()).getLocationId();
+  String getLocationId(Piece piece) {
+    return receivingItems.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
   }
 
 }

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -3708,21 +3708,12 @@ public class OrdersImplTest {
       .withToBeCheckedIn(toBeCheckedInList)
       .withTotalRecords(2);
 
-    String physicalPieceWithLocationId = "6689da99-8256-448c-8a28-db3b4d9e4017";
-    String electronicPieceWithLocationId = "fe51ae61-52f1-40ce-8236-825d4710a8b7";
     String physicalPieceWithoutLocationId = "90894300-5285-4d83-80f4-76cf621e555e";
     String electronicPieceWithoutLocationId = "1a247602-c51a-4221-9a07-27d075d03625";
 
     // Positive cases:
-    // 1. Both CheckInPieces don't contain LocationId but corresponding Pieces contain locationId
-    request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setId(physicalPieceWithLocationId);
-    request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setLocationId(null);
-    request.getToBeCheckedIn().get(0).getCheckInPieces().get(1).setId(electronicPieceWithLocationId);
-    request.getToBeCheckedIn().get(0).getCheckInPieces().get(1).setLocationId(null);
 
-    checkResultWithErrors(request, 0);
-
-    // 2. Both CheckInPiece with locationId
+    // 1. Both CheckInPiece with locationId
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setId(physicalPieceWithoutLocationId);
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setLocationId(UUID.randomUUID().toString());
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(1).setId(electronicPieceWithoutLocationId);

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -109,7 +109,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
-import org.junit.runners.Parameterized;
 
 import javax.ws.rs.core.Response.Status;
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -3705,7 +3705,6 @@ public class OrdersImplTest {
   }
 
   @Test
-  @Parameterized.Parameters
   public void testPostCheckInLocationId() {
     logger.info("=== Test POST Checkin - locationId checking");
 

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -3303,7 +3303,7 @@ public class OrdersImplTest {
     assertThat(itemsSearches, not(nullValue()));
     assertThat(pieceUpdates, is(nullValue()));
     assertThat(itemUpdates, is(nullValue()));
-    assertThat(polSearches, is(nullValue()));
+    assertThat(polSearches, not(nullValue()));
     assertThat(polUpdates, is(nullValue()));
   }
 

--- a/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
+++ b/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
@@ -249,6 +249,12 @@
       "receivingStatus": "Expected"
     },
     {
+      "id": "8c057872-9c75-4fb1-879d-de3b089b0387",
+      "itemId": "c0ac82e3-e53f-48d1-a435-86d965250e47",
+      "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",
+      "receivingStatus": "Expected"
+    },
+    {
       "id": "8c057872-9c75-4fb1-879d-de3b089b0388",
       "itemId": "c0ac82e3-e53f-48d1-a435-86d965250e47",
       "poLineId": "cf447221-29b9-481e-947c-9ad545f22888",

--- a/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
+++ b/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
@@ -359,20 +359,7 @@
       "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
       "format": "Electronic",
       "receivingStatus": "Expected"
-    },
-    {
-      "id": "6689da99-8256-448c-8a28-db3b4d9e4017",
-      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
-      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
-      "receivingStatus": "Expected"
-    },
-    {
-      "id": "fe51ae61-52f1-40ce-8236-825d4710a8b7",
-      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
-      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
-      "format": "Electronic",
-      "receivingStatus": "Expected"
     }
   ],
-  "totalRecords": 60
+  "totalRecords": 58
 }

--- a/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
+++ b/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
@@ -348,7 +348,31 @@
       "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
       "poLineId": "7c98369b-89e4-4b2a-9793-ba36c056fc97",
       "receivingStatus": "Received"
+    },
+    {
+      "id": "90894300-5285-4d83-80f4-76cf621e555e",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "1a247602-c51a-4221-9a07-27d075d03625",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "format": "Electronic",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "6689da99-8256-448c-8a28-db3b4d9e4017",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "receivingStatus": "Expected"
+    },
+    {
+      "id": "fe51ae61-52f1-40ce-8236-825d4710a8b7",
+      "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
+      "poLineId": "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56",
+      "format": "Electronic",
+      "receivingStatus": "Expected"
     }
   ],
-  "totalRecords": 55
+  "totalRecords": 60
 }


### PR DESCRIPTION
[MODORDERS-210](https://issues.folio.org/browse/MODORDERS-210) - Make locationId as not required in Check-in flow

## Purpose
After removing locationId from required fields [PR#114](https://github.com/folio-org/acq-models/pull/114) one need to validate that locationId is provided when createInventory is set to "Instance, Holding" or "Instance, Holding, Item". If not, an appropriate error message & code are returned.

## Approach
1. Logic for checking locationId presence implemented as part of checkin flow. If the conditions are not met, the corresponding error is added without finishing flow execution.
2. POLines added as  property of Receiving/Checkin helper because we need to retrieve this information several times during checkin flow execution.
3. Unit test implemented.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.