### PR TITLE
[MODORDERS-384] Item status not set to order closed

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -303,7 +303,7 @@
     },
     {
       "id": "pieces",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": ["POST"],
@@ -314,6 +314,7 @@
             "orders-storage.po-lines.item.get",
             "orders-storage.purchase-orders.item.get",
             "inventory.items.item.put",
+            "inventory.items.collection.get",
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get"
           ]

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -22,6 +22,7 @@ import static org.folio.orders.utils.HelperUtils.isItemsUpdateRequired;
 import static org.folio.orders.utils.HelperUtils.isProductIdsExist;
 import static org.folio.rest.acq.model.Piece.Format.ELECTRONIC;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -759,6 +760,20 @@ public class InventoryHelper extends AbstractHelper {
         logger.error("Can't convert {} to isbn13", isbn);
         List<Parameter> parameters = Collections.singletonList(new Parameter().withKey("isbn").withValue(isbn));
         throw new HttpException(400, ISBN_NOT_VALID.toError().withParameters(parameters));
+      });
+  }
+
+  public CompletableFuture<Void> updateItemWithPoLineId(String itemId, String poLineId) {
+    if (itemId == null || poLineId == null) return CompletableFuture.completedFuture(null);
+
+    return getItemRecordsByIds(ImmutableList.of(itemId))
+      .thenCompose(items -> {
+        if (items.isEmpty()) {
+          logger.error("Can't find any item with {} to update purchaseOrderLineIdentifier", itemId);
+          return CompletableFuture.completedFuture(null);
+        } else {
+          return updateItem(items.get(0).put(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER, poLineId));
+        }
       });
   }
 }

--- a/src/main/java/org/folio/rest/impl/PiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/PiecesHelper.java
@@ -28,17 +28,20 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 public class PiecesHelper extends AbstractHelper {
 
   private ProtectionHelper protectionHelper;
+  private InventoryHelper inventoryHelper;
 
   private static final String DELETE_PIECE_BY_ID = resourceByIdPath(PIECES, "%s") + "?lang=%s";
 
   public PiecesHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(okapiHeaders, ctx, lang);
     protectionHelper = new ProtectionHelper(httpClient, okapiHeaders, ctx, lang);
+    inventoryHelper = new InventoryHelper(httpClient, okapiHeaders, ctx, lang);
   }
 
   CompletableFuture<Piece> createPiece(Piece piece) {
       return getOrderByPoLineId(piece.getPoLineId())
         .thenCompose(order -> protectionHelper.isOperationRestricted(order.getAcqUnitIds(), ProtectedOperationType.CREATE))
+        .thenCompose(v -> inventoryHelper.updateItemWithPoLineId(piece.getItemId(), piece.getPoLineId()))
         .thenCompose(v -> createRecordInStorage(JsonObject.mapFrom(piece), resourcesPath(PIECES))
         .thenApply(piece::withId));
   }


### PR DESCRIPTION
## Purpose
[MODORDERS-384](https://issues.folio.org/browse/MODORDERS-384)
- Fix issue related with missing poLineId from item during closing the order
## Approach
- Update poLineId from item during piece creation
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
