### PR TITLE
MODORDERS-279 - Release 7.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 ## 8.0.0 - Unreleased
 
+## 7.0.1 - Released
+This release includes bug fix for issue related to order's closing.
+
+[Full Changelog](https://github.com/folio-org/mod-orders/compare/v7.0.0...v7.0.1)
+
+### Bug Fixes
+ * [MODORDERS-284](https://issues.folio.org/browse/MODORDERS-284) - `closeReason` is protected, so unable to close Order
+
 ## 7.0.0 - Released
 The primary focus of this release was to implement CRUD API for managing Teams (Units, Assignments, Memberships) and business logic improvements.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>7.0.1</version>
+  <version>7.1-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v7.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>7.1.0-SNAPSHOT</version>
+  <version>7.0.1</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v7.0.1</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
This release includes fix from story [MODORDERS-284](https://issues.folio.org/browse/MODORDERS-284) - closeReason is protected, so unable to close Order.