### PR TITLE
MODORDERS-294 Disallow "isDeleted" acq units to be assigned to orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ CRUD APIs are available to manage acquisitions units and memberships (user-unit 
 In order to avoid reference integrity issues when deleting acquisition units that are assigned to records, the logic implements a "soft delete" approach.
 * When client sends `DELETE /acquisitions-units/units/<id>`, the logic gets acquisitions unit by specified id and updates it setting `isDeleted` to `true`
 * When client sends `GET /acquisitions-units/units?query=<cql>` and `<cql>` does not contain criteria by `isDeleted`, the logic will search for records with `isDeleted==false`.
-* To get all the units regardless of `isDeleted` value, the request should be like `GET /acquisition-units/units?query=isDeleted=* AND (<cql>)`
+* To get all the units regardless of `isDeleted` value, the request should be like `GET /acquisitions-units/units?query=isDeleted=* AND (<cql>)`
 
 ### Issue tracker
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Note: receiving might lead to Order's workflow status update (see [MODORDERS-218
 ### Acquisitions units
 CRUD APIs are available to manage acquisitions units and memberships (user-unit relations).  
 In order to avoid reference integrity issues when deleting acquisition units that are assigned to records, the logic implements a "soft delete" approach.
-* When client sends `DELETE /acquisitions-units/units/<id>`, the logic gets acquisitions unit be specified id and updates it setting `isDeleted` to `true`
+* When client sends `DELETE /acquisitions-units/units/<id>`, the logic gets acquisitions unit by specified id and updates it setting `isDeleted` to `true`
 * When client sends `GET /acquisitions-units/units?query=<cql>` and `<cql>` does not contain criteria by `isDeleted`, the logic will search for records with `isDeleted==false`.
 * To get all the units regardless of `isDeleted` value, the request should be like `GET /acquisition-units/units?query=isDeleted=* AND (<cql>)`
 

--- a/ramls/acquisitions-units.raml
+++ b/ramls/acquisitions-units.raml
@@ -39,7 +39,7 @@ resourceTypes:
       description: Create new acquisitions unit
       is: [validate]
     get:
-      description: Get list of acquisitions units
+      description: Get list of acquisitions units. In case client does not specify search criteria by "isDeleted" property, the logic will search for records with "isDeleted==false"
       is: [
         searchable: {description: "with valid searchable fields: for example protectRead", example: "[\"protectRead\", \"false\"]"},
         pageable
@@ -56,6 +56,8 @@ resourceTypes:
       put:
         description: Update acquisitions unit
         is: [validate]
+      delete:
+        description: In order to avoid reference integrity issues when deleting acquisition units that are assigned to records, the logic implements a "soft delete". Update acquisitions unit setting the "isDeleted" field to true
   /memberships:
     type:
       collection:

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -48,7 +48,7 @@ public enum ErrorCodes {
   MISSING_LOAN_TYPE("missingLoanType", "Loan-type is a required field for creating an Item in Inventory"),
   ENCUMBRANCE_CREATION_FAILURE("encumbranceCreationFailure", "One or more encumbrance record(s) failed to be created"),
   PROHIBITED_FIELD_CHANGING("protectedFieldChanging","Protected fields can't be modified"),
-  ORDER_UNITS_NOT_FOUND("orderUnitsNotFound", "Units not found"),
+  ORDER_UNITS_NOT_FOUND("orderAcqUnitsNotFound", "Acquisitions units assigned to order cannot be found"),
   USER_HAS_NO_PERMISSIONS("userHasNoPermission", "User does not have permissions - operation is restricted"),
   USER_HAS_NO_ACQ_PERMISSIONS("userHasNoAcqUnitsPermission", "User does not have permissions to manage acquisition units assignments - operation is restricted"),
   USER_HAS_NO_APPROVAL_PERMISSIONS("userHasNoApprovalPermission", "User does not have permissions to approve order - operation is restricted"),

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -850,7 +850,7 @@ public class HelperUtils {
                                        Logger logger) {
     CompletableFuture<JsonObject> future = new VertxCompletableFuture<>(ctx);
     try {
-      logger.debug("Calling GET {}", endpoint);
+      logger.info("Calling GET {}", endpoint);
 
       httpClient
         .request(HttpMethod.GET, endpoint, okapiHeaders)
@@ -859,8 +859,8 @@ public class HelperUtils {
           return verifyAndExtractBody(response);
         })
         .thenAccept(body -> {
-          if (logger.isDebugEnabled()) {
-            logger.debug("The response body for GET {}: {}", endpoint, nonNull(body) ? body.encodePrettily() : null);
+          if (logger.isInfoEnabled()) {
+            logger.info("The response body for GET {}: {}", endpoint, nonNull(body) ? body.encodePrettily() : null);
           }
           future.complete(body);
         })

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitsHelper.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitsHelper.java
@@ -29,10 +29,10 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import one.util.streamex.StreamEx;
 
 public class AcquisitionsUnitsHelper extends AbstractHelper {
-  static final String ACQUISITIONS_UNIT_IDS = "acqUnitIds";
+  public static final String ACQUISITIONS_UNIT_IDS = "acqUnitIds";
   static final String IS_DELETED_PROP = "isDeleted";
   static final String ACTIVE_UNITS_CQL = IS_DELETED_PROP + "==false";
-  static final String ALL_UNITS_CQL = IS_DELETED_PROP + "==(true or false)";
+  static final String ALL_UNITS_CQL = IS_DELETED_PROP + "=*";
   static final String NO_ACQ_UNIT_ASSIGNED_CQL = "cql.allRecords=1 not " + ACQUISITIONS_UNIT_IDS + " <> []";
   private static final String GET_UNITS_BY_QUERY = resourcesPath(ACQUISITIONS_UNITS) + SEARCH_PARAMS;
   private static final String GET_UNITS_MEMBERSHIPS_BY_QUERY = resourcesPath(ACQUISITIONS_MEMBERSHIPS) + SEARCH_PARAMS;

--- a/src/main/java/org/folio/rest/impl/ProtectionHelper.java
+++ b/src/main/java/org/folio/rest/impl/ProtectionHelper.java
@@ -4,21 +4,25 @@ import static org.folio.orders.utils.ErrorCodes.ORDER_UNITS_NOT_FOUND;
 import static org.folio.orders.utils.ErrorCodes.USER_HAS_NO_PERMISSIONS;
 import static org.folio.orders.utils.HelperUtils.combineCqlExpressions;
 import static org.folio.orders.utils.HelperUtils.convertIdsToCqlQuery;
+import static org.folio.rest.impl.AcquisitionsUnitsHelper.ACQUISITIONS_UNIT_IDS;
 import static org.folio.rest.impl.AcquisitionsUnitsHelper.ALL_UNITS_CQL;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.folio.HttpStatus;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.ProtectedOperationType;
 import org.folio.rest.jaxrs.model.AcquisitionsUnit;
-import org.folio.rest.jaxrs.model.AcquisitionsUnitCollection;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.Context;
@@ -27,6 +31,7 @@ public class ProtectionHelper extends AbstractHelper {
 
   public static final String ACQUISITIONS_UNIT_ID = "acquisitionsUnitId";
   private AcquisitionsUnitsHelper acquisitionsUnitsHelper;
+  private List<AcquisitionsUnit> fetchedUnits = new ArrayList<>();
 
   public ProtectionHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(httpClient, okapiHeaders, ctx, lang);
@@ -45,26 +50,66 @@ public class ProtectionHelper extends AbstractHelper {
 
   /**
    * This method determines status of operation restriction based on unit IDs from {@link CompositePurchaseOrder}.
+   *
    * @param unitIds list of unit IDs.
    *
-   * @throws HttpException if user hasn't permissions or units not found
+   * @return completable future completed exceptionally if user does not have rights to perform operation or any unit does not
+   *         exist; successfully otherwise
    */
   public CompletableFuture<Void> isOperationRestricted(List<String> unitIds, Set<ProtectedOperationType> operations) {
     if (CollectionUtils.isNotEmpty(unitIds)) {
       return getUnitsByIds(unitIds)
         .thenCompose(units -> {
           if (unitIds.size() == units.size()) {
-            if (applyMergingStrategy(units, operations)) {
-              return verifyUserIsMemberOfOrdersUnits(unitIds);
+            // In case any unit is "soft deleted", just skip it (refer to MODORDERS-294)
+            List<AcquisitionsUnit> activeUnits = units.stream()
+              .filter(unit -> !unit.getIsDeleted())
+              .collect(Collectors.toList());
+
+            if (applyMergingStrategy(activeUnits, operations)) {
+              return verifyUserIsMemberOfOrdersUnits(extractUnitIds(activeUnits));
             }
             return CompletableFuture.completedFuture(null);
           } else {
-            throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), ORDER_UNITS_NOT_FOUND);
+            // In case any unit "hard deleted" or never existed by specified uuid
+            throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), buildUnitsNotFoundError(unitIds, extractUnitIds(units)));
           }
         });
     } else {
       return CompletableFuture.completedFuture(null);
     }
+  }
+
+  /**
+   * Verifies if all acquisition units exist and active based on passed ids
+   *
+   * @param acqUnitIds list of unit IDs.
+   * @return completable future completed successfully if all units exist and active or exceptionally otherwise
+   */
+  public CompletableFuture<Void> verifyIfUnitsAreActive(List<String> acqUnitIds) {
+    if (acqUnitIds.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    return getUnitsByIds(acqUnitIds).thenAccept(units -> {
+      List<String> activeUnitIds = units.stream()
+        .filter(unit -> !unit.getIsDeleted())
+        .map(AcquisitionsUnit::getId)
+        .collect(Collectors.toList());
+
+      if (acqUnitIds.size() != activeUnitIds.size()) {
+        throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), buildUnitsNotFoundError(acqUnitIds, activeUnitIds));
+      }
+    });
+  }
+
+  private Error buildUnitsNotFoundError(List<String> expectedUnitIds, List<String> availableUnitIds) {
+    List<String> missingUnitIds = ListUtils.subtract(expectedUnitIds, availableUnitIds);
+    return ORDER_UNITS_NOT_FOUND.toError().withAdditionalProperty(ACQUISITIONS_UNIT_IDS, missingUnitIds);
+  }
+
+  private List<String> extractUnitIds(List<AcquisitionsUnit> activeUnits) {
+    return activeUnits.stream().map(AcquisitionsUnit::getId).collect(Collectors.toList());
   }
 
   /**
@@ -89,9 +134,23 @@ public class ProtectionHelper extends AbstractHelper {
    * @return list of {@link AcquisitionsUnit}
    */
   private CompletableFuture<List<AcquisitionsUnit>> getUnitsByIds(List<String> unitIds) {
+    // Check if all required units are already available
+    List<AcquisitionsUnit> units = fetchedUnits.stream()
+      .filter(unit -> unitIds.contains(unit.getId()))
+      .distinct()
+      .collect(Collectors.toList());
+
+    if (units.size() == unitIds.size()) {
+      return CompletableFuture.completedFuture(units);
+    }
+
     String query = combineCqlExpressions("and", ALL_UNITS_CQL, convertIdsToCqlQuery(unitIds));
     return acquisitionsUnitsHelper.getAcquisitionsUnits(query, 0, Integer.MAX_VALUE)
-      .thenApply(AcquisitionsUnitCollection::getAcquisitionsUnits);
+      .thenApply(acquisitionsUnitCollection -> {
+        List<AcquisitionsUnit> acquisitionsUnits = acquisitionsUnitCollection.getAcquisitionsUnits();
+        fetchedUnits.addAll(acquisitionsUnits);
+        return acquisitionsUnits;
+      });
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -188,8 +188,7 @@ public class ApiTestBase {
 
   protected void clearServiceInteractions() {
     eventMessages.clear();
-    MockServer.serverRqRs.clear();
-    MockServer.serverRqQueries.clear();
+    MockServer.release();
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/impl/protection/OrdersProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/OrdersProtectionTest.java
@@ -4,22 +4,31 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.orders.utils.ErrorCodes.ORDER_UNITS_NOT_FOUND;
 import static org.folio.orders.utils.ErrorCodes.USER_HAS_NO_ACQ_PERMISSIONS;
 import static org.folio.orders.utils.ErrorCodes.USER_HAS_NO_PERMISSIONS;
+import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
 import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
 import static org.folio.orders.utils.ResourcePathResolver.PURCHASE_ORDER;
+import static org.folio.rest.impl.AcquisitionsUnitsHelper.ACQUISITIONS_UNIT_IDS;
 import static org.folio.rest.impl.MockServer.addMockEntry;
 import static org.folio.rest.impl.PurchaseOrdersApiTest.ALL_DESIRED_PERMISSIONS_HEADER;
 import static org.folio.rest.impl.PurchaseOrdersApiTest.COMPOSITE_ORDERS_PATH;
 import static org.folio.rest.impl.protection.ProtectedOperations.UPDATE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.folio.HttpStatus;
+import org.folio.rest.jaxrs.model.AcquisitionsUnit;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -126,6 +135,52 @@ public class OrdersProtectionTest extends ProtectedEntityTestBase {
     assertThat(errors.getErrors().get(0).getCode(), equalTo(USER_HAS_NO_ACQ_PERMISSIONS.getCode()));
 
     validateNumberOfRequests(0, 0);
+  }
+
+  @Test
+  @Parameters({
+    "CREATE",
+    "UPDATE"
+  })
+  public void testAssigningSoftDeletedUnit(ProtectedOperations operation) {
+    logger.info("=== Test order contains \"soft deleted\" unit id - expecting of call only to Units API ===");
+
+    final Headers headers = prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID);
+
+    // Acq to order in storage for update case and
+    AcquisitionsUnit unit1 = prepareTestUnit(false);
+    AcquisitionsUnit unit2 = prepareTestUnit(true);
+    AcquisitionsUnit unit3 = prepareTestUnit(true);
+    // Add all acq units as mock data
+    addMockEntry(ACQUISITIONS_UNITS, unit1);
+    addMockEntry(ACQUISITIONS_UNITS, unit2);
+    addMockEntry(ACQUISITIONS_UNITS, unit3);
+
+    // Prepare order with 2 acq units (one is "soft deleted") and add it as mock data for update case
+    CompositePurchaseOrder order = prepareOrder(Arrays.asList(unit1.getId(), unit2.getId()));
+
+    // Add the third unit to request
+    order.getAcqUnitIds().add(unit3.getId());
+
+    Errors errors = operation
+      .process(COMPOSITE_ORDERS_PATH, encodePrettily(order), headers, APPLICATION_JSON,
+          HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt())
+      .as(Errors.class);
+
+    assertThat(errors.getErrors(), hasSize(1));
+    Error error = errors.getErrors().get(0);
+    assertThat(error.getCode(), equalTo(ORDER_UNITS_NOT_FOUND.getCode()));
+    assertThat(error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS), instanceOf(List.class));
+
+    // Verify number of sub-requests
+    validateNumberOfRequests(1, 0);
+
+    List<String> ids = (List<String>) error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS);
+    if (operation == UPDATE) {
+      assertThat(ids, contains(unit3.getId()));
+    } else {
+      assertThat(ids, containsInAnyOrder(unit2.getId(), unit3.getId()));
+    }
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/protection/ProtectedEntityTestBase.java
+++ b/src/test/java/org/folio/rest/impl/protection/ProtectedEntityTestBase.java
@@ -8,13 +8,15 @@ import static org.folio.rest.impl.MockServer.addMockEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.folio.rest.impl.ApiTestBase;
 import org.folio.rest.impl.MockServer;
+import org.folio.rest.jaxrs.model.AcquisitionsUnit;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Piece;
@@ -53,7 +55,7 @@ public abstract class ProtectedEntityTestBase extends ApiTestBase {
 
   public CompositePurchaseOrder prepareOrder(List<String> acqUnitsIds) {
     CompositePurchaseOrder po = getMinimalContentCompositePurchaseOrder();
-    po.setAcqUnitIds(acqUnitsIds);
+    po.setAcqUnitIds(new ArrayList<>(acqUnitsIds));
     addMockEntry(PURCHASE_ORDER, JsonObject.mapFrom(po));
     return po;
   }
@@ -70,5 +72,10 @@ public abstract class ProtectedEntityTestBase extends ApiTestBase {
     Piece piece = getMinimalContentPiece(poLine.getId());
     addMockEntry(PIECES, JsonObject.mapFrom(piece));
     return piece;
+  }
+
+  public AcquisitionsUnit prepareTestUnit(boolean isDeleted) {
+    String id = getRandomId();
+    return new AcquisitionsUnit().withId(id).withName(id).withIsDeleted(isDeleted);
   }
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-294](https://issues.folio.org/browse/MODORDERS-294) Disallow "isDeleted" acq units to be assigned to orders

## Approach
- On order creation: in case any acq units assigned, check first if all exist and have `isDeleted==false`
- On order update: in case any acq units assigned, check that all newly assigned acq units (comparing to what is in storage) exist and have `isDeleted==false`.

In both cases above on failure, the flow is terminated and an error is returned to client like following
```json
{
  "message": "Acquisitions units assigned to order cannot be found",
  "code": "orderAcqUnitsNotFound",
  "acqUnitIds": [
    "a968d9fe-1230-4c44-8e59-87cd462a06e4",
    "eab71dbd-b14b-4cfb-9b1e-d6f450b5b00f"
  ]
}
```

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.