### PR TITLE
MODORDERS-360 Create holding when receiving a piece and location is changed

### DIFF
--- a/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
@@ -266,8 +266,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
       isHoldingUpdateRequired = isHoldingUpdateRequiredForPhysical(poLine.getPhysical());
     }
     return isHoldingUpdateRequired
-      && StringUtils.isNotEmpty(locationId)
-      && !StringUtils.equals(locationId, piece.getLocationId());
+      && StringUtils.isNotEmpty(locationId);
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -394,8 +394,15 @@ public class CheckinReceivingApiTest extends ApiTestBase {
     poLine.setEresource(new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE)); // holding mustn't be created
     poLine.setPhysical(new Physical().withCreateInventory(Physical.CreateInventory.INSTANCE_HOLDING)); // holding must be created
 
-    Piece physicalPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED).withFormat(org.folio.rest.jaxrs.model.Piece.Format.PHYSICAL);
-    Piece electronicPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED).withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
+
+    String locationForPhysical = UUID.randomUUID().toString();
+    String locationForElectronic = UUID.randomUUID().toString();
+
+    Piece physicalPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.PHYSICAL)
+      .withLocationId(locationForPhysical);
+    Piece electronicPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
 
     addMockEntry(PURCHASE_ORDER, order.withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN));
     addMockEntry(PO_LINES, poLine);
@@ -413,9 +420,6 @@ public class CheckinReceivingApiTest extends ApiTestBase {
     CheckinCollection request = new CheckinCollection()
       .withToBeCheckedIn(toBeCheckedInList)
       .withTotalRecords(2);
-
-    String locationForPhysical = UUID.randomUUID().toString();
-    String locationForElectronic = UUID.randomUUID().toString();
 
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setId(physicalPiece.getId());
     request.getToBeCheckedIn().get(0).getCheckInPieces().get(0).setLocationId(locationForPhysical);


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDERS-360?focusedCommentId=73359&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-73359

## Approach
- create holding even if new piece.locationId was updated before receiving

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
