### PR TITLE
MODORDERS-284- closeReason is protected, unable to close Order

### DIFF
--- a/src/main/java/org/folio/orders/utils/POLineProtectedFields.java
+++ b/src/main/java/org/folio/orders/utils/POLineProtectedFields.java
@@ -31,6 +31,7 @@ public enum POLineProtectedFields {
   FUND_DISTRIBUTION("fundDistribution"),
   LOCATION("locations") ,
   ORER_FORMAT("orderFormat"),
+  PHYSICAL_CREATE_INVENTORY("physical.createInventory"),
   PHYSICAL_VOLUMES("physical.volumes"),
   PHYSICAL_MATERIAL_TYPE("physical.materialType"),
   PUBLICATION_DATE("publicationDate"),

--- a/src/main/java/org/folio/orders/utils/POProtectedFields.java
+++ b/src/main/java/org/folio/orders/utils/POProtectedFields.java
@@ -31,4 +31,11 @@ public enum POProtectedFields {
       .map(POProtectedFields::getFieldName)
       .collect(Collectors.toList());
   }
+
+  public static List<String> getFieldNamesForOpenOrder() {
+    return Arrays.stream(POProtectedFields.values())
+      .map(POProtectedFields::getFieldName)
+      .filter(field -> !field.equals(CLOSE_REASON.getFieldName()))
+      .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -7,6 +7,9 @@ import static org.folio.orders.utils.HelperUtils.*;
 import static org.folio.orders.utils.ResourcePathResolver.*;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.PENDING;
+import static org.folio.orders.utils.POProtectedFields.getFieldNames;
+import static org.folio.orders.utils.POProtectedFields.getFieldNamesForOpenOrder;
+
 
 import io.vertx.core.Context;
 import io.vertx.core.http.HttpMethod;
@@ -24,7 +27,6 @@ import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.ErrorCodes;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.orders.utils.POLineProtectedFields;
-import org.folio.orders.utils.POProtectedFields;
 import org.folio.rest.jaxrs.model.*;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
 import org.folio.rest.jaxrs.model.Error;
@@ -134,9 +136,10 @@ public class PurchaseOrderHelper extends AbstractHelper {
 
   public CompletableFuture<JsonObject> validateIfPOProtectedFieldsChanged(CompositePurchaseOrder compPO,
       JsonObject compPOFromStorage) {
-    if (!compPOFromStorage.getString(WORKFLOW_STATUS)
-      .equals(CompositePurchaseOrder.WorkflowStatus.PENDING.value())) {
-      verifyProtectedFieldsChanged(POProtectedFields.getFieldNames(), compPOFromStorage, JsonObject.mapFrom(compPO));
+    WorkflowStatus storagePOWorkflowStatus = WorkflowStatus.fromValue(compPOFromStorage.getString(WORKFLOW_STATUS));
+    if (!PENDING.equals(storagePOWorkflowStatus)) {
+      List<String> fieldNames = OPEN.equals(storagePOWorkflowStatus) ? getFieldNamesForOpenOrder() : getFieldNames();
+      verifyProtectedFieldsChanged(fieldNames, compPOFromStorage, JsonObject.mapFrom(compPO));
     }
     return completedFuture(compPOFromStorage);
   }

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -2081,6 +2081,23 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     checkPreventProtectedFieldsModificationRule(COMPOSITE_ORDERS_BY_ID_PATH, reqData, allProtectedFieldsModification);
   }
 
+
+  @Test
+  public void testUpdateOrderCloseOrderWithCloseReason() throws IllegalAccessException {
+    logger.info("=== Test case: Able to Close Order with close Reason ===");
+
+    JsonObject reqData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, PO_ID_OPEN_STATUS);
+    assertThat(reqData.getString("workflowStatus"), is(CompositePurchaseOrder.WorkflowStatus.OPEN.value()));
+    reqData.put("workflowStatus", "Closed");
+    // close reason must not be checked if the Order is in OPEN status in storage
+    CloseReason closeReason = new CloseReason();
+    closeReason.setNote("can set close reason");
+    closeReason.setReason("Complete");
+    reqData.put("closeReason", JsonObject.mapFrom(closeReason));
+
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getString("id")), JsonObject.mapFrom(reqData), "", 204);
+  }
+
   @Test
   public void testUpdateOrderWithLineProtectedFieldsChanging() throws IllegalAccessException {
     logger.info("=== Test case when OPEN order errors if protected fields are changed in CompositePoLine===");
@@ -2122,6 +2139,10 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     Renewal renewal = new Renewal();
     renewal.setManualRenewal(true);
     allProtectedFieldsModification.put(POProtectedFields.RENEWAL.getFieldName(), JsonObject.mapFrom(renewal));
+    CloseReason closeReason = new CloseReason();
+    closeReason.setNote("testing reason on Closed Order");
+    closeReason.setReason("Complete");
+    allProtectedFieldsModification.put(POProtectedFields.CLOSE_REASON.getFieldName(), JsonObject.mapFrom(closeReason));
 
     checkPreventProtectedFieldsModificationRule(COMPOSITE_ORDERS_BY_ID_PATH, reqData, allProtectedFieldsModification);
   }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDERS-284

## Approach
- Exclude "CLOSE REASON" while closing orders(Order status "OPEN" in storage, and incoming request is in "CLOSED")
- adding Physical.createInventory, from comments in https://issues.folio.org/browse/MODORDERS-265


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
