### PR TITLE
MODORDERS-300 - Release 7.1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 ## 8.0.0 - Unreleased
 
+## 7.1.0 - Released
+The primary focus of this release was to implement Teams-based operations restriction logic and business logic improvements.
+
+[Full Changelog](https://github.com/folio-org/mod-orders/compare/v7.0.1...v7.1.0)
+
+### Stories
+ * [MODORDERS-298](https://issues.folio.org/browse/MODORDERS-298) - Temporarily disable interaction with encumbrance APIs
+ * [MODORDERS-294](https://issues.folio.org/browse/MODORDERS-294) - Disallow "isDeleted" acq units to be assigned to orders
+ * [MODORDERS-293](https://issues.folio.org/browse/MODORDERS-293) - Acquisition units - soft delete
+ * [MODORDERS-291](https://issues.folio.org/browse/MODORDERS-291) - Add approvedBy and approvalDate fields to purchase_order/composite_purchase_order
+ * [MODORDERS-290](https://issues.folio.org/browse/MODORDERS-290) - Enforce new setting: approval required to open orders
+ * [MODORDERS-286](https://issues.folio.org/browse/MODORDERS-286) - Restrict receive/checkin based on acquisitions units
+ * [MODORDERS-285](https://issues.folio.org/browse/MODORDERS-285) - Restrict receive/checkin records based upon acquisitions unit	
+ * [MODORDERS-283](https://issues.folio.org/browse/MODORDERS-283) - Validate/Normalize ISBNs upon order creation/update
+ * [MODORDERS-280](https://issues.folio.org/browse/MODORDERS-280) - Orders App: Ability to assign tags to a Purchase Order (PO) and Purchase Order Line (POL)
+ * [MODORDERS-256](https://issues.folio.org/browse/MODORDERS-256) - Restrict search/view of PO, POL, Piece records based upon acquisitions unit
+ * [MODORDERS-255](https://issues.folio.org/browse/MODORDERS-255) - Restrict deletion of PO, POL, Piece records based upon acquisitions unit
+ * [MODORDERS-254](https://issues.folio.org/browse/MODORDERS-254) - Restrict updates of PO, POL, Piece records based upon acquisitions unit
+ * [MODORDERS-251](https://issues.folio.org/browse/MODORDERS-251) - RRestrict creation of PO, POL, Piece records based upon acquisitions unit
+
 ## 7.0.1 - Released
 This release includes bug fix for issue related to order's closing.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "orders",
-      "version": "7.0",
+      "version": "7.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -439,7 +439,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "3.0"
+      "version": "3.1"
     },
     {
       "id": "orders-storage.po-number",
@@ -447,7 +447,7 @@
     },
     {
       "id": "inventory",
-      "version": "8.3 9.0"
+      "version": "8.3 9.4"
     },
     {
       "id": "instance-types",
@@ -459,7 +459,7 @@
     },
     {
       "id": "item-storage",
-      "version": "7.3"
+      "version": "7.5"
     },
     {
       "id": "identifier-types",
@@ -475,7 +475,7 @@
     },
     {
       "id":"organizations-storage.organizations",
-      "version": "2.0"
+      "version": "2.1"
     }
   ],
   "permissionSets": [

--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,20 @@
                   <resource>javamoney.properties</resource>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>org.folio:raml-module-builder</artifact>
+                  <excludes>
+                    <exclude>**/log4j2.properties</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/log4j.properties</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,15 @@
+status = info
+dest = err
+name = PropertiesConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%-25t] %c{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.netty.name = io.netty
+logger.netty.level = info
+logger.netty.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
MODORDERS-300 - Release 7.1.0

Only minor version increased because of non-backward compatible changes absence. No versions changes for mod-orders-storage interfaces. Inventory interface versions were refreshed.