### PR TITLE
MODORDERS-383 Can not receive piece when item has been deleted

### DIFF
--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -20,7 +20,6 @@ public enum ErrorCodes {
   PIECE_UPDATE_FAILED("pieceUpdateFailed", "The piece record failed to be updated"),
   ITEM_CREATION_FAILED("itemCreationFailed", "The item record failed to be created"),
   ITEM_UPDATE_FAILED("itemUpdateFailed", "The item record failed to be updated"),
-  ITEM_NOT_FOUND("itemNotFound", "The item record is not found"),
   ITEM_NOT_RETRIEVED("itemNotRetrieved", "The item record is not retrieved"),
   ZERO_COST_PHYSICAL_QTY("zeroCostQtyPhysical", "Physical cost quantity must be specified"),
   ZERO_COST_ELECTRONIC_QTY("zeroCostQtyElectronic", "Electronic cost quantity must be specified"),

--- a/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/CheckinReceivePiecesHelper.java
@@ -4,7 +4,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.groupingBy;
 import static me.escoffier.vertx.completablefuture.VertxCompletableFuture.allOf;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.folio.orders.utils.ErrorCodes.ITEM_NOT_FOUND;
 import static org.folio.orders.utils.ErrorCodes.ITEM_NOT_RETRIEVED;
 import static org.folio.orders.utils.ErrorCodes.ITEM_UPDATE_FAILED;
 import static org.folio.orders.utils.ErrorCodes.LOC_NOT_PROVIDED;
@@ -316,7 +315,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
 
   /**
    * Checks if all expected piece records found in the storage. If any is
-   * missing, adds corresponding error
+   * missing, remove from piece reference to item and exclude piece from {@param piecesWithItems}
    *
    * @param expectedItemIds
    *          list of expected item id's
@@ -335,7 +334,8 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
         .filter(id -> !foundItemIds.contains(id))
         .forEach(itemId -> {
           Piece piece = piecesWithItems.get(itemId);
-          addError(piece.getPoLineId(), piece.getId(), ITEM_NOT_FOUND.toError());
+          piece.setItemId(null);
+          piecesWithItems.remove(itemId);
         });
     }
   }


### PR DESCRIPTION
## Purpose
[MODORDERS-383](https://issues.folio.org/browse/MODORDERS-383)

## Approach
- do not fail check-in if item not found
- remove reference from piece to non-existent item upon check-in

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
