### PR TITLE
MODORDERS-341 Set item status to "Order closed"

### DIFF
--- a/src/main/java/org/folio/orders/events/handlers/OrderStatus.java
+++ b/src/main/java/org/folio/orders/events/handlers/OrderStatus.java
@@ -91,7 +91,7 @@ public class OrderStatus extends AbstractHelper implements Handler<Message<JsonO
     PurchaseOrderHelper helper = new PurchaseOrderHelper(httpClient, okapiHeaders, ctx, lang);
     return VertxCompletableFuture.supplyBlockingAsync(ctx, () -> changeOrderStatus(purchaseOrder, poLines))
       .thenCompose(isStatusChanged -> {
-        if (isStatusChanged) {
+        if (Boolean.TRUE.equals(isStatusChanged)) {
           return helper.handleFinalOrderStatus(purchaseOrder, poLines, initialStatus.value())
             .thenCompose(aVoid -> helper.updateOrderSummary(purchaseOrder));
         }


### PR DESCRIPTION
## Purpose
[Comment on MODORDERS-341](https://issues.folio.org/browse/MODORDERS-341?focusedCommentId=72597&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-72597)

**Updated description:**

PUT /orders/composite-orders (without compositePoLines)
- you should be able to update workflow status (this is what the UI currently does)

PUT /orders/composite-orders (with compositePoLines)

- the eventbus asynch processing will kick in and set the workflowStatus based on paymentStatus/receiptStatus
- We probably want to avoid triggering the asynch processing if workflowStatus is changed. See MODORDERS-369

_Whenever workflowStatus changes (Open/Closed), item statuses should be adjusted_

## Approach
- if PUT /orders/composite-orders (without compositePoLines) then do not adjust order.workflowStatus. Update status of items related to PO Lines stored in db
- if PUT /orders/composite-orders (with compositePoLines) - order.workflowStatus is changed automatically based on provided PO Lines.  Update status of items related to provided in request PO Lines.


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
