### PR TITLE
MODORDERS-256 Restrict view of PO and POL records based upon acquisitions unit

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -63,7 +63,9 @@
             "orders-storage.purchase-orders.item.get",
             "orders-storage.po-lines.collection.get",
             "orders-storage.alerts.item.get",
-            "orders-storage.reporting-codes.item.get"
+            "orders-storage.reporting-codes.item.get",
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get"
           ]
         },
         {
@@ -151,7 +153,10 @@
           "modulePermissions": [
             "orders-storage.po-lines.item.get",
             "orders-storage.alerts.item.get",
-            "orders-storage.reporting-codes.item.get"
+            "orders-storage.reporting-codes.item.get",
+            "orders-storage.purchase-orders.item.get",
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get"
           ]
         },
         {

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -103,6 +103,8 @@ public class ApiTestBase {
   protected static final String PO_ID_CLOSED_STATUS = "07f65192-44a4-483d-97aa-b137bbd96390";
   protected static final String PO_ID_OPEN_TO_BE_CLOSED = "9d56b621-202d-414b-9e7f-5fefe4422ab3";
   static final String PO_LINE_ID_FOR_SUCCESS_CASE = "fca5fa9e-15cb-4a3d-ab09-eeea99b97a47";
+  static final String MIN_PO_ID = UUID.randomUUID().toString();
+  static final String MIN_PO_LINE_ID = UUID.randomUUID().toString();
 
   static final String COMP_ORDER_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "compositeOrders/";
 
@@ -434,9 +436,13 @@ public class ApiTestBase {
       .withPoLineId(poLineId);
   }
 
+  public static PoLine getMinimalContentCompositePoLine() {
+    return getMinimalContentCompositePoLine(MIN_PO_ID);
+  }
+
   public static PoLine getMinimalContentCompositePoLine(String orderId) {
     return new PoLine().withSource(PoLine.Source.EDI)
-      .withId(UUID.randomUUID().toString())
+      .withId(MIN_PO_LINE_ID)
       .withOrderFormat(PoLine.OrderFormat.PHYSICAL_RESOURCE)
       .withAcquisitionMethod(PoLine.AcquisitionMethod.PURCHASE)
       .withPhysical(new Physical().withMaterialType("2d1398ae-e1aa-4c7c-b9c9-15adf8cf6425"))
@@ -448,12 +454,12 @@ public class ApiTestBase {
 
   public static PurchaseOrder getMinimalContentPurchaseOrder() {
     return new PurchaseOrder()
-      .withId(UUID.randomUUID().toString())
+      .withId(MIN_PO_ID)
       .withOrderType(PurchaseOrder.OrderType.ONE_TIME)
       .withVendor("7d232b43-bf9a-4301-a0ce-9e076298632e");
   }
 
-  public String encodePrettily(Object entity) {
+  public static String encodePrettily(Object entity) {
     return JsonObject.mapFrom(entity).encodePrettily();
   }
 }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -30,6 +30,8 @@ import static org.folio.rest.impl.ApiTestBase.ID;
 import static org.folio.rest.impl.ApiTestBase.ID_DOES_NOT_EXIST;
 import static org.folio.rest.impl.ApiTestBase.ID_FOR_INTERNAL_SERVER_ERROR;
 import static org.folio.rest.impl.ApiTestBase.INSTANCE_TYPE_CONTAINS_CODE_AS_INSTANCE_STATUS_TENANT;
+import static org.folio.rest.impl.ApiTestBase.MIN_PO_ID;
+import static org.folio.rest.impl.ApiTestBase.MIN_PO_LINE_ID;
 import static org.folio.rest.impl.ApiTestBase.NON_EXIST_CONTRIBUTOR_NAME_TYPE_TENANT;
 import static org.folio.rest.impl.ApiTestBase.NON_EXIST_INSTANCE_STATUS_TENANT;
 import static org.folio.rest.impl.ApiTestBase.NON_EXIST_INSTANCE_TYPE_TENANT;
@@ -38,6 +40,9 @@ import static org.folio.rest.impl.ApiTestBase.PO_ID_GET_LINES_INTERNAL_SERVER_ER
 import static org.folio.rest.impl.ApiTestBase.PO_LINE_NUMBER_VALUE;
 import static org.folio.rest.impl.ApiTestBase.PROTECTED_READ_ONLY_TENANT;
 import static org.folio.rest.impl.ApiTestBase.X_ECHO_STATUS;
+import static org.folio.rest.impl.ApiTestBase.encodePrettily;
+import static org.folio.rest.impl.ApiTestBase.getMinimalContentCompositePoLine;
+import static org.folio.rest.impl.ApiTestBase.getMinimalContentPurchaseOrder;
 import static org.folio.rest.impl.ApiTestBase.getMockAsJson;
 import static org.folio.rest.impl.InventoryHelper.HOLDING_PERMANENT_LOCATION_ID;
 import static org.folio.rest.impl.InventoryHelper.ITEMS;
@@ -965,6 +970,8 @@ public class MockServer {
 
     if (ID_FOR_INTERNAL_SERVER_ERROR.equals(id)) {
       serverResponse(ctx, 500, APPLICATION_JSON, INTERNAL_SERVER_ERROR);
+    } else if (MIN_PO_LINE_ID.equals(id)) {
+      serverResponse(ctx, 200, APPLICATION_JSON, encodePrettily(getMinimalContentCompositePoLine()));
     } else {
       try {
 
@@ -1161,6 +1168,11 @@ public class MockServer {
 
       // If previous step has no result then attempt to find PO in stubs
       if (po == null) {
+        if (MIN_PO_ID.equals(id)) {
+          serverResponse(ctx, 200, APPLICATION_JSON, encodePrettily(getMinimalContentPurchaseOrder()));
+          return;
+        }
+
         String filePath;
         if (ID_FOR_PRINT_MONOGRAPH_ORDER.equals(id)) {
           filePath = LISTED_PRINT_MONOGRAPH_PATH;

--- a/src/test/java/org/folio/rest/impl/protection/LinesProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/LinesProtectionTest.java
@@ -26,7 +26,8 @@ public class LinesProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testOperationWithNonExistedUnits(ProtectedOperations operation) {
     logger.info("=== Test corresponding order contains non-existent units - expecting of call only to Units API ===");
@@ -43,7 +44,8 @@ public class LinesProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testOperationWithAllowedUnits(ProtectedOperations operation) {
     logger.info("=== Test corresponding order has units allowed operation - expecting of call only to Units API ===");
@@ -56,7 +58,8 @@ public class LinesProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testWithRestrictedUnitsAndAllowedUser(ProtectedOperations operation) {
     logger.info("=== Test corresponding order has units, units protect operation, user is member of order's units - expecting of calls to Units, Memberships APIs and allowance of operation ===");
@@ -69,7 +72,8 @@ public class LinesProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testWithProtectedUnitsAndForbiddenUser(ProtectedOperations operation) {
     logger.info("=== Test corresponding order has units, units protect operation, user isn't member of order's units - expecting of calls to Units, Memberships APIs and restriction of operation ===");

--- a/src/test/java/org/folio/rest/impl/protection/OrdersProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/OrdersProtectionTest.java
@@ -29,7 +29,8 @@ public class OrdersProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testOperationWithNonExistedUnits(ProtectedOperations operation) {
     logger.info("=== Test order contains non-existent unit ids - expecting of call only to Units API ===");
@@ -46,7 +47,8 @@ public class OrdersProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testOperationWithAllowedUnits(ProtectedOperations operation) {
     logger.info("=== Test corresponding order has units allowed operation - expecting of call only to Units API ===");
@@ -59,7 +61,8 @@ public class OrdersProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testWithRestrictedUnitsAndAllowedUser(ProtectedOperations operation) {
     logger.info("=== Test corresponding order has units, units protect operation, user is member of order's units - expecting of calls to Units, Memberships APIs and allowance of operation ===");
@@ -72,7 +75,8 @@ public class OrdersProtectionTest extends ProtectedEntityTestBase {
 
   @Test
   @Parameters({
-    "CREATE"
+    "CREATE",
+    "READ"
   })
   public void testWithProtectedUnitsAndForbiddenUser(ProtectedOperations operation) {
     logger.info("=== Test corresponding order has units, units protect operation, user isn't member of order's units - expecting of calls to Units, Memberships APIs and restriction of operation ===");

--- a/src/test/java/org/folio/rest/impl/protection/ProtectedEntityTestBase.java
+++ b/src/test/java/org/folio/rest/impl/protection/ProtectedEntityTestBase.java
@@ -49,12 +49,12 @@ public abstract class ProtectedEntityTestBase extends ApiTestBase {
   public PurchaseOrder prepareOrder(List<String> acqUnitsIds) {
     PurchaseOrder po = getMinimalContentPurchaseOrder();
     po.setAcqUnitIds(acqUnitsIds);
+    addMockEntry(PURCHASE_ORDER, JsonObject.mapFrom(po));
     return po;
   }
 
   public PoLine preparePoLine(List<String> acqUnitsIds) {
     PurchaseOrder order = prepareOrder(acqUnitsIds);
-    addMockEntry(PURCHASE_ORDER, JsonObject.mapFrom(order));
     return getMinimalContentCompositePoLine(order.getId());
   }
 


### PR DESCRIPTION
## Purpose
[MODORDERS-256](https://issues.folio.org/browse/MODORDERS-256) Restrict search/view of PO, POL, Piece records based upon acquisitions unit

## Approach
Restrict get order and order line by id operations.
Note: there is no endpoint to get piece by id.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.