### PR TITLE
MODORDERS-284: closeReason is protected, so unable to close Order

### DIFF
--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -134,8 +134,8 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
   public CompletableFuture<JsonObject> validateIfPOProtectedFieldsChanged(CompositePurchaseOrder compPO,
       JsonObject compPOFromStorage) {
-    if (!compPOFromStorage.getString(WORKFLOW_STATUS)
-      .equals(CompositePurchaseOrder.WorkflowStatus.PENDING.value())) {
+    if ((compPOFromStorage.getString(WORKFLOW_STATUS).equals(CompositePurchaseOrder.WorkflowStatus.OPEN.value())) ||
+        (compPOFromStorage.getString(WORKFLOW_STATUS).equals(CompositePurchaseOrder.WorkflowStatus.CLOSED.value()) && compPO.getCloseReason() == null)) {
       verifyProtectedFieldsChanged(POProtectedFields.getFieldNames(), compPOFromStorage, JsonObject.mapFrom(compPO));
     }
     return completedFuture(compPOFromStorage);

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -366,7 +366,7 @@ public class ApiTestBase {
       assertThat(message.body().getString(HelperUtils.LANG), not(isEmptyOrNullString()));
     }
   }
-
+  
   void checkPreventProtectedFieldsModificationRule(String path, JsonObject compPO, Map<String, Object> updatedFields) {
     JsonObject compPOJson = JsonObject.mapFrom(compPO);
     JsonPathParser compPOParser = new JsonPathParser(compPOJson);

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -366,7 +366,7 @@ public class ApiTestBase {
       assertThat(message.body().getString(HelperUtils.LANG), not(isEmptyOrNullString()));
     }
   }
-  
+
   void checkPreventProtectedFieldsModificationRule(String path, JsonObject compPO, Map<String, Object> updatedFields) {
     JsonObject compPOJson = JsonObject.mapFrom(compPO);
     JsonPathParser compPOParser = new JsonPathParser(compPOJson);

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -109,7 +109,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -151,6 +150,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
   private static final String PO_ID_FOR_FAILURE_CASE = "bad500aa-aaaa-500a-aaaa-aaaaaaaaaaaa";
   private static final String ORDER_ID_WITHOUT_PO_LINES = "50fb922c-3fa9-494e-a972-f2801f1b9fd1";
   private static final String ORDER_WITHOUT_WORKFLOW_STATUS = "41d56e59-46db-4d5e-a1ad-a178228913e5";
+  private static final String ORDERS_CLOSED_REASON = "c1465131-ed35-4308-872c-d7cdf0af0000";
   static final String ORDER_WIT_PO_LINES_FOR_SORTING =  "9a952cd0-842b-4e71-bddd-014eb128dc8e";
 
   // API paths
@@ -2057,15 +2057,12 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     List<Encumbrance> createdEncumbrances = getCreatedEncumbrances();
     assertThat(createdEncumbrances, empty());
   }
-
-  // 1ab7ef6a-d1d4-4a4f-90a2-882aed18af14
   
   @Test
   public void testPutOrderReasonClosedProtectedFieldsChanged() throws IllegalAccessException {
     logger.info("=== Test PUT Order By Id - Reason Closed Protected fields changed ===");
 
-    JsonObject reqData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, "c1465131-ed35-4308-872c-d7cdf0af0000");
-    //JsonObject reqData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, "11111111-dddd-4444-9999-ffffffffffff");
+    JsonObject reqData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, ORDERS_CLOSED_REASON);
     assertThat(reqData.getString("workflowStatus"), is(CompositePurchaseOrder.WorkflowStatus.CLOSED.value()));
 
     Map<String, Object> allProtectedFieldsModification = new HashMap<>();

--- a/src/test/resources/mockdata/compositeOrders/c1465131-ed35-4308-872c-d7cdf0af0000.json
+++ b/src/test/resources/mockdata/compositeOrders/c1465131-ed35-4308-872c-d7cdf0af0000.json
@@ -1,0 +1,38 @@
+{
+  "id": "c1465131-ed35-4308-872c-d7cdf0af0000",
+  "approved": true,
+  "notes": [],
+  "manualPo": false,
+  "poNumber": "268s879",
+  "orderType": "One-Time",
+  "reEncumber": false,
+  "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflowStatus": "Closed",
+  "compositePoLines": [
+    {
+      "id": "ed97366a-7f11-4bdc-bc2d-cedc496e2a6e",
+      "acquisitionMethod": "Purchase At Vendor System",
+      "collection" : false,
+      "description": "ABCDEFGH",
+      "eresource":{
+        "createInventory": "None"
+      },
+      "poLineDescription": "PO Line description",
+      "poLineNumber": "268s879-1",
+      "orderFormat": "Electronic Resource",
+      "cost":{
+        "listUnitPriceElectronic": 0,
+        "currency" : "USD",
+        "quantityElectronic":1
+      },
+      "purchaseOrderId": "c1465131-ed35-4308-872c-d7cdf0af0000",
+      "rush" : false,
+      "source": "User",
+      "title": "Kayak Fishing in the Northern Gulf Coast"
+    }
+  ],
+  "metadata": {
+    "createdDate": "2014-07-06T00:00:00.000",
+    "createdByUserId": "28d10cfc-d137-11e8-a8d5-f2801f1b9fd1"
+  }
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/MODORDERS-284

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- close reason is a protected field only for Orders in closed status. 
- Should be able to close order with close reason specified
- add unit test

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
