### PR TITLE
MODORDERS-256 Restrict search/view of PO, POL, Piece records based upon acquisitions unit

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -11,6 +11,8 @@
           "pathPattern": "/orders/composite-orders",
           "permissionsRequired": ["orders.collection.get"],
           "modulePermissions": [
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get",
             "orders-storage.purchase-orders.collection.get"
           ]
         },
@@ -119,6 +121,8 @@
           "pathPattern": "/orders/order-lines",
           "permissionsRequired": ["orders.po-lines.collection.get"],
           "modulePermissions": [
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get",
             "orders-storage.po-lines.collection.get"
           ]
         },
@@ -229,6 +233,8 @@
           "pathPattern": "/orders/receiving-history",
           "permissionsRequired": ["orders.receiving-history.collection.get"],
           "modulePermissions": [
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get",
             "orders-storage.receiving-history.collection.get"
           ]
         },

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -98,7 +98,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
           String queryParam = buildQuery(acqUnitsCqlExpr, logger);
           return String.format(GET_PURCHASE_ORDERS, limit, offset, queryParam, lang);
         } else {
-          String queryParam = buildQuery(query + " and " + acqUnitsCqlExpr, logger);
+          String queryParam = buildQuery(acqUnitsCqlExpr + " and " + query, logger);
           return String.format(SEARCH_ORDERS_BY_LINES_DATA, limit, offset, queryParam, lang);
         }
       });

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -127,7 +127,7 @@ class PurchaseOrderLineHelper extends AbstractHelper {
       if (isEmpty(query)) {
         return getPoLines(limit, offset, acqUnitsCqlExpr, GET_PO_LINES_BY_QUERY);
       }
-      return getPoLines(limit, offset, query + " and " + acqUnitsCqlExpr, GET_ORDER_LINES_BY_QUERY);
+      return getPoLines(limit, offset, acqUnitsCqlExpr + " and " + query, GET_ORDER_LINES_BY_QUERY);
     });
   }
 

--- a/src/main/java/org/folio/rest/impl/ReceivingHelper.java
+++ b/src/main/java/org/folio/rest/impl/ReceivingHelper.java
@@ -87,7 +87,7 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
       AcquisitionsUnitsHelper acqUnitsHelper = new AcquisitionsUnitsHelper(httpClient, okapiHeaders, ctx, lang);
       acqUnitsHelper.buildAcqUnitsCqlExprToSearchRecords()
         .thenCompose(acqUnitsCqlExpr -> {
-          String queryParam = buildQuery(StringUtils.isEmpty(query) ? acqUnitsCqlExpr : query + " and " + acqUnitsCqlExpr, logger);
+          String queryParam = buildQuery(StringUtils.isEmpty(query) ? acqUnitsCqlExpr : acqUnitsCqlExpr + " and " + query, logger);
           String endpoint = String.format(GET_RECEIVING_HISTORY_BY_QUERY, limit, offset, queryParam, lang);
           return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
             .thenAccept(jsonReceivingHistory -> future.complete(jsonReceivingHistory.mapTo(ReceivingHistoryCollection.class)));


### PR DESCRIPTION
## Purpose
[MODORDERS-256](https://issues.folio.org/browse/MODORDERS-256) Restrict search of PO and POL records and receiving history based upon acquisitions unit
Adding acquisitions units CQL expression in the beginning of the query to allow sorting criteria to be specified (this is to resolve UIOR-327)

## Approach
- Adding acq units cql expression as first part of the query
- Adding acq units permissions

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
