### PR TITLE
MODORDERS-294 Disallow "isDeleted" acq units to be assigned to orders

### DIFF
--- a/src/main/java/org/folio/rest/impl/ProtectionHelper.java
+++ b/src/main/java/org/folio/rest/impl/ProtectionHelper.java
@@ -66,7 +66,7 @@ public class ProtectionHelper extends AbstractHelper {
               .filter(unit -> !unit.getIsDeleted())
               .collect(Collectors.toList());
 
-            if (applyMergingStrategy(activeUnits, operations)) {
+            if (!activeUnits.isEmpty() && applyMergingStrategy(activeUnits, operations)) {
               return verifyUserIsMemberOfOrdersUnits(extractUnitIds(activeUnits));
             }
             return CompletableFuture.completedFuture(null);

--- a/src/test/java/org/folio/rest/impl/protection/OrdersProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/OrdersProtectionTest.java
@@ -197,7 +197,7 @@ public class OrdersProtectionTest extends ProtectedEntityTestBase {
     // Add all acq units as mock data
     addMockEntry(ACQUISITIONS_UNITS, unit1);
 
-    // Prepare order with 2 acq units (one is "soft deleted") and add it as mock data for update case
+    // Prepare order with one acq unit ("soft deleted")
     CompositePurchaseOrder order = prepareOrder(Collections.singletonList(unit1.getId()));
 
     ProtectedOperations.READ.process(COMPOSITE_ORDERS_PATH, encodePrettily(order), headers, APPLICATION_JSON,


### PR DESCRIPTION
## Purpose
[MODORDERS-294](https://issues.folio.org/browse/MODORDERS-294) Disallow "isDeleted" acq units to be assigned to orders

## Approach
Handle case when only one unit assigned to order and it has `isDeleted==true` - no need to check user memberships

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.