### PR TITLE
MODORDERS-339 FOLIO-2358 manage container memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/openjdk8-jre-alpine:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE mod-orders-fat.jar
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -788,7 +788,7 @@
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        "value": "-XX:MaxRAMPercentage=66.0"
       }
     ]
   }


### PR DESCRIPTION
Use new Alpine base docker image with more recent Java 8 (222) with +UseContainerSupport, and JAVA_OPTIONS MaxRAMPercentage to manage container memory.

See notes at [FOLIO-2358](https://issues.folio.org/browse/FOLIO-2358).

Not expecting an actual "review", but this requires an approval so that i can merge and proceed with the remaining steps.

