### PR TITLE
MODORDERS-277 Update inventory interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -46,7 +46,6 @@
             "inventory-storage.holdings.collection.get",
             "inventory-storage.items.collection.get",
             "inventory-storage.items.item.post",
-            "inventory-storage.instances.item.get",
             "inventory-storage.loan-types.collection.get",
             "inventory-storage.contributor-name-types.collection.get",
             "organizations-storage.organizations.collection.get",
@@ -434,7 +433,7 @@
     },
     {
       "id": "inventory",
-      "version": "8.3"
+      "version": "8.3 9.0"
     },
     {
       "id": "instance-types",

--- a/src/test/resources/mockdata/instances/instance.json
+++ b/src/test/resources/mockdata/instances/instance.json
@@ -69,9 +69,6 @@
       "languages": [
         "eng"
       ],
-      "notes": [
-        "Bridget Jones finds herself unexpectedly pregnant at the eleventh hour. However, her joyful pregnancy is dominated by one crucial but awkward question --who is the father? Could it be honorable, decent, notable human rights lawyer, Mark Darcy? Or, is it charming, witty, and totally despicable, Daniel Cleaver?"
-      ],
       "previouslyHeld": true,
       "staffSuppress": true,
       "discoverySuppress": true,


### PR DESCRIPTION
## Purpose
[MODORDERS-277](https://issues.folio.org/browse/MODORDERS-277) Update inventory interface version

## Approach
- Updating `inventory` interface version including `9.0` along with `8.3` (there is no functionality which works with instance's notes)
- Removing unused `inventory-storage.instances.item.get` permission for order creation
- Updating mock instance removing notes

The changes verified locally by API tests
![image](https://user-images.githubusercontent.com/43410167/61044607-abfd8b00-a3e1-11e9-855f-eaa778da767d.png)

![image](https://user-images.githubusercontent.com/43410167/61044515-7eb0dd00-a3e1-11e9-91d8-4986974699cf.png)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
