### PR TITLE
MODORDERS-315: Default to In process for item status during receiving/checkin

### DIFF
--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -67,6 +67,7 @@ public class InventoryHelper extends AbstractHelper {
   static final String ITEM_LEVEL_CALL_NUMBER = "itemLevelCallNumber";
   static final String ITEM_STATUS = "status";
   static final String ITEM_STATUS_NAME = "name";
+  static final String ITEM_STATUS_IN_PROCESS = "In process";
   static final String ITEM_STATUS_ON_ORDER = "On order";
   static final String ITEM_MATERIAL_TYPE_ID = "materialTypeId";
   static final String ITEM_PERMANENT_LOAN_TYPE_ID = "permanentLoanTypeId";
@@ -186,7 +187,11 @@ public class InventoryHelper extends AbstractHelper {
     String endpoint = String.format(UPDATE_ITEM_ENDPOINT, itemRecord.getString(ID), lang);
 
     // Update item record with receiving details
-    itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, receivedItem.getItemStatus()));
+    if (StringUtils.isEmpty(receivedItem.getItemStatus())) {
+      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ITEM_STATUS_IN_PROCESS));
+    } else {
+      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, receivedItem.getItemStatus()));
+    }
     if (StringUtils.isNotEmpty(receivedItem.getBarcode())) {
       itemRecord.put(ITEM_BARCODE, receivedItem.getBarcode());
     }
@@ -200,7 +205,11 @@ public class InventoryHelper extends AbstractHelper {
     String endpoint = String.format(UPDATE_ITEM_ENDPOINT, itemRecord.getString(ID), lang);
 
     // Update item record with checkIn details
-    itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, checkinPiece.getItemStatus()));
+    if (StringUtils.isEmpty(checkinPiece.getItemStatus())) {
+      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ITEM_STATUS_IN_PROCESS));
+    } else {
+      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, checkinPiece.getItemStatus()));
+    }
     if (StringUtils.isNotEmpty(checkinPiece.getBarcode())) {
       itemRecord.put(ITEM_BARCODE, checkinPiece.getBarcode());
     }

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -187,11 +187,7 @@ public class InventoryHelper extends AbstractHelper {
     String endpoint = String.format(UPDATE_ITEM_ENDPOINT, itemRecord.getString(ID), lang);
 
     // Update item record with receiving details
-    if (StringUtils.isEmpty(receivedItem.getItemStatus())) {
-      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ITEM_STATUS_IN_PROCESS));
-    } else {
-      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, receivedItem.getItemStatus()));
-    }
+    itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, receivedItem.getItemStatus()));
     if (StringUtils.isNotEmpty(receivedItem.getBarcode())) {
       itemRecord.put(ITEM_BARCODE, receivedItem.getBarcode());
     }
@@ -205,11 +201,7 @@ public class InventoryHelper extends AbstractHelper {
     String endpoint = String.format(UPDATE_ITEM_ENDPOINT, itemRecord.getString(ID), lang);
 
     // Update item record with checkIn details
-    if (StringUtils.isEmpty(checkinPiece.getItemStatus())) {
-      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ITEM_STATUS_IN_PROCESS));
-    } else {
-      itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, checkinPiece.getItemStatus()));
-    }
+    itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, checkinPiece.getItemStatus()));
     if (StringUtils.isNotEmpty(checkinPiece.getBarcode())) {
       itemRecord.put(ITEM_BARCODE, checkinPiece.getBarcode());
     }

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -12,6 +12,7 @@ import static org.folio.orders.utils.ErrorCodes.PIECE_POL_MISMATCH;
 import static org.folio.orders.utils.ErrorCodes.PIECE_UPDATE_FAILED;
 import static org.folio.rest.impl.InventoryHelper.ITEM_BARCODE;
 import static org.folio.rest.impl.InventoryHelper.ITEM_STATUS;
+import static org.folio.rest.impl.InventoryHelper.ITEM_STATUS_IN_PROCESS;
 import static org.folio.rest.impl.InventoryHelper.ITEM_LEVEL_CALL_NUMBER;
 import static org.folio.rest.impl.InventoryHelper.ITEM_STATUS_NAME;
 import static org.folio.rest.impl.InventoryHelper.ITEM_STATUS_ON_ORDER;
@@ -168,6 +169,11 @@ public class CheckinReceivingApiTest extends ApiTestBase {
     assertThat(polSearches, hasSize(1));
     assertThat(polUpdates, hasSize(1));
 
+    itemUpdates.forEach(item -> {
+      assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
+      assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo(ITEM_STATUS_IN_PROCESS));
+    });
+    
     polUpdates.forEach(pol -> {
       PoLine poLine = pol.mapTo(PoLine.class);
       assertThat(poLine.getCheckinItems(), is(true));
@@ -242,7 +248,7 @@ public class CheckinReceivingApiTest extends ApiTestBase {
     toBeCheckedInList.add(new ToBeCheckedIn()
       .withCheckedIn(1)
       .withPoLineId(poLineId)
-      .withCheckInPieces(Arrays.asList(new CheckInPiece().withItemStatus("In process"), new CheckInPiece().withItemStatus("In process"))));
+      .withCheckInPieces(Arrays.asList(new CheckInPiece().withItemStatus(ITEM_STATUS_IN_PROCESS), new CheckInPiece().withItemStatus(ITEM_STATUS_IN_PROCESS))));
 
     CheckinCollection request = new CheckinCollection()
       .withToBeCheckedIn(toBeCheckedInList)
@@ -423,9 +429,16 @@ public class CheckinReceivingApiTest extends ApiTestBase {
       PIECE_POL_MISMATCH.getCode(), PIECE_NOT_FOUND.getCode(), ITEM_UPDATE_FAILED.getCode(), ITEM_NOT_FOUND.getCode(),
       PIECE_UPDATE_FAILED.getCode()));
 
+    List<JsonObject> itemUpdates = getItemUpdates();
     List<JsonObject> polUpdates = getPoLineUpdates();
     assertThat(getPoLineSearches(), hasSize(1));
     assertThat(polUpdates, hasSize(1));
+    assertThat(itemUpdates, hasSize(6));
+
+    itemUpdates.forEach(item -> {
+      assertThat(item.getJsonObject(ITEM_STATUS), notNullValue());
+      assertThat(item.getJsonObject(ITEM_STATUS).getString(ITEM_STATUS_NAME), equalTo(ITEM_STATUS_IN_PROCESS));
+    });
 
     polUpdates.forEach(pol -> {
       PoLine poLine = pol.mapTo(PoLine.class);

--- a/src/test/resources/mockdata/checkIn/checkin-pe-mix-2-physical-resources.json
+++ b/src/test/resources/mockdata/checkIn/checkin-pe-mix-2-physical-resources.json
@@ -18,8 +18,7 @@
           "productIdType": "bae22dfa-5ea8-43aa-b61d-8da89ba339c4",
           "accessionNumber": "1956.1",
           "itemDescription": "This is the piece with item",
-          "electronicBookplate": "This book is from the Harvard University library",
-          "itemStatus": "Received"
+          "electronicBookplate": "This book is from the Harvard University library"
         },
         {
           "id": "280d63bc-db44-49ba-b7fe-1f230a2eed19",
@@ -35,8 +34,7 @@
           "productIdType": "31dcaba7-bce1-4a12-bd06-9ce901422285",
           "accessionNumber": "2002.4",
           "itemDescription": "This is the piece with item",
-          "electronicBookplate": "This book is from the Florida University library",
-          "itemStatus":"Received"
+          "electronicBookplate": "This book is from the Florida University library"
         }
       ]
     }

--- a/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
+++ b/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
@@ -8,7 +8,6 @@
           "barcode": 11111111112,
           "comment": "Expected error pieceAlreadyReceived",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "8c057872-9c75-4fb1-879d-de3b089b0388"
         },
@@ -16,7 +15,6 @@
           "barcode": 11111111113,
           "comment": "Expected error itemNotFound",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "6f495150-9a7c-4104-84fa-16f3ec9ab005"
         },
@@ -24,7 +22,6 @@
           "barcode": 11111111114,
           "comment": "Very important note",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "2884f2cd-ccab-47e1-a021-9b22a05230d9"
         },
@@ -32,7 +29,6 @@
           "barcode": 11111111115,
           "comment": "Expected error piecePolMismatch",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "2f6056bd-e7f1-4e51-add2-b0c803066c74"
         },
@@ -40,7 +36,6 @@
           "barcode": 11111111116,
           "comment": "Expected error pieceNotFound",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "99e04f91-6985-48df-997d-289773fd8c44"
         },
@@ -48,7 +43,6 @@
           "barcode": 11111111117,
           "comment": "500500500500 Expected error pieceUpdateFailed",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "168f8a86-d26c-406e-813f-c7527f241ac3",
           "pieceId": "de647d4a-cc53-440d-be2b-da12559ba51c"
         },
@@ -56,7 +50,6 @@
           "barcode": 11111111118,
           "comment": "Very important note",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "f7272eb2-499f-4c29-985e-7ffc468d2360"
         },
@@ -64,7 +57,6 @@
           "barcode": 11111111119,
           "comment": "Very important note",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "70502e16-f07a-4156-a6b9-492862f1f8f3"
         },
@@ -72,7 +64,6 @@
           "barcode": 11111111120,
           "comment": "Very important note",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "5e8e29c4-801d-4e5b-a07c-3a975861db1c"
         },
@@ -80,7 +71,6 @@
           "barcode": 500500500500,
           "comment": "Expected error itemUpdateFailed",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
           "pieceId": "5062d4d7-2164-4cc0-bbb1-aa755324b95c"
         }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/MODORDERS-315

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Update checkinItem and recieveItem logic in inventoryHelper to set itemStatus as `"In process"` if it is empty
- Update and add unit tests
- Update test resource
- PR for schema changes - https://github.com/folio-org/acq-models/pull/211

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed? No
  - [ ] Were there any schema changes? Yes
  - [ ] Did any of the interface versions change? No
  - [ ] Were permissions changed, added, or removed? No
  - [ ] Are there new interface dependencies? No
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
