### PR TITLE
MODORDERS-302 - Create order-templates API (url typo fixing)

### DIFF
--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -45,7 +45,7 @@ public class ResourcePathResolver {
     apis.put(PO_LINE_NUMBER, "/orders-storage/po-line-number");
     apis.put(SEARCH_ORDERS, "/orders-storage/orders");
     apis.put(ORDER_LINES, "/orders-storage/order-lines");
-    apis.put(ORDER_TEMPLATES, "/order-storage/order-templates");
+    apis.put(ORDER_TEMPLATES, "/orders-storage/order-templates");
 
     SUB_OBJECT_COLLECTION_APIS = Collections.unmodifiableMap(apis);
     SUB_OBJECT_ITEM_APIS = Collections.unmodifiableMap(


### PR DESCRIPTION
In addition to PR [#217](https://github.com/folio-org/mod-orders/pull/217) fixing of typo in endpoint /orders-storage/order-templates.