### PR TITLE
MODORDERS-250 - Implement basic CRUD for /acquisitions-units/memberships

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -291,6 +291,36 @@
           "pathPattern": "/acquisitions-units/units/{id}",
           "permissionsRequired": ["acquisitions-units.units.item.delete"],
           "modulePermissions": ["acquisitions-units-storage.units.item.delete"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/acquisitions-units/memberships",
+          "permissionsRequired": ["acquisitions-units.memberships.collection.get"],
+          "modulePermissions": ["acquisitions-units-storage.memberships.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/acquisitions-units/memberships",
+          "permissionsRequired": ["acquisitions-units.memberships.item.post"],
+          "modulePermissions": ["acquisitions-units-storage.memberships.item.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/acquisitions-units/memberships/{id}",
+          "permissionsRequired": ["acquisitions-units.memberships.item.get"],
+          "modulePermissions": ["acquisitions-units-storage.memberships.item.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/acquisitions-units/memberships/{id}",
+          "permissionsRequired": ["acquisitions-units.memberships.item.put"],
+          "modulePermissions": ["acquisitions-units-storage.memberships.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/acquisitions-units/memberships/{id}",
+          "permissionsRequired": ["acquisitions-units.memberships.item.delete"],
+          "modulePermissions": ["acquisitions-units-storage.memberships.item.delete"]
         }
       ]
     },
@@ -309,6 +339,10 @@
   "requires": [
     {
       "id": "acquisitions-units-storage.units",
+      "version": "1.0"
+    },
+    {
+      "id": "acquisitions-units-storage.memberships",
       "version": "1.0"
     },
     {
@@ -376,7 +410,7 @@
       "version": "1.0"
     }
   ],
-    "permissionSets": [
+  "permissionSets": [
     {
       "permissionName": "orders.collection.get",
       "displayName": "orders - get orders collection",
@@ -502,6 +536,43 @@
         "acquisitions-units.units.item.get",
         "acquisitions-units.units.item.put",
         "acquisitions-units.units.item.delete"
+      ]
+    },
+    {
+      "permissionName": "acquisitions-units.memberships.collection.get",
+      "displayName": "Acquisitions units memberships - get units memberships",
+      "description": "Get a collection of acquisitions units memberships"
+    },
+    {
+      "permissionName": "acquisitions-units.memberships.item.post",
+      "displayName": "Acquisitions units memberships - create units membership",
+      "description": "Create a new acquisitions units membership"
+    },
+    {
+      "permissionName": "acquisitions-units.memberships.item.get",
+      "displayName": "Acquisitions units memberships - get units membership",
+      "description": "Fetch an acquisitions units membership"
+    },
+    {
+      "permissionName": "acquisitions-units.memberships.item.put",
+      "displayName": "Acquisitions units memberships - update units membership",
+      "description": "Update an acquisitions units membership"
+    },
+    {
+      "permissionName": "acquisitions-units.memberships.item.delete",
+      "displayName": "Acquisitions units memberships - delete units membership",
+      "description": "Delete an acquisitions units membership"
+    },
+    {
+      "permissionName": "acquisitions-units.memberships.all",
+      "displayName": "All acquisitions-units perms",
+      "description": "All permissions for the acquisitions-units memberships",
+      "subPermissions": [
+        "acquisitions-units.memberships.collection.get",
+        "acquisitions-units.memberships.item.post",
+        "acquisitions-units.memberships.item.get",
+        "acquisitions-units.memberships.item.put",
+        "acquisitions-units.memberships.item.delete"
       ]
     },
     {

--- a/ramls/acquisitions-units.raml
+++ b/ramls/acquisitions-units.raml
@@ -51,7 +51,7 @@ resourceTypes:
           type: UUID
       type:
         collection-item:
-          exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_post.sample
+          exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_get.sample
           schema: acquisitions-unit
       put:
         description: Update acquisitions unit
@@ -69,7 +69,7 @@ resourceTypes:
     get:
       description: Get list of acquisitions units memberships
       is: [
-        searchable: {description: "with valid searchable fields: for example protectRead", example: "[\"protectRead\", \"false\"]"},
+        searchable: {description: "with valid searchable fields: for example acquisitionsUnitId", example: "[\"acquisitionsUnitId\", \"57c35c88-625d-4f0e-bc79-d22818d84d1c\"]"},
         pageable
       ]
     /{id}:
@@ -79,7 +79,7 @@ resourceTypes:
           type: UUID
       type:
         collection-item:
-          exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_membership_post.sample
+          exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_membership_get.sample
           schema: acquisitions-unit-membership
       put:
         description: Update acquisitions units membership

--- a/ramls/acquisitions-units.raml
+++ b/ramls/acquisitions-units.raml
@@ -9,7 +9,9 @@ documentation:
 
 types:
     acquisitions-unit: !include acq-models/mod-orders-storage/schemas/acquisitions_unit.json
+    acquisitions-unit-membership: !include acq-models/mod-orders-storage/schemas/acquisitions_unit_membership.json
     acquisitions-unit-collection: !include acq-models/mod-orders-storage/schemas/acquisitions_unit_collection.json
+    acquisitions-unit-membership-collection: !include acq-models/mod-orders-storage/schemas/acquisitions_unit_membership_collection.json
     errors: !include raml-util/schemas/errors.schema
     UUID:
      type: string
@@ -53,4 +55,32 @@ resourceTypes:
           schema: acquisitions-unit
       put:
         description: Update acquisitions unit
+        is: [validate]
+  /memberships:
+    type:
+      collection:
+        exampleCollection: !include acq-models/mod-orders-storage/examples/acquisitions_unit_membership_collection.sample
+        exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_membership_post.sample
+        schemaCollection: acquisitions-unit-membership-collection
+        schemaItem: acquisitions-unit-membership
+    post:
+      description: Create new acquisitions units membership
+      is: [validate]
+    get:
+      description: Get list of acquisitions units memberships
+      is: [
+        searchable: {description: "with valid searchable fields: for example protectRead", example: "[\"protectRead\", \"false\"]"},
+        pageable
+      ]
+    /{id}:
+      uriParameters:
+        id:
+          description: The UUID of an acquisitions units membership
+          type: UUID
+      type:
+        collection-item:
+          exampleItem: !include acq-models/mod-orders-storage/examples/acquisitions_unit_membership_post.sample
+          schema: acquisitions-unit-membership
+      put:
+        description: Update acquisitions units membership
         is: [validate]

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -17,6 +17,7 @@ public class ResourcePathResolver {
 
   public static final String ALERTS = "alerts";
   public static final String ACQUISITIONS_UNITS = "acquisitionsUnits";
+  public static final String ACQUISITIONS_MEMBERSHIPS = "acquisitionsMemberships";
   public static final String REPORTING_CODES = "reportingCodes";
   public static final String PURCHASE_ORDER = "purchaseOrder";
   public static final String PIECES = "pieces";
@@ -35,6 +36,7 @@ public class ResourcePathResolver {
     Map<String, String> apis = new HashMap<>();
     apis.put(ALERTS, "/orders-storage/alerts");
     apis.put(ACQUISITIONS_UNITS, "/acquisitions-units-storage/units");
+    apis.put(ACQUISITIONS_MEMBERSHIPS, "/acquisitions-units-storage/memberships");
     apis.put(REPORTING_CODES, "/orders-storage/reporting-codes");
     apis.put(PO_LINES, "/orders-storage/po-lines");
     apis.put(PO_NUMBER, "/orders-storage/po-number");

--- a/src/main/java/org/folio/rest/impl/AcquisitionsMembershipsHelper.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsMembershipsHelper.java
@@ -1,0 +1,61 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.Context;
+import io.vertx.core.json.JsonObject;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitMembership;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitMembershipCollection;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.orders.utils.HelperUtils.buildQuery;
+import static org.folio.orders.utils.HelperUtils.handleDeleteRequest;
+import static org.folio.orders.utils.HelperUtils.handleGetRequest;
+import static org.folio.orders.utils.HelperUtils.handlePutRequest;
+import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_MEMBERSHIPS;
+import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
+import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+
+public class AcquisitionsMembershipsHelper extends AbstractHelper {
+  private static final String GET_UNITS_MEMBERSHIPS_BY_QUERY = resourcesPath(ACQUISITIONS_MEMBERSHIPS) + "?offset=%s&limit=%s%s&lang=%s";
+
+  AcquisitionsMembershipsHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
+    super(okapiHeaders, ctx, lang);
+  }
+
+  CompletableFuture<AcquisitionsUnitMembershipCollection> getAcquisitionsUnitsMemberships(String query, int offset, int limit) {
+    CompletableFuture<AcquisitionsUnitMembershipCollection> future = new VertxCompletableFuture<>(ctx);
+    try {
+      String endpoint = String.format(GET_UNITS_MEMBERSHIPS_BY_QUERY, offset, limit, buildQuery(query, logger), lang);
+      handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+        .thenApply(jsonUnitsMembership -> jsonUnitsMembership.mapTo(AcquisitionsUnitMembershipCollection.class))
+        .thenAccept(future::complete)
+        .exceptionally(t -> {
+          future.completeExceptionally(t.getCause());
+          return null;
+        });
+    } catch (Exception e) {
+      future.completeExceptionally(e);
+    }
+    return future;
+  }
+
+  CompletableFuture<AcquisitionsUnitMembership> createAcquisitionsUnitsMembership(AcquisitionsUnitMembership membership) {
+    return createRecordInStorage(JsonObject.mapFrom(membership), resourcesPath(ACQUISITIONS_MEMBERSHIPS)).thenApply(membership::withId);
+  }
+
+  CompletableFuture<Void> updateAcquisitionsUnitsMembership(AcquisitionsUnitMembership membership) {
+    String endpoint = resourceByIdPath(ACQUISITIONS_MEMBERSHIPS, membership.getId());
+    return handlePutRequest(endpoint, JsonObject.mapFrom(membership), httpClient, ctx, okapiHeaders, logger);
+  }
+
+  CompletableFuture<AcquisitionsUnitMembership> getAcquisitionsUnitsMembership(String id) {
+    return handleGetRequest(resourceByIdPath(ACQUISITIONS_MEMBERSHIPS, id), httpClient, ctx, okapiHeaders, logger)
+      .thenApply(json -> json.mapTo(AcquisitionsUnitMembership.class));
+  }
+
+  CompletableFuture<Void> deleteAcquisitionsUnitsMembership(String id) {
+    return handleDeleteRequest(resourceByIdPath(ACQUISITIONS_MEMBERSHIPS, id), httpClient, ctx, okapiHeaders, logger);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitsImpl.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitsImpl.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.AcquisitionsUnit;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitMembership;
 import org.folio.rest.jaxrs.resource.AcquisitionsUnits;
 
 import io.vertx.core.AsyncResult;
@@ -23,6 +24,7 @@ public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
   private static final Logger logger = LoggerFactory.getLogger(AcquisitionsUnit.class);
 
   private static final String ACQUISITIONS_UNITS_LOCATION_PREFIX = "/acquisitions-units/units/";
+  private static final String ACQUISITIONS_MEMBERSHIPS_LOCATION_PREFIX = "/acquisitions-units/memberships/";
 
   @Override
   @Validate
@@ -113,10 +115,95 @@ public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
       .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
   }
 
+  @Override
+  public void postAcquisitionsUnitsMemberships(String lang, AcquisitionsUnitMembership entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.createAcquisitionsUnitsMembership(entity)
+      .thenAccept(membership -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully created new acquisitions units membership: " + JsonObject.mapFrom(membership).encodePrettily());
+        }
+        asyncResultHandler.handle(succeededFuture(buildResponseForPostUnitsMembership(membership)));
+        helper.closeHttpClient();
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
+  @Override
+  public void getAcquisitionsUnitsMemberships(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.getAcquisitionsUnitsMemberships(query, offset, limit)
+      .thenAccept(memberships -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully created new acquisitions units memberships: " + JsonObject.mapFrom(memberships).encodePrettily());
+        }
+        asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(memberships)));
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
+  @Override
+  public void putAcquisitionsUnitsMembershipsById(String id, String lang, AcquisitionsUnitMembership entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
+
+    if (entity.getId() != null && !entity.getId().equals(id)) {
+      helper.addProcessingError(MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY.toError());
+      asyncResultHandler.handle(succeededFuture(helper.buildErrorResponse(422)));
+    } else {
+      helper.updateAcquisitionsUnitsMembership(entity.withId(id))
+        .thenAccept(membership -> {
+          logger.info("Successfully updated acquisitions units membership with id={}", id);
+          asyncResultHandler.handle(succeededFuture(helper.buildNoContentResponse()));
+        })
+        .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+    }
+  }
+
+  @Override
+  public void getAcquisitionsUnitsMembershipsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.getAcquisitionsUnitsMembership(id)
+      .thenAccept(membership -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully retrieved acquisitions units membership: " + JsonObject.mapFrom(membership).encodePrettily());
+        }
+        asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(membership)));
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
+  @Override
+  public void deleteAcquisitionsUnitsMembershipsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
+
+    helper.deleteAcquisitionsUnitsMembership(id)
+      .thenAccept(ok -> {
+        if (logger.isInfoEnabled()) {
+          logger.info("Successfully deleted acquisitions units membership with id={}", id);
+        }
+        asyncResultHandler.handle(succeededFuture(helper.buildNoContentResponse()));
+      })
+      .exceptionally(t -> handleErrorResponse(asyncResultHandler, helper, t));
+  }
+
   private Response buildResponseForPostUnit(AcquisitionsUnit unit) {
     PostAcquisitionsUnitsUnitsResponse.HeadersFor201 headersFor201 = PostAcquisitionsUnitsUnitsResponse.headersFor201()
       .withLocation(ACQUISITIONS_UNITS_LOCATION_PREFIX + unit.getId());
     return PostAcquisitionsUnitsUnitsResponse.respond201WithApplicationJson(unit, headersFor201);
+  }
+
+  private Response buildResponseForPostUnitsMembership(AcquisitionsUnitMembership membership) {
+    PostAcquisitionsUnitsMembershipsResponse.HeadersFor201 headersFor201 = PostAcquisitionsUnitsMembershipsResponse.headersFor201()
+      .withLocation(ACQUISITIONS_MEMBERSHIPS_LOCATION_PREFIX + membership.getId());
+    return PostAcquisitionsUnitsMembershipsResponse.respond201WithApplicationJson(membership, headersFor201);
   }
 
   private Void handleErrorResponse(Handler<AsyncResult<Response>> asyncResultHandler, AbstractHelper helper, Throwable t) {

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitsImpl.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitsImpl.java
@@ -116,6 +116,7 @@ public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
   }
 
   @Override
+  @Validate
   public void postAcquisitionsUnitsMemberships(String lang, AcquisitionsUnitMembership entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
@@ -132,6 +133,7 @@ public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
   }
 
   @Override
+  @Validate
   public void getAcquisitionsUnitsMemberships(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
@@ -147,6 +149,7 @@ public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
   }
 
   @Override
+  @Validate
   public void putAcquisitionsUnitsMembershipsById(String id, String lang, AcquisitionsUnitMembership entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
@@ -165,6 +168,7 @@ public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
   }
 
   @Override
+  @Validate
   public void getAcquisitionsUnitsMembershipsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);
@@ -180,6 +184,7 @@ public class AcquisitionsUnitsImpl implements AcquisitionsUnits {
   }
 
   @Override
+  @Validate
   public void deleteAcquisitionsUnitsMembershipsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     AcquisitionsMembershipsHelper helper = new AcquisitionsMembershipsHelper(okapiHeaders, vertxContext, lang);

--- a/src/test/java/org/folio/rest/impl/AcquisitionsMembershipsTests.java
+++ b/src/test/java/org/folio/rest/impl/AcquisitionsMembershipsTests.java
@@ -1,0 +1,148 @@
+package org.folio.rest.impl;
+
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitMembership;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitMembershipCollection;
+import org.folio.rest.jaxrs.model.Errors;
+import org.junit.Test;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.util.UUID;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.folio.orders.utils.ErrorCodes.MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class AcquisitionsMembershipsTests extends ApiTestBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(AcquisitionsMembershipsTests.class);
+
+  private static final String ACQ_UNITS_MEMBERSHIPS_ENDPOINT = "/acquisitions-units/memberships";
+
+  @Test
+  public void testGetAcqMembershipsNoQuery() {
+    logger.info("=== Test GET acquisitions units - with empty query ===");
+    final AcquisitionsUnitMembershipCollection memberships = verifySuccessGet(ACQ_UNITS_MEMBERSHIPS_ENDPOINT, AcquisitionsUnitMembershipCollection.class);
+    assertThat(memberships.getAcquisitionsUnitMemberships(), hasSize(3));
+  }
+
+  @Test
+  public void testGetAcqUnitsMembershipsWithQuery() {
+    logger.info("=== Test GET acquisitions units memberships - search by query ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "?query=userId==480dba68-ee84-4b9c-a374-7e824fc49227";
+
+    final AcquisitionsUnitMembershipCollection units = verifySuccessGet(url, AcquisitionsUnitMembershipCollection.class);
+    assertThat(units.getAcquisitionsUnitMemberships(), hasSize(2));
+  }
+
+  @Test
+  public void testGetAcqUnitsMembershipsWithUnprocessableQuery() {
+    logger.info("=== Test GET acquisitions units memberships - unprocessable query ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "?query=" + BAD_QUERY;
+
+    verifyGet(url, APPLICATION_JSON, 400);
+  }
+
+  @Test
+  public void testGetAcqUnitsMembershipSuccess() {
+    logger.info("=== Test GET acquisitions units membership - success case ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/567a6d67-460f-43ab-af28-8c730c9aa4da";
+
+    final AcquisitionsUnitMembership unit = verifySuccessGet(url, AcquisitionsUnitMembership.class);
+    assertThat(unit, notNullValue());
+  }
+
+  @Test
+  public void testGetAcqUnitsMembershipNotFound() {
+    logger.info("=== Test GET acquisitions units membership - not found ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/" + ID_DOES_NOT_EXIST;
+
+    verifyGet(url, APPLICATION_JSON, 404);
+  }
+
+  @Test
+  public void testPutAcqUnitsMembershipSuccess() {
+    logger.info("=== Test PUT acquisitions units membership - success case ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/0e9525aa-d123-4e4d-9f7e-1b302a97eb90";
+
+    verifyPut(url, JsonObject.mapFrom(new AcquisitionsUnitMembership().withUserId(UUID.randomUUID().toString()).withAcquisitionsUnitId(UUID.randomUUID().toString())), "", 204);
+  }
+
+  @Test
+  public void testValidationOnPutUnitsMembershipWithoutBody() {
+    logger.info("=== Test validation on PUT acquisitions units membership with no body ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/" + UUID.randomUUID().toString();
+
+    verifyPut(url, "", TEXT_PLAIN, 400);
+  }
+
+  @Test
+  public void testPutUnitsMembershipNotFound() {
+    logger.info("=== Test PUT acquisitions units membership - not found ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/" + ID_DOES_NOT_EXIST;
+
+    verifyPut(url, JsonObject.mapFrom(new AcquisitionsUnitMembership().withUserId(UUID.randomUUID().toString()).withAcquisitionsUnitId(UUID.randomUUID().toString())), APPLICATION_JSON, 404);
+  }
+
+  @Test
+  public void testPutUnitsMembershipIdMismatch() {
+    logger.info("=== Test PUT acquisitions units membership - different ids in path and body ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/" + UUID.randomUUID().toString();
+
+    AcquisitionsUnitMembership unit = new AcquisitionsUnitMembership().withUserId(UUID.randomUUID().toString()).withAcquisitionsUnitId(UUID.randomUUID().toString()).withId(UUID.randomUUID().toString());
+    Errors errors = verifyPut(url, JsonObject.mapFrom(unit), APPLICATION_JSON, 422).as(Errors.class);
+    assertThat(errors.getErrors(), hasSize(1));
+    assertThat(errors.getErrors().get(0).getCode(), equalTo(MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY.getCode()));
+  }
+
+  @Test
+  public void testDeleteAcqUnitsMembershipSuccess() {
+    logger.info("=== Test DELETE acquisitions units membership - success case ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/0e9525aa-d123-4e4d-9f7e-1b302a97eb90";
+
+    verifyDeleteResponse(url, "", 204);
+  }
+
+  @Test
+  public void testDeletePutUnitsMembershipNotFound() {
+    logger.info("=== Test DELETE acquisitions units membership - not found ===");
+    String url = ACQ_UNITS_MEMBERSHIPS_ENDPOINT + "/" + ID_DOES_NOT_EXIST;
+
+    verifyPut(url, JsonObject.mapFrom(new AcquisitionsUnitMembership().withUserId(UUID.randomUUID().toString()).withAcquisitionsUnitId(UUID.randomUUID().toString())), APPLICATION_JSON, 404);
+  }
+
+  @Test
+  public void testPostAcqUnitsMembershipSuccess() {
+    logger.info("=== Test POST acquisitions unit - success case ===");
+
+    String body = JsonObject.mapFrom(new AcquisitionsUnitMembership().withUserId(UUID.randomUUID().toString()).withAcquisitionsUnitId(UUID.randomUUID().toString())).encode();
+
+    Response response = verifyPostResponse(ACQ_UNITS_MEMBERSHIPS_ENDPOINT, body, prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10),
+        APPLICATION_JSON, 201);
+    AcquisitionsUnitMembership unit = response.as(AcquisitionsUnitMembership.class);
+
+    assertThat(unit.getId(), not(isEmptyOrNullString()));
+    assertThat(response.header(HttpHeaders.LOCATION), containsString(unit.getId()));
+  }
+
+  @Test
+  public void testPostAcqUnitsMembershipServerError() {
+    logger.info("=== Test POST acquisitions unit - Server Error ===");
+
+    String body = JsonObject.mapFrom(new AcquisitionsUnitMembership().withUserId(UUID.randomUUID().toString()).withAcquisitionsUnitId(UUID.randomUUID().toString())).encode();
+    Headers headers = prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, new Header(X_ECHO_STATUS, String.valueOf(500)));
+    verifyPostResponse(ACQ_UNITS_MEMBERSHIPS_ENDPOINT, body, headers, APPLICATION_JSON, 500);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/ApiTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestSuite.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeoutException;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
   AcquisitionsUnitsTests.class,
+  AcquisitionsMembershipsTests.class,
   PurchaseOrdersApiTest.class,
   PurchaseOrderLinesApiTest.class,
   CheckinReceivingApiTest.class,

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -27,6 +27,8 @@ import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.EncumbranceCollection;
 import org.folio.rest.jaxrs.model.AcquisitionsUnit;
 import org.folio.rest.jaxrs.model.AcquisitionsUnitCollection;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitMembership;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitMembershipCollection;
 import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLineCollection;
@@ -57,6 +59,7 @@ import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.calculateEstimatedPrice;
 import static org.folio.orders.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
+import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_MEMBERSHIPS;
 import static org.folio.orders.utils.ResourcePathResolver.ALERTS;
 import static org.folio.orders.utils.ResourcePathResolver.FINANCE_STORAGE_ENCUMBRANCES;
 import static org.folio.orders.utils.ResourcePathResolver.SEARCH_ORDERS;
@@ -129,6 +132,7 @@ public class MockServer {
   private static final String ORGANIZATIONS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "organizations/";
   static final String POLINES_COLLECTION = PO_LINES_MOCK_DATA_PATH + "/po_line_collection.json";
   private static final String ACQUISITIONS_UNITS_COLLECTION = ACQUISITIONS_UNITS_MOCK_DATA_PATH + "/units.json";
+  private static final String ACQUISITIONS_MEMBERSHIPS_COLLECTION = ACQUISITIONS_UNITS_MOCK_DATA_PATH + "/memberships.json";
 
   static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
   static final String HEADER_SERVER_ERROR = "X-Okapi-InternalServerError";
@@ -278,6 +282,7 @@ public class MockServer {
     router.route(HttpMethod.POST, resourcesPath(FINANCE_STORAGE_ENCUMBRANCES))
       .handler(ctx -> handlePostGeneric(ctx, FINANCE_STORAGE_ENCUMBRANCES));
     router.route(HttpMethod.POST, resourcesPath(ACQUISITIONS_UNITS)).handler(ctx -> handlePostGenericSubObj(ctx, ACQUISITIONS_UNITS));
+    router.route(HttpMethod.POST, resourcesPath(ACQUISITIONS_MEMBERSHIPS)).handler(ctx -> handlePostGenericSubObj(ctx, ACQUISITIONS_MEMBERSHIPS));
 
     router.route(HttpMethod.GET, resourcePath(PURCHASE_ORDER)).handler(this::handleGetPurchaseOrderById);
     router.route(HttpMethod.GET, resourcesPath(PURCHASE_ORDER)).handler(ctx -> handleGetPurchaseOrderByQuery(ctx, PURCHASE_ORDER));
@@ -305,6 +310,8 @@ public class MockServer {
     router.route(HttpMethod.GET, resourcesPath(FINANCE_STORAGE_ENCUMBRANCES)).handler(this::handleGetEncumbrances);
     router.route(HttpMethod.GET, resourcesPath(ACQUISITIONS_UNITS)).handler(this::handleGetAcquisitionsUnits);
     router.route(HttpMethod.GET, resourcePath(ACQUISITIONS_UNITS)).handler(this::handleGetAcquisitionsUnit);
+    router.route(HttpMethod.GET, resourcesPath(ACQUISITIONS_MEMBERSHIPS)).handler(this::handleGetAcquisitionsMemberships);
+    router.route(HttpMethod.GET, resourcePath(ACQUISITIONS_MEMBERSHIPS)).handler(this::handleGetAcquisitionsMembership);
 
     router.route(HttpMethod.PUT, resourcePath(PURCHASE_ORDER)).handler(ctx -> handlePutGenericSubObj(ctx, PURCHASE_ORDER));
     router.route(HttpMethod.PUT, resourcePath(PO_LINES)).handler(ctx -> handlePutGenericSubObj(ctx, PO_LINES));
@@ -314,6 +321,7 @@ public class MockServer {
     router.route(HttpMethod.PUT, "/inventory/items/:id").handler(ctx -> handlePutGenericSubObj(ctx, ITEM_RECORDS));
     router.route(HttpMethod.PUT, "/holdings-storage/holdings/:id").handler(ctx -> handlePutGenericSubObj(ctx, ITEM_RECORDS));
     router.route(HttpMethod.PUT, resourcePath(ACQUISITIONS_UNITS)).handler(ctx -> handlePutGenericSubObj(ctx, ACQUISITIONS_UNITS));
+    router.route(HttpMethod.PUT, resourcePath(ACQUISITIONS_MEMBERSHIPS)).handler(ctx -> handlePutGenericSubObj(ctx, ACQUISITIONS_MEMBERSHIPS));
 
     router.route(HttpMethod.DELETE, resourcePath(PURCHASE_ORDER)).handler(ctx -> handleDeleteGenericSubObj(ctx, PURCHASE_ORDER));
     router.route(HttpMethod.DELETE, resourcePath(PO_LINES)).handler(ctx -> handleDeleteGenericSubObj(ctx, PO_LINES));
@@ -321,6 +329,7 @@ public class MockServer {
     router.route(HttpMethod.DELETE, resourcePath(REPORTING_CODES)).handler(ctx -> handleDeleteGenericSubObj(ctx, REPORTING_CODES));
     router.route(HttpMethod.DELETE, resourcePath(PIECES)).handler(ctx -> handleDeleteGenericSubObj(ctx, PIECES));
     router.route(HttpMethod.DELETE, resourcePath(ACQUISITIONS_UNITS)).handler(ctx -> handleDeleteGenericSubObj(ctx, ACQUISITIONS_UNITS));
+    router.route(HttpMethod.DELETE, resourcePath(ACQUISITIONS_MEMBERSHIPS)).handler(ctx -> handleDeleteGenericSubObj(ctx, ACQUISITIONS_MEMBERSHIPS));
 
     router.get("/configurations/entries").handler(this::handleConfigurationModuleResponse);
     return router;
@@ -1182,6 +1191,8 @@ public class MockServer {
         return org.folio.rest.acq.model.Piece.class;
       case ACQUISITIONS_UNITS:
         return AcquisitionsUnit.class;
+      case ACQUISITIONS_MEMBERSHIPS:
+        return AcquisitionsUnitMembership.class;
     }
 
     fail("The sub-object is unknown");
@@ -1361,6 +1372,57 @@ public class MockServer {
     if (acquisitionsUnit != null) {
       JsonObject data = JsonObject.mapFrom(acquisitionsUnit);
       addServerRqRsData(HttpMethod.GET, ACQUISITIONS_UNITS, data);
+      serverResponse(ctx, 200, APPLICATION_JSON, data.encodePrettily());
+    } else {
+      serverResponse(ctx, 404, TEXT_PLAIN, id);
+    }
+  }
+
+  private void handleGetAcquisitionsMemberships(RoutingContext ctx) {
+    logger.info("handleGetAcquisitionsMemberships got: " + ctx.request().path());
+
+    String query = StringUtils.trimToEmpty(ctx.request().getParam("query"));
+    if (query.contains(BAD_QUERY)) {
+      serverResponse(ctx, 400, APPLICATION_JSON, Response.Status.BAD_REQUEST.getReasonPhrase());
+    } else {
+      String userId = query.replace("userId==", "");
+      AcquisitionsUnitMembershipCollection memberships;
+      try {
+        memberships = new JsonObject(ApiTestBase.getMockData(ACQUISITIONS_MEMBERSHIPS_COLLECTION)).mapTo(AcquisitionsUnitMembershipCollection.class);
+      } catch (IOException e) {
+        memberships = new AcquisitionsUnitMembershipCollection();
+      }
+
+      if (StringUtils.isNotEmpty(userId)) {
+        memberships.getAcquisitionsUnitMemberships().removeIf(membership -> !membership.getUserId().equals(userId));
+      }
+
+      JsonObject data = JsonObject.mapFrom(memberships.withTotalRecords(memberships.getAcquisitionsUnitMemberships().size()));
+      addServerRqRsData(HttpMethod.GET, ACQUISITIONS_MEMBERSHIPS, data);
+      serverResponse(ctx, 200, APPLICATION_JSON, data.encodePrettily());
+    }
+  }
+
+  private void handleGetAcquisitionsMembership(RoutingContext ctx) {
+    logger.info("handleGetAcquisitionsMembership got: " + ctx.request().path());
+    String id = ctx.request().getParam(ID);
+
+    AcquisitionsUnitMembershipCollection memberships;
+    try {
+      memberships = new JsonObject(ApiTestBase.getMockData(ACQUISITIONS_MEMBERSHIPS_COLLECTION)).mapTo(AcquisitionsUnitMembershipCollection.class);
+    } catch (IOException e) {
+      memberships = new AcquisitionsUnitMembershipCollection();
+    }
+
+    AcquisitionsUnitMembership acquisitionsUnitMembership = memberships.getAcquisitionsUnitMemberships()
+      .stream()
+      .filter(membership -> membership.getId().equals(id))
+      .findAny()
+      .orElse(null);
+
+    if (acquisitionsUnitMembership != null) {
+      JsonObject data = JsonObject.mapFrom(acquisitionsUnitMembership);
+      addServerRqRsData(HttpMethod.GET, ACQUISITIONS_MEMBERSHIPS, data);
       serverResponse(ctx, 200, APPLICATION_JSON, data.encodePrettily());
     } else {
       serverResponse(ctx, 404, TEXT_PLAIN, id);

--- a/src/test/resources/mockdata/acquisitionsUnits/units/memberships.json
+++ b/src/test/resources/mockdata/acquisitionsUnits/units/memberships.json
@@ -1,0 +1,21 @@
+{
+  "acquisitionsUnitMemberships":
+  [
+    {
+      "id": "39982f76-9738-4f49-b3a6-707d1e76853c",
+      "userId": "6e076ac5-371e-4462-af79-187c54fe70de",
+      "acquisitionsUnitId": "57c35c88-625d-4f0e-bc79-d22818d84d1c"
+    },
+    {
+      "id": "567a6d67-460f-43ab-af28-8c730c9aa4da",
+      "userId": "480dba68-ee84-4b9c-a374-7e824fc49227",
+      "acquisitionsUnitId": "f6d2cc9d-82ca-437c-a4e6-e5c30323df00"
+    },
+    {
+      "id": "874225ae-e3f5-4666-ae19-b35709ff0ee9",
+      "userId": "480dba68-ee84-4b9c-a374-7e824fc49227",
+      "acquisitionsUnitId": "aa0ec4e1-782f-45f6-a6f3-8e6b6c00599c"
+    }
+  ],
+  "totalRecords": 3
+}


### PR DESCRIPTION
[MODORDERS-250](https://issues.folio.org/browse/MODORDERS-250) - Implement basic CRUD for /acquisitions-units/memberships

## Purpose

Define and implement the acquisitions-unit memberships API

## Approach
Memberships API implementation in accordance with https://docs.google.com/spreadsheets/d/1se-a2owRfHLG5eaAZglx4vLvRClCKGp2wZCfD39ZJRY/edit#gid=894044560

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
 