### PR TITLE
[MODORDERS-376] Make field "Piece.receiptDate" optional

### DIFF
--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -56,7 +56,6 @@ public enum ErrorCodes {
   ISBN_NOT_VALID("invalidISBN", "ISBN value is invalid"),
   FUNDS_NOT_FOUND("fundsNotFound", "The fund records are not found"),
   CURRENT_FISCAL_YEAR_NOT_FOUND("currentFYearNotFound", "Current fiscal year not found for ledger"),
-  MISSING_RECEIPT_DATE("missingReceiptDate", "receiptDate cannot be null"),
   TITLE_NOT_FOUND("titleNotFound", "Associated title not found for non package PO Line"),
   MULTIPLE_NONPACKAGE_TITLES("multipleNonPackageTitles", "Non package PO Line must contain only one title."),
   BUDGET_NOT_FOUND_FOR_TRANSACTION("budgetNotFoundForTransaction", "Budget not found for transaction"),

--- a/src/main/java/org/folio/rest/impl/PiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/PiecesHelper.java
@@ -1,6 +1,5 @@
 package org.folio.rest.impl;
 
-import static org.folio.orders.utils.ErrorCodes.MISSING_RECEIPT_DATE;
 import static org.folio.orders.utils.HelperUtils.URL_WITH_LANG_PARAM;
 import static org.folio.orders.utils.HelperUtils.getPoLineById;
 import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
@@ -13,11 +12,9 @@ import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.orders.events.handlers.MessageAddress;
-import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.orders.utils.ProtectedOperationType;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Piece;
@@ -40,16 +37,10 @@ public class PiecesHelper extends AbstractHelper {
   }
 
   CompletableFuture<Piece> createPiece(Piece piece) {
-    CompletableFuture<Piece> future = new CompletableFuture<>();
-    if (Objects.isNull(piece.getReceiptDate())) {
-      future.completeExceptionally(new HttpException(422, MISSING_RECEIPT_DATE));
-      return future;
-    } else {
-      future = getOrderByPoLineId(piece.getPoLineId())
+      return getOrderByPoLineId(piece.getPoLineId())
         .thenCompose(order -> protectionHelper.isOperationRestricted(order.getAcqUnitIds(), ProtectedOperationType.CREATE))
-        .thenCompose(v -> createRecordInStorage(JsonObject.mapFrom(piece), resourcesPath(PIECES)).thenApply(piece::withId));
-    }
-    return future;
+        .thenCompose(v -> createRecordInStorage(JsonObject.mapFrom(piece), resourcesPath(PIECES))
+        .thenApply(piece::withId));
   }
 
   // Flow to update piece

--- a/src/test/java/org/folio/rest/impl/PieceApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PieceApiTest.java
@@ -2,17 +2,14 @@ package org.folio.rest.impl;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static org.folio.orders.utils.ErrorCodes.MISSING_RECEIPT_DATE;
 import static org.folio.rest.impl.MockServer.PIECE_RECORDS_MOCK_DATA_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 
 import org.folio.HttpStatus;
 import org.folio.rest.acq.model.Piece;
-import org.folio.rest.jaxrs.model.Errors;
 import org.junit.Test;
 
 import io.restassured.http.Header;
@@ -61,7 +58,7 @@ public class PieceApiTest extends ApiTestBase {
   }
 
   @Test
-  public void testPostPieceWithoutReceiptDate() {
+  public void testPostShouldSuccessfullyCreatePieceWithoutReceiptDate() {
     logger.info("=== Test POST Piece (Create Piece) without receiptDate===");
 
     Piece postPieceRq = pieceJsonReqData.mapTo(Piece.class);
@@ -69,12 +66,10 @@ public class PieceApiTest extends ApiTestBase {
     postPieceRq.setPoLineId("0009662b-8b80-4001-b704-ca10971f175d");
     postPieceRq.setReceiptDate(null);
 
-    Errors errors = verifyPostResponse(PIECES_ENDPOINT, JsonObject.mapFrom(postPieceRq).encode(),
-      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 422).as(Errors.class);
+    Piece piece = verifyPostResponse(PIECES_ENDPOINT, JsonObject.mapFrom(postPieceRq).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 201).as(Piece.class);
 
-    assertThat(errors.getErrors(), hasSize(1));
-    assertThat(errors.getErrors().get(0).getCode(), is(MISSING_RECEIPT_DATE.getCode()));
-
+    assertNull(piece.getReceiptDate());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDERS-376
* Make field "Piece.receiptDate" optional

## Approach
* delete validation business logic of "Piece.receiptDate"

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
