### PR TITLE
MODORDERS-310 Use the new version of the schema with qualifier field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>27.0.0</raml-module-builder.version>
+    <raml-module-builder.version>27.1.1</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.5.4</version>
+      <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/rest/impl/AbstractHelper.java
+++ b/src/main/java/org/folio/rest/impl/AbstractHelper.java
@@ -15,7 +15,6 @@ import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 import io.vertx.core.Context;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -27,6 +26,7 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -126,9 +126,8 @@ public abstract class AbstractHelper {
    * Some requests do not have body and in happy flow do not produce response body. The Accept header is required for calls to storage
    */
   private static void setDefaultHeaders(HttpClientInterface httpClient) {
-    Map<String, String> customHeader = new HashMap<>();
-    customHeader.put(HttpHeaders.ACCEPT.toString(), APPLICATION_JSON + ", " + TEXT_PLAIN);
-    httpClient.setDefaultHeaders(customHeader);
+    // The RMB's HttpModuleClient2.ACCEPT is in sentence case. Using the same format to avoid duplicates (issues migrating to RMB 27.1.1)
+    httpClient.setDefaultHeaders(Collections.singletonMap("Accept", APPLICATION_JSON + ", " + TEXT_PLAIN));
   }
 
   protected Errors getProcessingErrors() {


### PR DESCRIPTION
## Purpose
[MODORDERS-310](https://issues.folio.org/browse/MODORDERS-310) Use the new version of the schema with qualifier field

## Approach
Updating the acq-models

#### TODOS and Open Questions
- [ ] Merge together with https://github.com/folio-org/mod-orders-storage/pull/156

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
