### PR TITLE
MODORDERS-265 Restrict which fields can be edited once worflowStatus = Open

### DIFF
--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,7 +1,11 @@
 package org.folio.rest.impl;
 
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import io.vertx.core.json.Json;
 import org.folio.config.ApplicationConfig;
 import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.rest.tools.utils.ObjectMapperTool;
 import org.folio.spring.SpringContextUtil;
 
 import io.vertx.core.AsyncResult;
@@ -22,6 +26,14 @@ public class InitAPIs implements InitAPI {
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
     vertx.executeBlocking(
       handler -> {
+        SerializationConfig serializationConfig = ObjectMapperTool.getMapper().getSerializationConfig();
+        DeserializationConfig deserializationConfig = ObjectMapperTool.getMapper().getDeserializationConfig();
+
+        Json.mapper.setConfig(serializationConfig);
+        Json.prettyMapper.setConfig(serializationConfig);
+        Json.mapper.setConfig(deserializationConfig);
+        Json.prettyMapper.setConfig(deserializationConfig);
+
         SpringContextUtil.init(vertx, context, ApplicationConfig.class);
         handler.complete();
       },


### PR DESCRIPTION
## Purpose
Some of the API tests for the poLine update fell with an error `protectedFieldChanging`, although the body of the request was fully consistent with what was stored in the storage. It turned out that `RestVerticle` uses a `ObjectMapper` with different serialization configs for Date serialization from that used by Vertx.
`org.folio.rest.tools.utils.ObjectMapperTool.MAPPER` сonverts the `Date` into  `String`
`io.vertx.core.json.Json.mapper` сonverts the `Date` to `long`

## Approach
- applying `org.folio.rest.tools.utils.ObjectMapperTool.MAPPER` serialization and deserialization configs to `io.vertx.core.json.Json.mapper` in `InitAPI.init()` phase

API test run on folio-testing:
![image](https://user-images.githubusercontent.com/41672277/61132601-636ace00-a4c4-11e9-98ea-9cf04ec68b2a.png)

After the fix locally:
![image](https://user-images.githubusercontent.com/41672277/61132676-885f4100-a4c4-11e9-8374-aa8f48948776.png)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
