### PR TITLE
MODORDERS-293 GET units - handle soft "deleted" units

### DIFF
--- a/src/test/java/org/folio/rest/impl/AcquisitionsUnitsTests.java
+++ b/src/test/java/org/folio/rest/impl/AcquisitionsUnitsTests.java
@@ -4,8 +4,11 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.orders.utils.ErrorCodes.MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY;
 import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
+import static org.folio.rest.impl.AcquisitionsUnitsHelper.ACTIVE_UNITS_CQL;
+import static org.folio.rest.impl.AcquisitionsUnitsHelper.ALL_UNITS_CQL;
 import static org.folio.rest.impl.MockServer.ACQUISITIONS_UNITS_COLLECTION;
 import static org.folio.rest.impl.MockServer.getAcqUnitsRetrievals;
+import static org.folio.rest.impl.MockServer.getQueryParams;
 import static org.folio.rest.impl.MockServer.getRqRsEntries;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -49,15 +52,24 @@ public class AcquisitionsUnitsTests extends ApiTestBase {
     final AcquisitionsUnitCollection units = verifySuccessGet(ACQ_UNITS_UNITS_ENDPOINT, AcquisitionsUnitCollection.class);
     assertThat(expected.getAcquisitionsUnits(), hasSize(expected.getTotalRecords()));
     assertThat(units.getAcquisitionsUnits(), hasSize(expected.getTotalRecords()));
+
+    List<String> queryParams = getQueryParams(ACQUISITIONS_UNITS);
+    assertThat(queryParams, hasSize(1));
+    assertThat(queryParams.get(0), containsString(ACTIVE_UNITS_CQL));
   }
 
   @Test
   public void testGetAcqUnitsWithQuery() {
     logger.info("=== Test GET Acquisitions Units - search by query ===");
-    String url = ACQ_UNITS_UNITS_ENDPOINT + "?query=name==Read only";
+    String cql = ALL_UNITS_CQL + " and name==Read only";
+    String url = ACQ_UNITS_UNITS_ENDPOINT + "?query=" + cql;
 
     final AcquisitionsUnitCollection units = verifySuccessGet(url, AcquisitionsUnitCollection.class);
     assertThat(units.getAcquisitionsUnits(), hasSize(1));
+
+    List<String> queryParams = getQueryParams(ACQUISITIONS_UNITS);
+    assertThat(queryParams, hasSize(1));
+    assertThat(queryParams.get(0), equalTo(cql));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -1413,6 +1413,7 @@ public class MockServer {
     logger.info("handleGetAcquisitionsUnits got: " + ctx.request().path());
     String tenant = ctx.request().getHeader(OKAPI_HEADER_TENANT);
     String query = StringUtils.trimToEmpty(ctx.request().getParam("query"));
+    addServerRqQuery(ACQUISITIONS_UNITS, query);
 
     AcquisitionsUnitCollection units;
 


### PR DESCRIPTION
## Purpose
[MODORDERS-293](https://issues.folio.org/browse/MODORDERS-293) Acquisition units - soft delete

## Approach
Updating `GET /acquisitions-units/units` logic:
- if query contains `isDeleted` key word, just send query as is to storage. 
- if not, add `isDeleted==false and <original query>`

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.