### PR TITLE
MODORDERS-229 - Sort PO Lines array by POLNumber in composite PO GET by id response

### DIFF
--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -52,7 +52,6 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
   private static final String SEARCH_PURCHASE_ORDERS = resourcesPath(SEARCH_ORDERS) + "?limit=%s&offset=%s%s&lang=%s";
   private static final String GET_PURCHASE_ORDERS = resourcesPath(PURCHASE_ORDER) + "?limit=%s&offset=%s&lang=%s";
-  private static final String DASH = "-";
 
   private final PoNumberHelper poNumberHelper;
   private final PurchaseOrderLineHelper orderLineHelper;
@@ -197,7 +196,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
         getCompositePoLines(id, lang, httpClient, ctx, okapiHeaders, logger)
           .thenApply(poLines -> {
-            poLines.sort(PurchaseOrderHelper::comparePoLinesByPoLineNumber);
+            orderLineHelper.sortPoLinesByPoLineNumber(poLines);
             return poLines;
           })
           .thenApply(compPO::withCompositePoLines)
@@ -566,27 +565,4 @@ public class PurchaseOrderHelper extends AbstractHelper {
       .stream()
       .filter(poLine -> !lineIdsInStorage.contains(poLine.getId()));
   }
-
-  private static int comparePoLinesByPoLineNumber(CompositePoLine poLine1, CompositePoLine poLine2) {
-    String[] poLineNumberArray1 = poLine1.getPoLineNumber().split(DASH);
-    String[] poLineNumberArray2 = poLine2.getPoLineNumber().split(DASH);
-    int value;
-    return (value = compareStringInAlphaNumericOrder(poLineNumberArray1[0], poLineNumberArray2[0])) != 0 ? value
-      : compareStringInAlphaNumericOrder(poLineNumberArray1[1], poLineNumberArray2[1]);
-  }
-
-  private static int compareStringInAlphaNumericOrder(String str1, String str2) {
-    boolean isFirstNumeric = StringUtils.isNumeric(str1);
-    boolean isSecondNumeric = StringUtils.isNumeric(str2);
-    if(isFirstNumeric && isSecondNumeric) {
-      return Integer.parseInt(str1) - Integer.parseInt(str2);
-    } else if(isFirstNumeric) {
-      return -1;
-    } else if(isSecondNumeric) {
-      return 1;
-    } else {
-      return str1.compareTo(str2);
-    }
-  }
-
 }

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -52,6 +52,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
   private static final String SEARCH_PURCHASE_ORDERS = resourcesPath(SEARCH_ORDERS) + "?limit=%s&offset=%s%s&lang=%s";
   private static final String GET_PURCHASE_ORDERS = resourcesPath(PURCHASE_ORDER) + "?limit=%s&offset=%s&lang=%s";
+  private static final String DASH = "-";
 
   private final PoNumberHelper poNumberHelper;
   private final PurchaseOrderLineHelper orderLineHelper;
@@ -195,6 +196,10 @@ public class PurchaseOrderHelper extends AbstractHelper {
         CompositePurchaseOrder compPO = HelperUtils.convertToCompositePurchaseOrder(po);
 
         getCompositePoLines(id, lang, httpClient, ctx, okapiHeaders, logger)
+          .thenApply(poLines -> {
+            poLines.sort(PurchaseOrderHelper::comparePoLinesByPoLineNumber);
+            return poLines;
+          })
           .thenApply(compPO::withCompositePoLines)
           .thenApply(this::populateOrderSummary)
           .thenAccept(future::complete)
@@ -561,4 +566,27 @@ public class PurchaseOrderHelper extends AbstractHelper {
       .stream()
       .filter(poLine -> !lineIdsInStorage.contains(poLine.getId()));
   }
+
+  private static int comparePoLinesByPoLineNumber(CompositePoLine poLine1, CompositePoLine poLine2) {
+    String[] poLineNumberArray1 = poLine1.getPoLineNumber().split(DASH);
+    String[] poLineNumberArray2 = poLine2.getPoLineNumber().split(DASH);
+    int value;
+    return (value = compareStringInAlphaNumericOrder(poLineNumberArray1[0], poLineNumberArray2[0])) != 0 ? value
+      : compareStringInAlphaNumericOrder(poLineNumberArray1[1], poLineNumberArray2[1]);
+  }
+
+  private static int compareStringInAlphaNumericOrder(String str1, String str2) {
+    boolean isFirstNumeric = StringUtils.isNumeric(str1);
+    boolean isSecondNumeric = StringUtils.isNumeric(str2);
+    if(isFirstNumeric && isSecondNumeric) {
+      return Integer.parseInt(str1) - Integer.parseInt(str2);
+    } else if(isFirstNumeric) {
+      return -1;
+    } else if(isSecondNumeric) {
+      return 1;
+    } else {
+      return str1.compareTo(str2);
+    }
+  }
+
 }

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -60,6 +60,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
   private static final String ERESOURCE = "eresource";
   private static final String PHYSICAL = "physical";
   private static final String OTHER = "other";
+  private static final String REGEX_DASH = "-";
 
   private final InventoryHelper inventoryHelper;
 
@@ -364,6 +365,10 @@ class PurchaseOrderLineHelper extends AbstractHelper {
     }
     logger.error("PO Line - {} has invalid or missing number.", poLineFromStorage.getString(ID));
     return oldPoLineNumber;
+  }
+
+  void sortPoLinesByPoLineNumber(List<CompositePoLine> poLines) {
+    poLines.sort(this::comparePoLinesByPoLineNumber);
   }
 
   /**
@@ -768,5 +773,11 @@ class PurchaseOrderLineHelper extends AbstractHelper {
       }
     }
     return completedFuture(null);
+  }
+
+  private int comparePoLinesByPoLineNumber(CompositePoLine poLine1, CompositePoLine poLine2) {
+    String poLineNumberSuffix1 = poLine1.getPoLineNumber().split(REGEX_DASH)[1];
+    String poLineNumberSuffix2 = poLine2.getPoLineNumber().split(REGEX_DASH)[1];
+    return Integer.parseInt(poLineNumberSuffix1) - Integer.parseInt(poLineNumberSuffix2);
   }
 }

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -60,7 +60,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
   private static final String ERESOURCE = "eresource";
   private static final String PHYSICAL = "physical";
   private static final String OTHER = "other";
-  private static final String REGEX_DASH = "-";
+  private static final String DASH_SEPARATOR = "-";
 
   private final InventoryHelper inventoryHelper;
 
@@ -432,7 +432,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
   }
 
   private String buildPoLineNumber(String poNumber, String sequence) {
-    return poNumber + "-" + sequence;
+    return poNumber + DASH_SEPARATOR + sequence;
   }
 
   /**
@@ -776,8 +776,8 @@ class PurchaseOrderLineHelper extends AbstractHelper {
   }
 
   private int comparePoLinesByPoLineNumber(CompositePoLine poLine1, CompositePoLine poLine2) {
-    String poLineNumberSuffix1 = poLine1.getPoLineNumber().split(REGEX_DASH)[1];
-    String poLineNumberSuffix2 = poLine2.getPoLineNumber().split(REGEX_DASH)[1];
+    String poLineNumberSuffix1 = poLine1.getPoLineNumber().split(DASH_SEPARATOR)[1];
+    String poLineNumberSuffix2 = poLine2.getPoLineNumber().split(DASH_SEPARATOR)[1];
     return Integer.parseInt(poLineNumberSuffix1) - Integer.parseInt(poLineNumberSuffix2);
   }
 }

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -790,7 +790,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
   public void testGetOrderByIdWithPoLinesSorting() {
     logger.info("=== Test Get Order By Id - PoLines sorting ===");
 
-    String[] expectedPoLineNumbers = {"200-2", "201-1", "201-2", "1001-21", "841240-021", "ABCD32-011", "C25DE-021"};
+    String[] expectedPoLineNumbers = {"841240-001", "841240-02", "841240-3", "841240-21"};
 
     logger.info(String.format("using mock datafile: %s%s.json", COMP_ORDER_MOCK_DATA_PATH, ORDER_WIT_PO_LINES_FOR_SORTING));
     final CompositePurchaseOrder resp = verifySuccessGet(String.format(COMPOSITE_ORDERS_BY_ID_PATH, ORDER_WIT_PO_LINES_FOR_SORTING), CompositePurchaseOrder.class);

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -27,6 +27,7 @@ import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.PurchaseOrders;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -34,6 +35,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -100,6 +103,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -134,6 +138,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
   private static final String PO_ID_FOR_FAILURE_CASE = "bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa";
   private static final String ORDER_ID_WITHOUT_PO_LINES = "50fb922c-3fa9-494e-a972-f2801f1b9fd1";
   private static final String ORDER_WITHOUT_WORKFLOW_STATUS = "41d56e59-46db-4d5e-a1ad-a178228913e5";
+  static final String ORDER_WIT_PO_LINES_FOR_SORTING =  "9a952cd0-842b-4e71-bddd-014eb128dc8e";
 
   // API paths
   private final static String COMPOSITE_ORDERS_PATH = "/orders/composite-orders";
@@ -781,6 +786,18 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     verifyCalculatedData(resp);
   }
 
+  @Test
+  public void testGetOrderByIdWithPoLinesSorting() {
+    logger.info("=== Test Get Order By Id - PoLines sorting ===");
+
+    String[] expectedPoLineNumbers = {"200-2", "201-1", "201-2", "1001-21", "841240-021", "ABCD32-011", "C25DE-021"};
+
+    logger.info(String.format("using mock datafile: %s%s.json", COMP_ORDER_MOCK_DATA_PATH, ORDER_WIT_PO_LINES_FOR_SORTING));
+    final CompositePurchaseOrder resp = verifySuccessGet(String.format(COMPOSITE_ORDERS_BY_ID_PATH, ORDER_WIT_PO_LINES_FOR_SORTING), CompositePurchaseOrder.class);
+    logger.info(JsonObject.mapFrom(resp).encodePrettily());
+
+    assertArrayEquals(expectedPoLineNumbers, resp.getCompositePoLines().stream().map(CompositePoLine::getPoLineNumber).toArray());
+  }
 
   private void verifyCalculatedData(CompositePurchaseOrder resp) {
     Integer expectedQuantity = resp

--- a/src/test/resources/mockdata/compositeOrders/9a952cd0-842b-4e71-bddd-014eb128dc8e.json
+++ b/src/test/resources/mockdata/compositeOrders/9a952cd0-842b-4e71-bddd-014eb128dc8e.json
@@ -1,0 +1,89 @@
+{
+  "id": "9a952cd0-842b-4e71-bddd-014eb128dc8e",
+  "compositePoLines": [
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 0.9
+      },
+      "poLineNumber": "1001-21"
+    },
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 0.9
+      },
+      "poLineNumber": "201-2"
+    },
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 0.9
+      },
+      "poLineNumber": "200-2"
+    },
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 0.9
+      },
+      "poLineNumber": "201-1"
+    },
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 0.9
+      },
+      "poLineNumber": "C25DE-021"
+    },
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 0.9
+      },
+      "poLineNumber": "ABCD32-011"
+    },
+    {
+      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 0.9
+      },
+      "poLineNumber": "841240-021"
+    }
+  ]
+}

--- a/src/test/resources/mockdata/compositeOrders/9a952cd0-842b-4e71-bddd-014eb128dc8e.json
+++ b/src/test/resources/mockdata/compositeOrders/9a952cd0-842b-4e71-bddd-014eb128dc8e.json
@@ -11,7 +11,7 @@
         "quantityPhysical": 1,
         "poLineEstimatedPrice": 0.9
       },
-      "poLineNumber": "1001-21"
+      "poLineNumber": "841240-02"
     },
     {
       "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
@@ -23,7 +23,7 @@
         "quantityPhysical": 1,
         "poLineEstimatedPrice": 0.9
       },
-      "poLineNumber": "201-2"
+      "poLineNumber": "841240-3"
     },
     {
       "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
@@ -35,7 +35,7 @@
         "quantityPhysical": 1,
         "poLineEstimatedPrice": 0.9
       },
-      "poLineNumber": "200-2"
+      "poLineNumber": "841240-21"
     },
     {
       "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
@@ -47,43 +47,7 @@
         "quantityPhysical": 1,
         "poLineEstimatedPrice": 0.9
       },
-      "poLineNumber": "201-1"
-    },
-    {
-      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
-      "cost": {
-        "listUnitPrice": 1.0,
-        "currency": "USD",
-        "discount": 10.0,
-        "discountType": "percentage",
-        "quantityPhysical": 1,
-        "poLineEstimatedPrice": 0.9
-      },
-      "poLineNumber": "C25DE-021"
-    },
-    {
-      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
-      "cost": {
-        "listUnitPrice": 1.0,
-        "currency": "USD",
-        "discount": 10.0,
-        "discountType": "percentage",
-        "quantityPhysical": 1,
-        "poLineEstimatedPrice": 0.9
-      },
-      "poLineNumber": "ABCD32-011"
-    },
-    {
-      "id": "50fb5514-cdf1-11e8-a8d5-f2801f1b9fd1",
-      "cost": {
-        "listUnitPrice": 1.0,
-        "currency": "USD",
-        "discount": 10.0,
-        "discountType": "percentage",
-        "quantityPhysical": 1,
-        "poLineEstimatedPrice": 0.9
-      },
-      "poLineNumber": "841240-021"
+      "poLineNumber": "841240-001"
     }
   ]
 }


### PR DESCRIPTION
[MODORDERS-229](https://issues.folio.org/browse/MODORDERS-229) - Sort PO Lines array by POLNumber in composite PO GET by id response

## Purpose
To support default sorting in PO Lines list with minimal efforts.

## Approach

Approach | Advantages | Disadvantages
-- | -- | --
Custom "comparator" in the PostgreSQL | "Native approach" | Hard implementation related to work on DB side
PoLineNumber format changing - adding zeroes at the begin of poLineNumber suffix |Simple implementation | This approach relates with additional difficulties in  the implementation of this approach, since it is necessary to provide  additional comparison logic and to process the string value for correct  displaying.
Comparator for suffix in mod-orders code | Simple implementation | Negative performance impact

Comparator for suffix in mod-orders code for sorting PoLines seems more simple. Sorting looks like, for example: 841240-1, 841240-02, 841240-2, 841240-21.


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
