### PR TITLE
Modorders 249 acquisitions units

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -259,6 +259,42 @@
       ]
     },
     {
+      "id": "acquisitions-units",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/acquisitions-units/units",
+          "permissionsRequired": ["acquisitions-units.units.collection.get"],
+          "modulePermissions": ["acquisitions-units-storage.units.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/acquisitions-units/units",
+          "permissionsRequired": ["acquisitions-units.units.item.post"],
+          "modulePermissions": ["acquisitions-units-storage.units.item.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/acquisitions-units/units/{id}",
+          "permissionsRequired": ["acquisitions-units.units.item.get"],
+          "modulePermissions": ["acquisitions-units-storage.units.item.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/acquisitions-units/units/{id}",
+          "permissionsRequired": ["acquisitions-units.units.item.put"],
+          "modulePermissions": ["acquisitions-units-storage.units.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/acquisitions-units/units/{id}",
+          "permissionsRequired": ["acquisitions-units.units.item.delete"],
+          "modulePermissions": ["acquisitions-units-storage.units.item.delete"]
+        }
+      ]
+    },
+    {
       "id": "_jsonSchemas",
       "version": "1.0",
       "interfaceType" : "multiple",
@@ -271,6 +307,10 @@
     }
   ],
   "requires": [
+    {
+      "id": "acquisitions-units-storage.units",
+      "version": "1.0"
+    },
     {
       "id": "configuration",
       "version": "2.0"
@@ -426,6 +466,43 @@
       "permissionName": "orders.pieces.item.delete",
       "displayName": "orders - delete an existing piece record",
       "description": "Delete an existing piece"
+    },
+    {
+      "permissionName": "acquisitions-units.units.collection.get",
+      "displayName": "Acquisitions units - get units",
+      "description": "Get a collection of acquisitions units"
+    },
+    {
+      "permissionName": "acquisitions-units.units.item.post",
+      "displayName": "Acquisitions units - create unit",
+      "description": "Create a new acquisitions unit"
+    },
+    {
+      "permissionName": "acquisitions-units.units.item.get",
+      "displayName": "Acquisitions units - get unit",
+      "description": "Fetch an acquisitions unit"
+    },
+    {
+      "permissionName": "acquisitions-units.units.item.put",
+      "displayName": "Acquisitions units - update unit",
+      "description": "Update an acquisitions unit"
+    },
+    {
+      "permissionName": "acquisitions-units.units.item.delete",
+      "displayName": "Acquisitions units - delete unit",
+      "description": "Delete an acquisitions unit"
+    },
+    {
+      "permissionName": "acquisitions-units.units.all",
+      "displayName": "All acquisitions-units perms",
+      "description": "All permissions for the acquisitions-units",
+      "subPermissions": [
+        "acquisitions-units.units.collection.get",
+        "acquisitions-units.units.item.post",
+        "acquisitions-units.units.item.get",
+        "acquisitions-units.units.item.put",
+        "acquisitions-units.units.item.delete"
+      ]
     },
     {
       "permissionName": "orders.all",

--- a/ramls/acquisitions-units.raml
+++ b/ramls/acquisitions-units.raml
@@ -1,0 +1,56 @@
+#%RAML 1.0
+title: "Acquisitions units"
+baseUri: http://github.com/folio-org/mod-orders
+version: v1
+
+documentation:
+  - title: Acquisitions units
+    content: <b>CRUD APIs used to manage acquisitions units.</b>
+
+types:
+    acquisitions-unit: !include acq-models/mod-orders-storage/schemas/acquisitions_unit.json
+    acquisitions-unit-collection: !include acq-models/mod-orders-storage/schemas/acquisitions_unit_collection.json
+    errors: !include raml-util/schemas/errors.schema
+    UUID:
+     type: string
+     pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
+
+traits:
+    validate: !include raml-util/traits/validation.raml
+    pageable:  !include raml-util/traits/pageable.raml
+    searchable: !include raml-util/traits/searchable.raml
+    language: !include raml-util/traits/language.raml
+
+resourceTypes:
+    collection: !include raml-util/rtypes/collection.raml
+    collection-item: !include raml-util/rtypes/item-collection.raml
+
+/acquisitions-units:
+  /units:
+    type:
+      collection:
+        exampleCollection: !include acq-models/mod-orders-storage/examples/acquisitions_unit_collection.sample
+        exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_post.sample
+        schemaCollection: acquisitions-unit-collection
+        schemaItem: acquisitions-unit
+    post:
+      description: Create new acquisitions unit
+      is: [validate]
+    get:
+      description: Get list of acquisitions units
+      is: [
+        searchable: {description: "with valid searchable fields: for example protectRead", example: "[\"protectRead\", \"false\"]"},
+        pageable
+      ]
+    /{id}:
+      uriParameters:
+        id:
+          description: The UUID of an acquisitions unit
+          type: UUID
+      type:
+        collection-item:
+          exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_post.sample
+          schema: acquisitions-unit
+      put:
+        description: Update acquisitions unit
+        is: [validate]

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -16,6 +16,7 @@ public class ResourcePathResolver {
   public static final String PO_LINE_NUMBER = "poLineNumber";
 
   public static final String ALERTS = "alerts";
+  public static final String ACQUISITIONS_UNITS = "acquisitionsUnits";
   public static final String REPORTING_CODES = "reportingCodes";
   public static final String PURCHASE_ORDER = "purchaseOrder";
   public static final String PIECES = "pieces";
@@ -33,6 +34,7 @@ public class ResourcePathResolver {
   static {
     Map<String, String> apis = new HashMap<>();
     apis.put(ALERTS, "/orders-storage/alerts");
+    apis.put(ACQUISITIONS_UNITS, "/acquisitions-units-storage/units");
     apis.put(REPORTING_CODES, "/orders-storage/reporting-codes");
     apis.put(PO_LINES, "/orders-storage/po-lines");
     apis.put(PO_NUMBER, "/orders-storage/po-number");

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitsHelper.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitsHelper.java
@@ -1,0 +1,65 @@
+package org.folio.rest.impl;
+
+import static org.folio.orders.utils.HelperUtils.buildQuery;
+import static org.folio.orders.utils.HelperUtils.handleDeleteRequest;
+import static org.folio.orders.utils.HelperUtils.handleGetRequest;
+import static org.folio.orders.utils.HelperUtils.handlePutRequest;
+import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
+import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
+import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.rest.jaxrs.model.AcquisitionsUnit;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitCollection;
+
+import io.vertx.core.Context;
+import io.vertx.core.json.JsonObject;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+
+public class AcquisitionsUnitsHelper extends AbstractHelper {
+  private static final String GET_UNITS_BY_QUERY = resourcesPath(ACQUISITIONS_UNITS) + "?offset=%s&limit=%s%s&lang=%s";
+
+  AcquisitionsUnitsHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
+    super(okapiHeaders, ctx, lang);
+  }
+
+  CompletableFuture<AcquisitionsUnitCollection> getAcquisitionsUnits(String query, int offset, int limit) {
+    CompletableFuture<AcquisitionsUnitCollection> future = new VertxCompletableFuture<>(ctx);
+
+    try {
+      String endpoint = String.format(GET_UNITS_BY_QUERY, limit, offset, buildQuery(query, logger), lang);
+
+      handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+        .thenApply(jsonUnits -> jsonUnits.mapTo(AcquisitionsUnitCollection.class))
+        .thenAccept(future::complete)
+        .exceptionally(t -> {
+          future.completeExceptionally(t.getCause());
+          return null;
+        });
+    } catch (Exception e) {
+      future.completeExceptionally(e);
+    }
+
+    return future;
+  }
+
+  CompletableFuture<AcquisitionsUnit> createAcquisitionsUnit(AcquisitionsUnit unit) {
+    return createRecordInStorage(JsonObject.mapFrom(unit), resourcesPath(ACQUISITIONS_UNITS)).thenApply(unit::withId);
+  }
+
+  CompletableFuture<Void> updateAcquisitionsUnit(AcquisitionsUnit unit) {
+    String endpoint = resourceByIdPath(ACQUISITIONS_UNITS, unit.getId());
+    return handlePutRequest(endpoint, JsonObject.mapFrom(unit), httpClient, ctx, okapiHeaders, logger);
+  }
+
+  CompletableFuture<AcquisitionsUnit> getAcquisitionsUnit(String id) {
+    return handleGetRequest(resourceByIdPath(ACQUISITIONS_UNITS, id), httpClient, ctx, okapiHeaders, logger)
+      .thenApply(json -> json.mapTo(AcquisitionsUnit.class));
+  }
+
+  CompletableFuture<Void> deleteAcquisitionsUnit(String id) {
+    return handleDeleteRequest(resourceByIdPath(ACQUISITIONS_UNITS, id), httpClient, ctx, okapiHeaders, logger);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitsHelper.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitsHelper.java
@@ -29,7 +29,7 @@ public class AcquisitionsUnitsHelper extends AbstractHelper {
     CompletableFuture<AcquisitionsUnitCollection> future = new VertxCompletableFuture<>(ctx);
 
     try {
-      String endpoint = String.format(GET_UNITS_BY_QUERY, limit, offset, buildQuery(query, logger), lang);
+      String endpoint = String.format(GET_UNITS_BY_QUERY, offset, limit, buildQuery(query, logger), lang);
 
       handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
         .thenApply(jsonUnits -> jsonUnits.mapTo(AcquisitionsUnitCollection.class))

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitsImpl.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitsImpl.java
@@ -1,0 +1,126 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.orders.utils.ErrorCodes.MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.AcquisitionsUnit;
+import org.folio.rest.jaxrs.resource.AcquisitionsUnits;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
+
+  private static final Logger logger = LoggerFactory.getLogger(AcquisitionsUnit.class);
+
+  private static final String ACQUISITIONS_UNITS_LOCATION_PREFIX = "/acquisitions-units/units/";
+
+  @Override
+  @Validate
+  public void postAcquisitionsUnitsUnits(String lang, AcquisitionsUnit entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    AcquisitionsUnitsHelper helper = new AcquisitionsUnitsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.createAcquisitionsUnit(entity)
+      .thenAccept(unit -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully created new acquisitions unit: " + JsonObject.mapFrom(unit).encodePrettily());
+        }
+
+        asyncResultHandler.handle(succeededFuture(buildResponseForPostUnit(unit)));
+        helper.closeHttpClient();
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
+  @Override
+  @Validate
+  public void getAcquisitionsUnitsUnits(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsUnitsHelper helper = new AcquisitionsUnitsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.getAcquisitionsUnits(query, offset, limit)
+      .thenAccept(units -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully created new acquisitions units: " + JsonObject.mapFrom(units).encodePrettily());
+        }
+        asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(units)));
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
+  @Override
+  @Validate
+  public void putAcquisitionsUnitsUnitsById(String id, String lang, AcquisitionsUnit entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsUnitsHelper helper = new AcquisitionsUnitsHelper(okapiHeaders, vertxContext, lang);
+
+    if (entity.getId() != null && !entity.getId().equals(id)) {
+      helper.addProcessingError(MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY.toError());
+      asyncResultHandler.handle(succeededFuture(helper.buildErrorResponse(422)));
+    } else {
+      helper.updateAcquisitionsUnit(entity.withId(id))
+        .thenAccept(units -> {
+          logger.info("Successfully updated acquisitions unit with id={}", id);
+          asyncResultHandler.handle(succeededFuture(helper.buildNoContentResponse()));
+        })
+        .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+    }
+  }
+
+  @Override
+  @Validate
+  public void getAcquisitionsUnitsUnitsById(String id, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsUnitsHelper helper = new AcquisitionsUnitsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.getAcquisitionsUnit(id)
+      .thenAccept(unit -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully retrieved acquisitions unit: " + JsonObject.mapFrom(unit).encodePrettily());
+        }
+        asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(unit)));
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
+  @Override
+  @Validate
+  public void deleteAcquisitionsUnitsUnitsById(String id, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsUnitsHelper helper = new AcquisitionsUnitsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.deleteAcquisitionsUnit(id)
+      .thenAccept(ok -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully deleted acquisitions unit with id={}", id);
+        }
+        asyncResultHandler.handle(succeededFuture(helper.buildNoContentResponse()));
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
+  private Response buildResponseForPostUnit(AcquisitionsUnit unit) {
+    PostAcquisitionsUnitsUnitsResponse.HeadersFor201 headersFor201 = PostAcquisitionsUnitsUnitsResponse.headersFor201()
+      .withLocation(ACQUISITIONS_UNITS_LOCATION_PREFIX + unit.getId());
+    return PostAcquisitionsUnitsUnitsResponse.respond201WithApplicationJson(unit, headersFor201);
+  }
+
+  private Void handleErrorResponse(Handler<AsyncResult<Response>> asyncResultHandler, AbstractHelper helper, Throwable t) {
+    asyncResultHandler.handle(succeededFuture(helper.buildErrorResponse(t)));
+    return null;
+  }
+}

--- a/src/test/java/org/folio/rest/impl/AcquisitionsUnitsTests.java
+++ b/src/test/java/org/folio/rest/impl/AcquisitionsUnitsTests.java
@@ -1,0 +1,148 @@
+package org.folio.rest.impl;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.folio.orders.utils.ErrorCodes.MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.UUID;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import org.folio.rest.jaxrs.model.AcquisitionsUnit;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitCollection;
+import org.folio.rest.jaxrs.model.Errors;
+import org.junit.Test;
+
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class AcquisitionsUnitsTests extends ApiTestBase {
+  private static final Logger logger = LoggerFactory.getLogger(AcquisitionsUnitsTests.class);
+
+  private static final String ACQ_UNITS_UNITS_ENDPOINT = "/acquisitions-units/units";
+
+  @Test
+  public void testGetAcqUnitsNoQuery() {
+    logger.info("=== Test Get Acquisitions Units - With empty query ===");
+    final AcquisitionsUnitCollection units = verifySuccessGet(ACQ_UNITS_UNITS_ENDPOINT, AcquisitionsUnitCollection.class);
+    assertThat(units.getAcquisitionsUnits(), hasSize(2));
+  }
+
+  @Test
+  public void testGetAcqUnitsWithQuery() {
+    logger.info("=== Test GET Acquisitions Units - search by query ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "?query=name==Read only";
+
+    final AcquisitionsUnitCollection units = verifySuccessGet(url, AcquisitionsUnitCollection.class);
+    assertThat(units.getAcquisitionsUnits(), hasSize(1));
+  }
+
+  @Test
+  public void testGetAcqUnitsWithUnprocessableQuery() {
+    logger.info("=== Test GET Acquisitions Units - unprocessable query ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "?query=" + BAD_QUERY;
+
+    verifyGet(url, APPLICATION_JSON, 400);
+  }
+
+  @Test
+  public void testGetAcqUnitSuccess() {
+    logger.info("=== Test GET Acquisitions Unit - success case ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/0e9525aa-d123-4e4d-9f7e-1b302a97eb90";
+
+    final AcquisitionsUnit unit = verifySuccessGet(url, AcquisitionsUnit.class);
+    assertThat(unit, notNullValue());
+  }
+
+  @Test
+  public void testGetAcqUnitNotFound() {
+    logger.info("=== Test GET Acquisitions Unit - not found ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/" + ID_DOES_NOT_EXIST;
+
+    verifyGet(url, APPLICATION_JSON, 404);
+  }
+
+  @Test
+  public void testPutAcqUnitSuccess() {
+    logger.info("=== Test PUT acquisitions unit - success case ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/0e9525aa-d123-4e4d-9f7e-1b302a97eb90";
+
+    verifyPut(url, JsonObject.mapFrom(new AcquisitionsUnit().withName("Some name")), "", 204);
+  }
+
+  @Test
+  public void testValidationOnPutUnitWithoutBody() {
+    logger.info("=== Test validation on PUT acquisitions unit with no body ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/" + UUID.randomUUID().toString();
+
+    verifyPut(url, "", TEXT_PLAIN, 400);
+  }
+
+  @Test
+  public void testPutUnitNotFound() {
+    logger.info("=== Test PUT acquisitions unit - not found ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/" + ID_DOES_NOT_EXIST;
+
+    verifyPut(url, JsonObject.mapFrom(new AcquisitionsUnit().withName("Some name")), APPLICATION_JSON, 404);
+  }
+
+  @Test
+  public void testPutUnitIdMismatch() {
+    logger.info("=== Test PUT acquisitions unit - different ids in path and body ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/" + UUID.randomUUID().toString();
+
+    AcquisitionsUnit unit = new AcquisitionsUnit().withName("Some name").withId(UUID.randomUUID().toString());
+    Errors errors = verifyPut(url, JsonObject.mapFrom(unit), APPLICATION_JSON, 422).as(Errors.class);
+    assertThat(errors.getErrors(), hasSize(1));
+    assertThat(errors.getErrors().get(0).getCode(), equalTo(MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY.getCode()));
+  }
+
+  @Test
+  public void testDeleteAcqUnitSuccess() {
+    logger.info("=== Test DELETE acquisitions unit - success case ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/0e9525aa-d123-4e4d-9f7e-1b302a97eb90";
+
+    verifyDeleteResponse(url, "", 204);
+  }
+
+  @Test
+  public void testDeletePutUnitNotFound() {
+    logger.info("=== Test DELETE acquisitions unit - not found ===");
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "/" + ID_DOES_NOT_EXIST;
+
+    verifyPut(url, JsonObject.mapFrom(new AcquisitionsUnit().withName("Some name")), APPLICATION_JSON, 404);
+  }
+
+  @Test
+  public void testPostAcqUnitSuccess() {
+    logger.info("=== Test POST acquisitions unit - success case ===");
+
+    String body = JsonObject.mapFrom(new AcquisitionsUnit().withName("Some name")).encode();
+    Response response = verifyPostResponse(ACQ_UNITS_UNITS_ENDPOINT, body, prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10),
+        APPLICATION_JSON, 201);
+    AcquisitionsUnit unit = response.as(AcquisitionsUnit.class);
+
+    assertThat(unit.getId(), not(isEmptyOrNullString()));
+    assertThat(response.header(HttpHeaders.LOCATION), containsString(unit.getId()));
+  }
+
+  @Test
+  public void testPostAcqUnitServerError() {
+    logger.info("=== Test POST acquisitions unit - Server Error ===");
+
+    String body = JsonObject.mapFrom(new AcquisitionsUnit().withName("Some name")).encode();
+    Headers headers = prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, new Header(X_ECHO_STATUS, String.valueOf(500)));
+    verifyPostResponse(ACQ_UNITS_UNITS_ENDPOINT, body, headers, APPLICATION_JSON, 500);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/ApiTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestSuite.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+  AcquisitionsUnitsTests.class,
   PurchaseOrdersApiTest.class,
   PurchaseOrderLinesApiTest.class,
   CheckinReceivingApiTest.class,

--- a/src/test/resources/mockdata/acquisitionsUnits/units/units.json
+++ b/src/test/resources/mockdata/acquisitionsUnits/units/units.json
@@ -1,0 +1,21 @@
+{
+  "acquisitionsUnits": [
+    {
+      "id": "0e9525aa-d123-4e4d-9f7e-1b302a97eb90",
+      "name": "Super users",
+      "protectCreate": false,
+      "protectRead": false,
+      "protectUpdate": false,
+      "protectDelete": false
+    },
+    {
+      "id": "6b982ffe-8efd-4690-8168-0c773b49cde1",
+      "name": "Read only",
+      "protectCreate": true,
+      "protectRead": false,
+      "protectUpdate": true,
+      "protectDelete": true
+    }
+  ],
+  "totalRecords": 2
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-249](https://issues.folio.org/browse/MODORDERS-249) Implement basic CRUD for /acquisitions-units/units

## Approach
Define and implement the acquisitions-units API
- new interfrace: `acquisitions-units`
- Proxies to corresponding storage endpoint

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
