### PR TITLE
MODORDERS-245 Update module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -22,15 +22,17 @@
             "orders-storage.purchase-orders.collection.get",
             "orders-storage.purchase-orders.item.post",
             "orders-storage.purchase-orders.item.put",
+            "orders-storage.alerts.item.post",
+            "orders-storage.alerts.item.put",
             "orders-storage.po-lines.item.post",
             "orders-storage.po-lines.item.put",
             "orders-storage.po-lines.collection.get",
             "orders-storage.pieces.item.post",
             "orders-storage.pieces.collection.get",
-            "orders-storage.po-number.get",
-            "orders-storage.alerts.item.post",
-            "orders-storage.reporting-codes.item.post",
             "orders-storage.po-line-number.get",
+            "orders-storage.po-number.get",
+            "orders-storage.reporting-codes.item.post",
+            "orders-storage.reporting-codes.item.put",
             "configuration.entries.collection.get",
             "inventory-storage.identifier-types.collection.get",
             "inventory.instances.collection.get",
@@ -55,7 +57,7 @@
           "modulePermissions": [
             "orders-storage.purchase-orders.item.get",
             "orders-storage.po-lines.collection.get",
-             "orders-storage.alerts.item.get",
+            "orders-storage.alerts.item.get",
             "orders-storage.reporting-codes.item.get"
           ]
         },
@@ -64,12 +66,25 @@
           "pathPattern": "/orders/composite-orders/{id}",
           "permissionsRequired": ["orders.item.put"],
           "modulePermissions": [
+            "orders-storage.purchase-orders.collection.get",
             "orders-storage.purchase-orders.item.put",
-            "orders-storage.po-lines.all",
-            "orders-storage.alerts.all",
+            "orders-storage.purchase-orders.item.get",
+            "orders-storage.po-lines.collection.get",
+            "orders-storage.po-lines.item.post",
+            "orders-storage.po-lines.item.put",
+            "orders-storage.po-lines.item.delete",
+            "orders-storage.alerts.item.post",
+            "orders-storage.alerts.item.get",
+            "orders-storage.alerts.item.put",
+            "orders-storage.alerts.item.delete",
             "orders-storage.pieces.item.post",
             "orders-storage.pieces.collection.get",
-            "orders-storage.reporting-codes.all",
+            "orders-storage.po-line-number.get",
+            "orders-storage.reporting-codes.item.post",
+            "orders-storage.reporting-codes.item.get",
+            "orders-storage.reporting-codes.item.put",
+            "orders-storage.reporting-codes.item.delete",
+            "configuration.entries.collection.get",
             "inventory-storage.identifier-types.collection.get",
             "inventory.instances.collection.get",
             "inventory.instances.item.post",
@@ -91,10 +106,10 @@
           "permissionsRequired": ["orders.item.delete"],
           "modulePermissions": [
             "orders-storage.purchase-orders.item.delete",
+            "orders-storage.po-lines.collection.get",
             "orders-storage.po-lines.item.delete",
             "orders-storage.alerts.item.delete",
-            "orders-storage.reporting-codes.item.delete",
-            "orders-storage.sources.item.delete"
+            "orders-storage.reporting-codes.item.delete"
           ]
         },
         {
@@ -110,6 +125,9 @@
           "pathPattern": "/orders/order-lines",
           "permissionsRequired": ["orders.po-lines.item.post"],
           "modulePermissions": [
+            "orders-storage.purchase-orders.item.get",
+            "orders-storage.po-line-number.get",
+            "orders-storage.po-lines.collection.get",
             "orders-storage.po-lines.item.post",
             "orders-storage.alerts.item.post",
             "orders-storage.reporting-codes.item.post",
@@ -131,9 +149,16 @@
           "pathPattern": "/orders/order-lines/{id}",
           "permissionsRequired": ["orders.po-lines.item.put"],
           "modulePermissions": [
+            "orders-storage.alerts.item.post",
+            "orders-storage.alerts.item.put",
+            "orders-storage.alerts.item.delete",
+            "orders-storage.po-lines.item.get",
             "orders-storage.po-lines.item.put",
-            "orders-storage.alerts.all",
-            "orders-storage.reporting-codes.all"
+            "orders-storage.purchase-orders.item.put",
+            "orders-storage.reporting-codes.item.post",
+            "orders-storage.reporting-codes.item.put",
+            "orders-storage.reporting-codes.item.delete",
+            "configuration.entries.collection.get"
           ]
         },
         {
@@ -141,6 +166,7 @@
           "pathPattern": "/orders/order-lines/{id}",
           "permissionsRequired": ["orders.po-lines.item.delete"],
           "modulePermissions": [
+            "orders-storage.po-lines.item.get",
             "orders-storage.po-lines.item.delete",
             "orders-storage.alerts.item.delete",
             "orders-storage.reporting-codes.item.delete"
@@ -171,8 +197,12 @@
             "orders-storage.pieces.item.put",
             "orders-storage.po-lines.collection.get",
             "orders-storage.po-lines.item.put",
+            "orders-storage.purchase-orders.item.get",
+            "orders-storage.purchase-orders.item.put",
             "inventory.items.collection.get",
-            "inventory.items.item.put"
+            "inventory.items.item.put",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.holdings.item.post"
           ]
         },
         {
@@ -184,9 +214,12 @@
             "orders-storage.pieces.item.put",
             "orders-storage.po-lines.collection.get",
             "orders-storage.po-lines.item.put",
-            "inventory-storage.items.collection.get",
-            "inventory-storage.items.item.post",
-            "inventory-storage.items.item.put"
+            "orders-storage.purchase-orders.item.get",
+            "orders-storage.purchase-orders.item.put",
+            "inventory.items.collection.get",
+            "inventory.items.item.put",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.holdings.item.post"
           ]
         },
         {
@@ -220,6 +253,10 @@
     }
   ],
   "requires": [
+    {
+      "id": "configuration",
+      "version": "2.0"
+    },
     {
       "id": "orders-storage.purchase-orders",
       "version": "5.0"
@@ -377,6 +414,7 @@
         "orders.po-lines.item.get",
         "orders.po-lines.item.put",
         "orders.po-lines.item.delete",
+        "orders.po-number.item.get",
         "orders.po-number.item.post",
         "orders.receiving.collection.post",
         "orders.check-in.collection.post",


### PR DESCRIPTION
## Purpose
[MODORDERS-245](https://issues.folio.org/browse/MODORDERS-245) Update API tests to use a user account with limited permissions

## Approach
- Adding missing permissions
- Replacing `orders-storage.*.all` by individual permissions (see [discussion in #development](https://folio-project.slack.com/archives/C210RP0T1/p1559047992010100?thread_ts=1559047980.010000&cid=C210RP0T1))
- Adding `configuration` interface as required because there are a lot functionality which relies on configs

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  