### PR TITLE
MODORDERS-234 Update PO status based on receipt/payment status - Part 2

### DIFF
--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -1413,7 +1413,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
           .as(Errors.class);
 
     logger.info(JsonObject.mapFrom(errors).encodePrettily());
-    assertEquals(2, errors.getErrors().size());
+    assertEquals(1, errors.getErrors().size());
     assertNull(getInstancesSearches());
     assertNull(getItemsSearches());
   }


### PR DESCRIPTION
## Purpose
[MODORDERS-234](https://issues.folio.org/browse/MODORDERS-234) fix bug: when trying update order.workflowStatus to "Closed" without poLines in request, workflowStatus doesn't change automatically when it should.

## Approach
If there is no need to update the poLines during the order update, than rely on the lines from the storage to determine if the status should be changed.


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
