### PR TITLE
MODORDERS-304 - Fix CreateInventory with ReceiptNotRequired

### DIFF
--- a/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderLineHelper.java
@@ -439,12 +439,13 @@ class PurchaseOrderLineHelper extends AbstractHelper {
    * @return CompletableFuture with void.
    */
   CompletableFuture<Void> updateInventory(CompositePoLine compPOL) {
-    // create pieces only, in case of no inventory updates and receiving is required
-    if (inventoryUpdateNotRequired(compPOL) && !isReceiptNotRequired(compPOL.getReceiptStatus())) {
-      return createPieces(compPOL, Collections.emptyList())
-        .thenRun(() ->
-          logger.info("Create pieces for PO Line with '{}' id where inventory updates are not required", compPOL.getId())
-        );
+    if (inventoryUpdateNotRequired(compPOL)) {
+      // don't create pieces, if no inventory updates and receiving not required
+      if (isReceiptNotRequired(compPOL.getReceiptStatus())) {
+        return completedFuture(null);
+      }
+      return createPieces(compPOL, Collections.emptyList()).thenRun(
+          () -> logger.info("Create pieces for PO Line with '{}' id where inventory updates are not required", compPOL.getId()));
     }
 
     return inventoryHelper.handleInstanceRecord(compPOL)

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -2477,7 +2477,6 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
   public void testPostOrdersInventoryInteractionWithReceiptNotRequired() throws Exception {
     logger.info("=== Test POST electronic PO, to create Instance and Holding even if receipt not required==");
 
-
     JsonObject order = new JsonObject(getMockData(ELECTRONIC_FOR_CREATE_INVENTORY_TEST));
     CompositePurchaseOrder reqData = order.mapTo(CompositePurchaseOrder.class);
     // Make sure that Order is Open
@@ -2492,6 +2491,31 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     assertNotNull(getCreatedInstances());
     assertNotNull(getCreatedHoldings());
+    assertNull(getItemsSearches());
+    assertNull(getCreatedPieces());
+  }
+
+  @Test
+  public void testPostOrdersNoInventoryInteractionWithReceiptNotRequired() throws Exception {
+    logger.info("=== Test POST PO, to have no inventory Interaction, with CreateInventory None and receipt not required==");
+
+    JsonObject order = new JsonObject(getMockData(MONOGRAPH_FOR_CREATE_INVENTORY_TEST));
+    // Get Open Order
+    CompositePurchaseOrder reqData = order.mapTo(CompositePurchaseOrder.class);
+    // Make sure that Order moves to Open
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+
+    // Set CreateInventory value to create nothing in inventory
+    reqData.getCompositePoLines().get(0).getPhysical().setCreateInventory(Physical.CreateInventory.NONE);
+    reqData.getCompositePoLines().get(0).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
+    reqData.getCompositePoLines().get(0).setReceiptStatus(ReceiptStatus.RECEIPT_NOT_REQUIRED);
+
+    verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+
+    // No inventory interation necessary with "Receipt Not Required" and CreateInventory "None"
+    assertNull(getInstancesSearches());
+    assertNull(getHoldingsSearches());
     assertNull(getItemsSearches());
     assertNull(getCreatedPieces());
   }


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDERS-304

## Purpose
A case were CreateInventory was set to None and ReceiptStatus set to ReceiptNotRequired, was not handled earlier

## Approach
-  Add unit test to handle the case

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
