### PR TITLE
MODORDERS-234 Update PO status based on receipt/payment status

### DIFF
--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -484,6 +484,8 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
     if (changeOrderStatus(purchaseOrder, poLines)) {
       logger.debug("Workflow status update required for order with id={}", compPO.getId());
+      compPO.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.fromValue(purchaseOrder.getWorkflowStatus().value()));
+      compPO.setCloseReason(purchaseOrder.getCloseReason());
     }
 
     return handlePutRequest(resourceByIdPath(PURCHASE_ORDER, compPO.getId()), JsonObject.mapFrom(purchaseOrder), httpClient, ctx, okapiHeaders, logger);

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -1871,6 +1871,24 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
   }
 
   @Test
+  public void testPostOrderToAutomaticallyChangeStatusFromOpenToClosed() {
+
+    logger.info("===  Test case when order status update is expected from Open to Closed ===");
+
+    CompositePurchaseOrder reqData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, PO_ID_OPEN_TO_BE_CLOSED).mapTo(CompositePurchaseOrder.class);
+    reqData.setVendor("d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1");
+    assertThat(reqData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.OPEN));
+
+    CompositePurchaseOrder respData = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).encodePrettily(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+
+    assertThat(respData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.CLOSED));
+    assertThat(respData.getCloseReason(), notNullValue());
+    assertThat(respData.getCloseReason().getReason(), equalTo(HelperUtils.REASON_COMPLETE));
+
+  }
+
+  @Test
   public void testPutOrderToAutomaticallyChangeStatusFromClosedToOpen() {
 
     logger.info("=== Test case when order status update is expected from Closed to Open ===");


### PR DESCRIPTION
## Purpose
[MODORDERS-234](https://issues.folio.org/browse/MODORDERS-234) The workflowStatus, closeReason  of the order from the response to POST request does not correspond to the persisted.
## Approach
- return updated workflowStatus, closeReason 

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
