### PR TITLE
MODORDERS-210 - Make locationId as not required in Check-in flow

### DIFF
--- a/src/main/java/org/folio/rest/impl/CheckinHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinHelper.java
@@ -180,8 +180,8 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
   }
 
   @Override
-  String getLocationId(PoLine poLine, Piece piece) {
-    return checkinPieces.get(poLine.getId()).get(piece.getId()).getLocationId();
+  String getLocationId(Piece piece) {
+    return checkinPieces.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
@@ -455,12 +455,15 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
    */
   private CompletableFuture<ReceiptStatus> calculatePoLineReceiptStatus(PoLine poLine, List<Piece> pieces) {
     // Search for pieces with Expected status
-    return getPiecesQuantityByPoLineAndStatus(poLine.getId(), ReceivingStatus.EXPECTED)
-      // Calculate receipt status
-      .thenCompose(expectedQty -> calculatePoLineReceiptStatus(expectedQty, poLine, pieces))
-      .exceptionally(e -> {
-        logger.error("The expected receipt status for PO Line '{}' cannot be calculated", e, poLine.getId());
-        return null;
+    return pieces.isEmpty()
+      // No successfully pieces processed - receipt status unchanged
+      ? completedFuture(poLine.getReceiptStatus())
+      : getPiecesQuantityByPoLineAndStatus(poLine.getId(), ReceivingStatus.EXPECTED)
+        // Calculate receipt status
+        .thenCompose(expectedQty -> calculatePoLineReceiptStatus(expectedQty, poLine, pieces))
+        .exceptionally(e -> {
+          logger.error("The expected receipt status for PO Line '{}' cannot be calculated", e, poLine.getId());
+          return null;
       });
   }
 

--- a/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
@@ -582,9 +582,9 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
   private boolean isMissingLocation(PoLine poLine, Piece piece) {
     // Check if locationId doesn't presented in piece from request and retrieved from storage
     // Corresponding piece from collection
-    if (getLocationId(poLine, piece) == null && !isRevertToOnOrder(piece)) {
+    if (getLocationId(piece) == null && !isRevertToOnOrder(piece)) {
       if (piece.getFormat() == Piece.Format.ELECTRONIC) {
-        // Check Eresource
+        // Check E-Resource
         if (poLine.getEresource() != null && poLine.getEresource().getCreateInventory() != Eresource.CreateInventory.NONE
           && poLine.getEresource().getCreateInventory() != Eresource.CreateInventory.INSTANCE) {
           addError(poLine.getId(), piece.getId(), LOC_NOT_PROVIDED.toError());
@@ -602,6 +602,6 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
     return false;
   }
 
-  abstract String getLocationId(PoLine poLine, Piece piece);
+  abstract String getLocationId(Piece piece);
 
 }

--- a/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
@@ -570,13 +570,13 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
    *         and list of corresponding pieces as value
    */
   CompletableFuture<Map<String, List<Piece>>> filterMissingLocations(Map<String, List<Piece>> piecesRecords) {
-    getPoLines(piecesRecords)
-      .thenAccept(poLines -> {
+    return getPoLines(piecesRecords)
+      .thenApply(poLines -> {
         for(PoLine poLine : poLines) {
           piecesRecords.get(poLine.getId()).removeIf(piece -> isMissingLocation(poLine, piece));
         }
+        return piecesRecords;
       });
-    return VertxCompletableFuture.completedFuture(piecesRecords);
   }
 
   private boolean isMissingLocation(PoLine poLine, Piece piece) {

--- a/src/main/java/org/folio/rest/impl/ReceivingHelper.java
+++ b/src/main/java/org/folio/rest/impl/ReceivingHelper.java
@@ -207,8 +207,8 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
   }
 
   @Override
-  String getLocationId(PoLine poLine, Piece piece) {
-    return receivingItems.get(poLine.getId()).get(piece.getId()).getLocationId();
+  String getLocationId(Piece piece) {
+    return receivingItems.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
   }
 
 }

--- a/src/test/java/org/folio/rest/impl/OrdersImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersImplTest.java
@@ -3679,18 +3679,34 @@ public class OrdersImplTest {
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(1).setId(electronicPieceWithoutLocationId);
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(1).setLocationId(UUID.randomUUID().toString());
 
+    MockServer.serverRqRs.clear();
     checkResultWithErrors(request, 0);
+    assertThat(MockServer.serverRqRs.get(PIECES, HttpMethod.GET), hasSize(2));
+    assertThat(MockServer.serverRqRs.get(PIECES, HttpMethod.PUT), hasSize(2));
+    assertThat(MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET), hasSize(1));
+    assertThat(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT), hasSize(1));
 
     // Negative cases:
     // 1. One CheckInPiece and corresponding Piece without locationId
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setLocationId(null);
 
+    MockServer.serverRqRs.clear();
     checkResultWithErrors(request, 1);
+    assertThat(MockServer.serverRqRs.get(PIECES, HttpMethod.GET), hasSize(2));
+    assertThat(MockServer.serverRqRs.get(PIECES, HttpMethod.PUT), hasSize(1));
+    assertThat(MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET), hasSize(1));
+    assertThat(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT), hasSize(1));
 
     // 2. All CheckInPieces and corresponding Pieces without locationId
+    request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setLocationId(null);
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(1).setLocationId(null);
 
+    MockServer.serverRqRs.clear();
     checkResultWithErrors(request, 2);
+    assertThat(MockServer.serverRqRs.get(PIECES, HttpMethod.GET), hasSize(1));
+    assertThat(MockServer.serverRqRs.get(PIECES, HttpMethod.PUT), nullValue());
+    assertThat(MockServer.serverRqRs.get(PO_LINES, HttpMethod.GET), hasSize(1));
+    assertThat(MockServer.serverRqRs.get(PO_LINES, HttpMethod.PUT), nullValue());
   }
 
   private void checkResultWithErrors(CheckinCollection request, int expectedNumOfErrors) {


### PR DESCRIPTION
Fixing issue with failed piece removing from piece records map for [PR#140](https://github.com/folio-org/mod-orders/pull/140)