### PR TITLE
MODORDERS-231-fixing error message for instance type

### DIFF
--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -41,7 +41,8 @@ public enum ErrorCodes {
   COST_ADDITIONAL_COST_INVALID("costAdditionalCostInvalid", "Cost's additional cost must be positive number"),
   COST_DISCOUNT_INVALID("costDiscountInvalid", "Cost's discount is invalid"),
   LOC_NOT_PROVIDED("locNotProvided", "Location not provided"),
-  ORGANIZATION_NOT_A_VENDOR("organizationNotAVendor", "Order cannot be opened as the associated vendorId belongs to an organization not vendor");
+  ORGANIZATION_NOT_A_VENDOR("organizationNotAVendor", "Order cannot be opened as the associated vendorId belongs to an organization not vendor"),
+  MISSING_INSTANCE_TYPE("missingInstanceType", "Instance-type is a required field for creating an Instance in Inventory");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -41,7 +41,7 @@ public enum ErrorCodes {
   COST_ADDITIONAL_COST_INVALID("costAdditionalCostInvalid", "Cost's additional cost must be positive number"),
   COST_DISCOUNT_INVALID("costDiscountInvalid", "Cost's discount is invalid"),
   LOC_NOT_PROVIDED("locNotProvided", "Location not provided"),
-  ORGANIZATION_NOT_A_VENDOR("organizationNotAVendor", "Order cannot be opened as the associated vendorId belongs to an organization not vendor"),
+  ORGANIZATION_NOT_A_VENDOR("organizationNotAVendor", "Order cannot be opened as the associated vendorId belongs to non-vendor organization"),
   MISSING_INSTANCE_TYPE("missingInstanceType", "Instance-type is a required field for creating an Instance in Inventory");
 
   private final String code;

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -91,11 +91,13 @@ public class ApiTestBase {
   static final String NON_EXIST_CONTRIBUTOR_NAME_TYPE_TENANT = "nonExistContributorNameType";
   static final String INSTANCE_TYPE_CONTAINS_CODE_AS_INSTANCE_STATUS_TENANT = "hasCodeLikeInstanceStatus";
   static final String NON_EXIST_INSTANCE_STATUS_TENANT = "nonExistInstanceStatus";
+  static final String NON_EXIST_INSTANCE_TYPE_TENANT = "nonExistInstanceType";
 
   protected static final Header X_OKAPI_URL = new Header("X-Okapi-Url", "http://localhost:" + mockPort);
 
   static final Header INSTANCE_TYPE_CONTAINS_CODE_AS_INSTANCE_STATUS_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, INSTANCE_TYPE_CONTAINS_CODE_AS_INSTANCE_STATUS_TENANT);
   static final Header NON_EXIST_INSTANCE_STATUS_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, NON_EXIST_INSTANCE_STATUS_TENANT);
+  static final Header NON_EXIST_INSTANCE_TYPE_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, NON_EXIST_INSTANCE_TYPE_TENANT);
 
   static final Header NON_EXIST_CONFIG_X_OKAPI_TENANT = new Header(OKAPI_HEADER_TENANT, "ordersimpltest");
   static final Header X_OKAPI_USER_ID = new Header(OKAPI_USERID_HEADER, "440c89e3-7f6c-578a-9ea8-310dad23605e");

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -96,6 +96,7 @@ import static org.folio.rest.impl.PurchaseOrdersApiTest.VENDOR_WITH_BAD_CONTENT;
 import static org.folio.rest.impl.PurchaseOrdersApiTest.ORGANIZATION_NOT_VENDOR;
 import static org.folio.rest.impl.ApiTestBase.X_ECHO_STATUS;
 import static org.folio.rest.impl.ReceivingHistoryApiTest.RECEIVING_HISTORY_PURCHASE_ORDER_ID;
+import static org.folio.rest.impl.ApiTestBase.NON_EXIST_INSTANCE_TYPE_TENANT;
 import static org.junit.Assert.fail;
 
 public class MockServer {
@@ -598,6 +599,10 @@ public class MockServer {
     try {
       if (INSTANCE_TYPE_CONTAINS_CODE_AS_INSTANCE_STATUS_TENANT.equals(tenantId)) {
         body = ApiTestBase.getMockData(INSTANCE_TYPES_MOCK_DATA_PATH + "temp.json");
+        serverResponse(ctx, HttpStatus.HTTP_OK.toInt(), APPLICATION_JSON, body);
+        addServerRqRsData(HttpMethod.GET, INSTANCE_TYPES, new JsonObject(body));
+      } else if (NON_EXIST_INSTANCE_TYPE_TENANT.equals(tenantId)) {
+        body = ApiTestBase.getMockData(INSTANCE_TYPES_MOCK_DATA_PATH + "empty_instance_type.json");
         serverResponse(ctx, HttpStatus.HTTP_OK.toInt(), APPLICATION_JSON, body);
         addServerRqRsData(HttpMethod.GET, INSTANCE_TYPES, new JsonObject(body));
       } else {

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -1918,6 +1918,34 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
   }
 
+  @Test
+  public void testInventoryHelperEmptyInstanceTypeThrowsProperError() throws Exception {
+
+    MockServer.serverRqRs.clear();
+    CompositePurchaseOrder reqData = getMockDraftOrder().mapTo(CompositePurchaseOrder.class);
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    reqData.getCompositePoLines()
+      .remove(1);
+    assertThat(reqData.getCompositePoLines(), hasSize(1));
+
+    Headers headers = prepareHeaders(NON_EXIST_INSTANCE_TYPE_TENANT_HEADER);
+
+    Response resp = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData)
+      .encodePrettily(), headers, APPLICATION_JSON, 500);
+
+    Error err = resp.getBody()
+      .as(Errors.class)
+      .getErrors()
+      .get(0);
+
+    assertThat(err.getCode(), equalTo(ErrorCodes.MISSING_INSTANCE_TYPE.getCode()));
+    assertThat(err.getMessage(), equalTo(ErrorCodes.MISSING_INSTANCE_TYPE.getDescription()));
+
+    assertThat(getContributorNameTypesSearches(), hasSize(1));
+    assertThat(getInstanceStatusesSearches(), hasSize(1));
+    assertThat(MockServer.getInstanceTypesSearches(), hasSize(1));
+  }
+
   private Errors verifyPostResponseErrors(int expectedErrorsNumber, String body) {
     Errors errors = verifyPostResponse(COMPOSITE_ORDERS_PATH, body,
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 422).as(Errors.class);

--- a/src/test/resources/mockdata/instanceTypes/empty_instance_type.json
+++ b/src/test/resources/mockdata/instanceTypes/empty_instance_type.json
@@ -1,0 +1,5 @@
+{
+  "instanceTypes": [
+  ],
+  "totalRecords": 0
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDERS-231
## Purpose
https://issues.folio.org/browse/MODORDERS-231 - throw proper error if instance-type is not present

## Approach
1) throwing a new error with proper code and message for the UI to map easily


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
