### PR TITLE
MODORDERS-244 - Missing module permission for getting contributor-name-types

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -43,6 +43,7 @@
             "inventory-storage.items.item.post",
             "inventory-storage.instances.item.get",
             "inventory-storage.loan-types.collection.get",
+            "inventory-storage.contributor-name-types.collection.get",
             "organizations-storage.organizations.collection.get",
             "organizations-storage.organizations.item.get"
           ]
@@ -79,6 +80,7 @@
             "inventory-storage.items.collection.get",
             "inventory-storage.items.item.post",
             "inventory-storage.loan-types.collection.get",
+            "inventory-storage.contributor-name-types.collection.get",
             "organizations-storage.organizations.collection.get",
             "organizations-storage.organizations.item.get"
           ]


### PR DESCRIPTION
[MODORDERS-244](https://issues.folio.org/browse/MODORDERS-244) - Missing module permission for getting contributor-name-types.

## Purpose
Fixing of missing module permission.


## Approach
Permission inventory-storage.contributor-name-types.collection.get added to endpoints: POST /orders/composite-orders and PUT /orders/composite-orders/<id>.


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
  