### PR TITLE
MODORDERS-335 - Edit quantity when Order is re-opened

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -302,7 +302,7 @@
     },
     {
       "id": "pieces",
-      "version": "1.2",
+      "version": "1.3",
       "handlers": [
         {
           "methods": ["POST"],
@@ -343,7 +343,9 @@
             "orders-storage.po-lines.item.get",
             "orders-storage.purchase-orders.item.get",
             "acquisitions-units-storage.units.collection.get",
-            "acquisitions-units-storage.memberships.collection.get"
+            "acquisitions-units-storage.memberships.collection.get",
+            "acquisitions-units-storage.memberships.collection.get",
+            "circulation.requests.collection.get"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "orders",
-      "version": "10.3",
+      "version": "10.4",
       "handlers": [
         {
           "methods": [

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -64,7 +64,9 @@ public enum ErrorCodes {
   MISSING_ONGOING("missingOngoing", "Ongoing field must be present for Ongoing order"),
   ONGOING_NOT_ALLOWED("ongoingNotAllowed", "Ongoing field must be absent for One-time order"),
   INCORRECT_FUND_DISTRIBUTION_TOTAL("incorrectFundDistributionTotal","Fund distribution total must add to 100% or totalPrice"),
-  INSTANCE_ID_NOT_ALLOWED_FOR_PACKAGE_POLINE("InstanceIdNotAllowedForPackagePoLine", "Instance id not allowed for package poline");
+  INSTANCE_ID_NOT_ALLOWED_FOR_PACKAGE_POLINE("InstanceIdNotAllowedForPackagePoLine", "Instance id not allowed for package poline"),
+  PIECES_NEED_TO_BE_DELETED("piecesNeedToBeDeleted", "Pieces need to be deleted"),
+  THERE_ARE_NO_REQUESTS("thereAreNoRequests", "There are no requests on item");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/rest/impl/InventoryHelper.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHelper.java
@@ -91,6 +91,7 @@ public class InventoryHelper extends AbstractHelper {
   static final String INSTANCE_TYPES = "instanceTypes";
   public static final String ITEMS = "items";
   static final String LOAN_TYPES = "loantypes";
+  public static final String REQUESTS = "requests";
 
   // mod-configuration: config names and default values
   static final String CONFIG_NAME_INSTANCE_TYPE_CODE = "inventory-instanceTypeCode";
@@ -124,6 +125,7 @@ public class InventoryHelper extends AbstractHelper {
     apis.put(INSTANCE_TYPES, "/instance-types?query=code==%s&lang=%s");
     apis.put(INSTANCES, "/inventory/instances?query=%s&lang=%s");
     apis.put(ITEMS, "/inventory/items?query=%s&limit=%d&lang=%s");
+    apis.put(REQUESTS, "/circulation/requests?query=%s&limit=%d");
 
     INVENTORY_LOOKUP_ENDPOINTS = Collections.unmodifiableMap(apis);
   }
@@ -185,7 +187,19 @@ public class InventoryHelper extends AbstractHelper {
     String query = encodeQuery(HelperUtils.convertIdsToCqlQuery(ids), logger);
     String endpoint = buildLookupEndpoint(ITEMS, query, ids.size(), lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
-      .thenApply(this::extractItems);
+      .thenApply(response -> extractEntities(response, ITEMS));
+  }
+
+  /**
+   * Returns list of requests for specified item.
+   *
+   * @param itemId id of Item
+   * @return future with list of requests
+   */
+  public CompletableFuture<List<JsonObject>> getRequestsByItemId(String itemId) {
+    String endpoint = buildLookupEndpoint(REQUESTS, "itemId==" + itemId, Integer.MAX_VALUE, lang);
+    return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+      .thenApply(response -> extractEntities(response, REQUESTS));
   }
 
   /**
@@ -197,7 +211,7 @@ public class InventoryHelper extends AbstractHelper {
   public CompletableFuture<List<JsonObject>> getItemRecordsByQuery(String query) {
     String endpoint = buildLookupEndpoint(ITEMS, query, Integer.MAX_VALUE, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
-      .thenApply(this::extractItems);
+      .thenApply(response -> extractEntities(response, ITEMS));
   }
 
   public CompletableFuture<Void> updateItem(JsonObject item) {
@@ -538,23 +552,23 @@ public class InventoryHelper extends AbstractHelper {
     String endpoint = String.format(LOOKUP_ITEM_STOR_ENDPOINT, query, expectedQuantity, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
       .thenApply(itemsCollection -> {
-        List<JsonObject> items = extractItems(itemsCollection);
+        List<JsonObject> items = extractEntities(itemsCollection, ITEMS);
         logger.debug("{} existing items found out of {} for PO Line with '{}' id", items.size(), expectedQuantity, compPOL.getId());
         return items;
       });
   }
 
   /**
-   * Validates if the json object contains items and returns items as list of JsonObject elements
-   * @param itemEntries {@link JsonObject} representing item storage response
-   * @return list of the item records as JsonObject elements
+   * Validates if the json object contains entries and returns entries as list of JsonObject elements
+   * @param entries {@link JsonObject} representing item storage response
+   * @return list of the entry records as JsonObject elements
    */
-  private List<JsonObject> extractItems(JsonObject itemEntries) {
-    return Optional.ofNullable(itemEntries.getJsonArray(ITEMS))
-                   .map(items -> items.stream()
-                                      .map(item -> (JsonObject) item)
-                                      .collect(toList()))
-                   .orElseGet(Collections::emptyList);
+  private List<JsonObject> extractEntities(JsonObject entries, String key) {
+    return Optional.ofNullable(entries.getJsonArray(key))
+      .map(objects -> objects.stream()
+        .map(entry -> (JsonObject) entry)
+        .collect(toList()))
+      .orElseGet(Collections::emptyList);
   }
 
 /**

--- a/src/main/java/org/folio/rest/impl/PiecesHelper.java
+++ b/src/main/java/org/folio/rest/impl/PiecesHelper.java
@@ -1,11 +1,6 @@
 package org.folio.rest.impl;
 
-import static org.folio.orders.utils.HelperUtils.URL_WITH_LANG_PARAM;
-import static org.folio.orders.utils.HelperUtils.getPoLineById;
-import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
-import static org.folio.orders.utils.HelperUtils.handleDeleteRequest;
-import static org.folio.orders.utils.HelperUtils.handleGetRequest;
-import static org.folio.orders.utils.HelperUtils.handlePutRequest;
+import static org.folio.orders.utils.HelperUtils.*;
 import static org.folio.orders.utils.ProtectedOperationType.DELETE;
 import static org.folio.orders.utils.ResourcePathResolver.PIECES;
 import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
@@ -15,7 +10,11 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.orders.events.handlers.MessageAddress;
+import org.folio.orders.rest.exceptions.HttpException;
+import org.folio.orders.utils.ErrorCodes;
+import org.folio.orders.utils.HelperUtils;
 import org.folio.orders.utils.ProtectedOperationType;
+import org.folio.rest.acq.model.PieceCollection;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.Piece.ReceivingStatus;
@@ -24,6 +23,7 @@ import org.folio.rest.jaxrs.model.PoLine;
 import io.vertx.core.Context;
 import io.vertx.core.json.JsonObject;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 public class PiecesHelper extends AbstractHelper {
 
@@ -31,6 +31,14 @@ public class PiecesHelper extends AbstractHelper {
   private InventoryHelper inventoryHelper;
 
   private static final String DELETE_PIECE_BY_ID = resourceByIdPath(PIECES, "%s") + "?lang=%s";
+
+  private static final String GET_PIECES_BY_QUERY = resourcesPath(PIECES) + SEARCH_PARAMS;
+
+  public PiecesHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {
+    super(httpClient, okapiHeaders, ctx, lang);
+    protectionHelper = new ProtectionHelper(httpClient, okapiHeaders, ctx, lang);
+    inventoryHelper = new InventoryHelper(httpClient, okapiHeaders, ctx, lang);
+  }
 
   public PiecesHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(okapiHeaders, ctx, lang);
@@ -110,9 +118,16 @@ public class PiecesHelper extends AbstractHelper {
 
   public CompletableFuture<Void> deletePiece(String id) {
     return getPieceById(id)
-      .thenCompose(piece -> getOrderByPoLineId(piece.getPoLineId()))
-      .thenCompose(purchaseOrder -> protectionHelper.isOperationRestricted(purchaseOrder.getAcqUnitIds(), DELETE))
-      .thenCompose(aVoid -> handleDeleteRequest(String.format(DELETE_PIECE_BY_ID, id, lang), httpClient, ctx, okapiHeaders, logger));
+      .thenCompose(piece -> getOrderByPoLineId(piece.getPoLineId())
+        .thenCompose(purchaseOrder -> protectionHelper.isOperationRestricted(purchaseOrder.getAcqUnitIds(), DELETE))
+        .thenCompose(vVoid -> inventoryHelper.getRequestsByItemId(piece.getItemId()))
+        .thenAccept(items -> {
+          if (items.isEmpty()) {
+            throw new HttpException(422, ErrorCodes.THERE_ARE_NO_REQUESTS.toError());
+          }
+        })
+        .thenCompose(aVoid -> handleDeleteRequest(String.format(DELETE_PIECE_BY_ID, id, lang), httpClient, ctx, okapiHeaders, logger))
+      );
   }
 
 
@@ -121,5 +136,11 @@ public class PiecesHelper extends AbstractHelper {
       .thenApply(json -> json.mapTo(PoLine.class))
       .thenCompose(poLine -> getPurchaseOrderById(poLine.getPurchaseOrderId(), lang, httpClient, ctx, okapiHeaders, logger))
       .thenApply(jsonObject -> jsonObject.mapTo(CompositePurchaseOrder.class));
+  }
+
+  public CompletableFuture<PieceCollection> getPieces(int limit, int offset, String query) {
+    String endpoint = String.format(GET_PIECES_BY_QUERY, limit, offset, buildQuery(query, logger), lang);
+    return HelperUtils.handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
+      .thenCompose(json -> VertxCompletableFuture.supplyBlockingAsync(ctx, () -> json.mapTo(PieceCollection.class)));
   }
 }

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -189,9 +189,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
             if (isTransitionToOpen) {
               String query = buildQuery(convertIdsToCqlQuery(compPO.getCompositePoLines().stream().map(CompositePoLine::getId).collect(toList()), "poLineId"), logger);
               return piecesHelper.getPieces(Integer.MAX_VALUE, 0, query)
-                .thenAccept(pieces -> {
-                  verifyLocationsAndPiecesConsistency(compPO, pieces);
-                });
+                .thenAccept(pieces -> verifyLocationsAndPiecesConsistency(compPO, pieces));
             } else {
               return CompletableFuture.completedFuture(null);
             }

--- a/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrderHelper.java
@@ -1,37 +1,13 @@
 package org.folio.rest.impl;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.*;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.folio.orders.utils.AcqDesiredPermissions.ASSIGN;
 import static org.folio.orders.utils.AcqDesiredPermissions.MANAGE;
-import static org.folio.orders.utils.ErrorCodes.APPROVAL_REQUIRED_TO_OPEN;
-import static org.folio.orders.utils.ErrorCodes.MISSING_ONGOING;
-import static org.folio.orders.utils.ErrorCodes.ONGOING_NOT_ALLOWED;
-import static org.folio.orders.utils.ErrorCodes.USER_HAS_NO_ACQ_PERMISSIONS;
-import static org.folio.orders.utils.ErrorCodes.USER_HAS_NO_APPROVAL_PERMISSIONS;
-import static org.folio.orders.utils.ErrorCodes.INCORRECT_FUND_DISTRIBUTION_TOTAL;
-import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
-import static org.folio.orders.utils.HelperUtils.WORKFLOW_STATUS;
-import static org.folio.orders.utils.HelperUtils.buildQuery;
-import static org.folio.orders.utils.HelperUtils.calculateTotalEstimatedPrice;
-import static org.folio.orders.utils.HelperUtils.changeOrderStatus;
-import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
-import static org.folio.orders.utils.HelperUtils.combineCqlExpressions;
-import static org.folio.orders.utils.HelperUtils.convertToCompositePurchaseOrder;
-import static org.folio.orders.utils.HelperUtils.deletePoLine;
-import static org.folio.orders.utils.HelperUtils.deletePoLines;
-import static org.folio.orders.utils.HelperUtils.encodeQuery;
-import static org.folio.orders.utils.HelperUtils.getCompositePoLines;
-import static org.folio.orders.utils.HelperUtils.getPoLineLimit;
-import static org.folio.orders.utils.HelperUtils.getPoLines;
-import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
-import static org.folio.orders.utils.HelperUtils.handleDeleteRequest;
-import static org.folio.orders.utils.HelperUtils.handleGetRequest;
-import static org.folio.orders.utils.HelperUtils.handlePutRequest;
-import static org.folio.orders.utils.HelperUtils.verifyNonPackageTitles;
-import static org.folio.orders.utils.HelperUtils.verifyProtectedFieldsChanged;
+import static org.folio.orders.utils.ErrorCodes.*;
+import static org.folio.orders.utils.HelperUtils.*;
 import static org.folio.orders.utils.POProtectedFields.getFieldNames;
 import static org.folio.orders.utils.POProtectedFields.getFieldNamesForOpenOrder;
 import static org.folio.orders.utils.ProtectedOperationType.CREATE;
@@ -75,18 +51,11 @@ import org.folio.orders.utils.HelperUtils;
 import org.folio.orders.utils.POLineProtectedFields;
 import org.folio.orders.utils.ProtectedOperationType;
 import org.folio.orders.utils.validators.CompositePoLineValidationUtil;
-import org.folio.rest.jaxrs.model.CompositePoLine;
-import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.acq.model.PieceCollection;
+import org.folio.rest.jaxrs.model.*;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
 import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.FundDistribution;
 import org.folio.rest.jaxrs.model.FundDistribution.DistributionType;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.rest.jaxrs.model.PoLine;
-import org.folio.rest.jaxrs.model.PurchaseOrder;
-import org.folio.rest.jaxrs.model.PurchaseOrders;
-import org.folio.rest.jaxrs.model.Title;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.javamoney.moneta.Money;
 import org.javamoney.moneta.function.MonetaryOperators;
@@ -111,6 +80,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
   private final PurchaseOrderLineHelper orderLineHelper;
   private final ProtectionHelper protectionHelper;
   private TitlesHelper titlesHelper;
+  private final PiecesHelper piecesHelper;
 
   public PurchaseOrderHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(httpClient, okapiHeaders, ctx, lang);
@@ -119,6 +89,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
     orderLineHelper = new PurchaseOrderLineHelper(httpClient, okapiHeaders, ctx, lang);
     protectionHelper = new ProtectionHelper(httpClient, okapiHeaders, ctx, lang);
     titlesHelper = new TitlesHelper(httpClient, okapiHeaders, ctx, lang);
+    piecesHelper = new PiecesHelper(httpClient, okapiHeaders, ctx, lang);
   }
 
   PurchaseOrderHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
@@ -204,26 +175,39 @@ public class PurchaseOrderHelper extends AbstractHelper {
     return getPurchaseOrderById(compPO.getId(), lang, httpClient, ctx, okapiHeaders, logger)
       .thenCompose(jsonPoFromStorage -> validateIfPOProtectedFieldsChanged(compPO, jsonPoFromStorage))
       .thenApply(HelperUtils::convertToCompositePurchaseOrder)
-      .thenCompose(poFromStorage -> validateAcqUnitsOnUpdate(compPO, poFromStorage)
-        .thenCompose(ok -> validatePoNumber(poFromStorage, compPO))
-        .thenCompose(ok -> {
-          if (isTransitionToApproved(poFromStorage, compPO)) {
-            return checkOrderApprovalPermissions(compPO);
-          }
-          return completedFuture(null);
-        })
-        .thenCompose(v -> updatePoLines(poFromStorage, compPO))
-        .thenCompose(v -> {
-          if (isTransitionToOpen(poFromStorage, compPO)) {
-            return checkOrderApprovalRequired(compPO).thenCompose(ok -> openOrder(compPO));
-          } else {
-            return CompletableFuture.completedFuture(null);
-          }
-        })
-        .thenCompose(ok -> handleFinalOrderStatus(compPO, poFromStorage.getWorkflowStatus().value()))
-      );
-  }
+      .thenCompose(poFromStorage -> {
+        boolean isTransitionToOpen = isTransitionToOpen(poFromStorage, compPO);
+        return validateAcqUnitsOnUpdate(compPO, poFromStorage)
+          .thenCompose(ok -> validatePoNumber(poFromStorage, compPO))
+          .thenCompose(ok -> {
+            if (isTransitionToApproved(poFromStorage, compPO)) {
+              return checkOrderApprovalPermissions(compPO);
+            }
+            return completedFuture(null);
+          })
+          .thenCompose(v -> {
+            if (isTransitionToOpen) {
+              String query = buildQuery(convertIdsToCqlQuery(compPO.getCompositePoLines().stream().map(CompositePoLine::getId).collect(toList()), "poLineId"), logger);
+              return piecesHelper.getPieces(Integer.MAX_VALUE, 0, query)
+                .thenAccept(pieces -> {
+                  verifyLocationsAndPiecesConsistency(compPO, pieces);
+                });
+            } else {
+              return CompletableFuture.completedFuture(null);
+            }
+          })
+          .thenCompose(v -> updatePoLines(poFromStorage, compPO))
+          .thenCompose(v -> {
+            if (isTransitionToOpen) {
+              return checkOrderApprovalRequired(compPO).thenCompose(ok -> openOrder(compPO));
+            } else {
+              return CompletableFuture.completedFuture(null);
+            }
+          })
+          .thenCompose(ok -> handleFinalOrderStatus(compPO, poFromStorage.getWorkflowStatus().value()));
 
+      });
+  }
 
   public CompletableFuture<Void> handleFinalOrderStatus(CompositePurchaseOrder compPO, String initialOrdersStatus) {
     PurchaseOrder purchaseOrder = convertToPurchaseOrder(compPO).mapTo(PurchaseOrder.class);
@@ -283,7 +267,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
       .ofSubLists(lineIds, MAX_IDS_FOR_GET_RQ)
       // Get item records from Inventory storage
       .map(ids -> {
-        String query = encodeQuery(String.format("status.name==%s and %s", itemStatus, HelperUtils.convertIdsToCqlQuery(ids, InventoryHelper.ITEM_PURCHASE_ORDER_LINE_IDENTIFIER, true)), logger);
+        String query = encodeQuery(String.format("status.name==%s and %s", itemStatus, convertIdsToCqlQuery(ids, InventoryHelper.ITEM_PURCHASE_ORDER_LINE_IDENTIFIER, true)), logger);
         return inventoryHelper.getItemRecordsByQuery(query);
       })
       .toList();
@@ -1037,5 +1021,21 @@ public class PurchaseOrderHelper extends AbstractHelper {
         }
     }
     return purchaseOrder;
+  }
+
+  private void verifyLocationsAndPiecesConsistency(CompositePurchaseOrder compPO, PieceCollection pieces) {
+
+    if (!compPO.getCompositePoLines().isEmpty()) {
+      Map<String, Map<String, Integer>> numOfPiecesByPoLineIdAndLocationId = pieces.getPieces().stream()
+        .filter(p -> Objects.nonNull(p.getPoLineId()) && Objects.nonNull(p.getLocationId()))
+        .collect(groupingBy(piece -> piece.getPoLineId(), groupingBy(location -> location.getLocationId(), summingInt(q -> 1))));
+
+      Map<String, Map<String, Integer>> numOfLocationsByPoLineIdAndLocationId = compPO.getCompositePoLines().stream()
+        .collect(toMap(CompositePoLine::getId, poLine -> poLine.getLocations().stream().collect(toMap(Location::getLocationId, Location::getQuantity))));
+
+      if (!Objects.deepEquals(numOfPiecesByPoLineIdAndLocationId, numOfLocationsByPoLineIdAndLocationId)) {
+        throw new HttpException(422, PIECES_NEED_TO_BE_DELETED.toError());
+      }
+    }
   }
 }

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -71,7 +71,6 @@ import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -148,6 +147,9 @@ public class ApiTestBase {
   private static final String LOCATION_ID = "f34d27c6-a8eb-461b-acd6-5dea81771e70";
 
   private static boolean runningOnOwn;
+
+  public static final String PIECE_ID = "0f1bb087-72e9-44ce-a145-bfc2e7b005cf";
+  public static final String ITEM_ID = "522a501a-56b5-48d9-b28a-3a8f02482d97";
 
   // The variable is defined in main thread but the value is going to be inserted in vert.x event loop thread
   private static volatile List<Message<JsonObject>> eventMessages = new ArrayList<>();
@@ -474,9 +476,10 @@ public class ApiTestBase {
 
   public static Piece getMinimalContentPiece(String poLineId) {
     return new Piece()
-      .withId(UUID.randomUUID().toString())
+      .withId(PIECE_ID)
       .withReceivingStatus(Piece.ReceivingStatus.RECEIVED)
       .withFormat(Piece.Format.PHYSICAL)
+      .withItemId(ITEM_ID)
       .withReceiptDate(new Date())
       .withPoLineId(poLineId);
   }

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -393,9 +393,13 @@ public class CheckinReceivingApiTest extends ApiTestBase {
 
     Piece physicalPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.PHYSICAL)
-      .withLocationId(locationForPhysical);
+      .withLocationId(locationForPhysical)
+      .withId(UUID.randomUUID().toString())
+      .withItemId(UUID.randomUUID().toString());;
     Piece electronicPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
-      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
+      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC)
+      .withId(UUID.randomUUID().toString())
+      .withItemId(UUID.randomUUID().toString());
 
     addMockEntry(PURCHASE_ORDER, order.withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN));
     addMockEntry(PO_LINES, poLine);

--- a/src/test/java/org/folio/rest/impl/InventoryInteractionTestHelper.java
+++ b/src/test/java/org/folio/rest/impl/InventoryInteractionTestHelper.java
@@ -11,8 +11,7 @@ import static org.folio.orders.utils.HelperUtils.getElectronicCostQuantity;
 import static org.folio.orders.utils.HelperUtils.getPhysicalCostQuantity;
 import static org.folio.orders.utils.HelperUtils.groupLocationsById;
 import static org.folio.orders.utils.HelperUtils.isHoldingCreationRequiredForLocation;
-import static org.folio.rest.impl.ApiTestBase.EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10;
-import static org.folio.rest.impl.ApiTestBase.getInstanceId;
+import static org.folio.rest.impl.ApiTestBase.*;
 import static org.folio.rest.impl.InventoryHelper.CONFIG_NAME_INSTANCE_STATUS_CODE;
 import static org.folio.rest.impl.InventoryHelper.CONFIG_NAME_INSTANCE_TYPE_CODE;
 import static org.folio.rest.impl.InventoryHelper.CONFIG_NAME_LOAN_TYPE_NAME;
@@ -43,19 +42,7 @@ import static org.folio.rest.impl.InventoryHelper.ITEM_PURCHASE_ORDER_LINE_IDENT
 import static org.folio.rest.impl.InventoryHelper.ITEM_STATUS;
 import static org.folio.rest.impl.InventoryHelper.ITEM_STATUS_NAME;
 import static org.folio.rest.impl.InventoryHelper.LOAN_TYPES;
-import static org.folio.rest.impl.MockServer.CONFIG_MOCK_PATH;
-import static org.folio.rest.impl.MockServer.INSTANCE_STATUSES_MOCK_DATA_PATH;
-import static org.folio.rest.impl.MockServer.INSTANCE_TYPES_MOCK_DATA_PATH;
-import static org.folio.rest.impl.MockServer.LOAN_TYPES_MOCK_DATA_PATH;
-import static org.folio.rest.impl.MockServer.getCreatedHoldings;
-import static org.folio.rest.impl.MockServer.getCreatedInstances;
-import static org.folio.rest.impl.MockServer.getCreatedItems;
-import static org.folio.rest.impl.MockServer.getCreatedPieces;
-import static org.folio.rest.impl.MockServer.getHoldingsSearches;
-import static org.folio.rest.impl.MockServer.getInstancesSearches;
-import static org.folio.rest.impl.MockServer.getItemsSearches;
-import static org.folio.rest.impl.MockServer.getPieceSearches;
-import static org.folio.rest.impl.MockServer.getPoLineUpdates;
+import static org.folio.rest.impl.MockServer.*;
 import static org.folio.rest.impl.PurchaseOrdersApiTest.ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -65,17 +52,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -235,7 +215,7 @@ class InventoryInteractionTestHelper {
     int totalForAllPoLines = 0;
     for (CompositePoLine poLine : compositePoLines) {
       List<Location> locations = poLine.getLocations().stream()
-        .filter(location -> isHoldingCreationRequiredForLocation(poLine, location))
+        .filter(location -> isHoldingCreationRequiredForLocation(poLine, location) && !Objects.equals(location.getLocationId(), ID_FOR_INTERNAL_SERVER_ERROR))
         .collect(Collectors.toList());
 
       // Prepare data first
@@ -294,6 +274,36 @@ class InventoryInteractionTestHelper {
 
     // Make sure that none of pieces missed
     assertThat(pieceJsons, hasSize(totalForAllPoLines));
+  }
+
+  public static void verifyInventoryNonInteraction() {
+    // Searches
+    List<JsonObject> instancesSearches = getInstancesSearches();
+    List<JsonObject> holdingsSearches = getHoldingsSearches();
+    List<JsonObject> itemsSearches = getItemsSearches();
+    List<JsonObject> piecesSearches = getPieceSearches();
+    List<JsonObject> poLineSearches = getPoLineSearches();
+    List<JsonObject> ordersSearches = getPurchaseOrderRetrievals();
+    assertNull(instancesSearches);
+    assertNull(holdingsSearches);
+    assertNull(itemsSearches);
+    assertThat(piecesSearches, hasSize(1));
+    assertThat(poLineSearches, hasSize(1));
+    assertThat(ordersSearches, hasSize(1));
+
+    // Creation/updating
+    List<JsonObject> createdInstances = getCreatedInstances();
+    List<JsonObject> createdHoldings = getCreatedHoldings();
+    List<JsonObject> createdItems = getCreatedItems();
+    List<JsonObject> createdPieces = getCreatedPieces();
+    List<JsonObject> updatedPoLines = getPoLineUpdates();
+    List<JsonObject> updatedOrders = getPurchaseOrderUpdates();
+    assertNull(createdInstances);
+    assertNull(createdHoldings);
+    assertNull(createdItems);
+    assertNull(createdPieces);
+    assertNull(updatedPoLines);
+    assertNull(updatedOrders);
   }
 
   private static void verifyHoldingsCreated(List<JsonObject> holdings, CompositePoLine pol) {

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -65,9 +65,7 @@ import static org.folio.rest.impl.ApiTestBase.getMinimalContentCompositePoLine;
 import static org.folio.rest.impl.ApiTestBase.getMinimalContentCompositePurchaseOrder;
 import static org.folio.rest.impl.ApiTestBase.getMockAsJson;
 import static org.folio.rest.impl.ApiTestBase.getMockData;
-import static org.folio.rest.impl.InventoryHelper.HOLDING_PERMANENT_LOCATION_ID;
-import static org.folio.rest.impl.InventoryHelper.ITEMS;
-import static org.folio.rest.impl.InventoryHelper.LOAN_TYPES;
+import static org.folio.rest.impl.InventoryHelper.*;
 import static org.folio.rest.impl.PoNumberApiTest.EXISTING_PO_NUMBER;
 import static org.folio.rest.impl.PoNumberApiTest.NONEXISTING_PO_NUMBER;
 import static org.folio.rest.impl.ProtectionHelper.ACQUISITIONS_UNIT_ID;
@@ -199,6 +197,7 @@ public class MockServer {
   private static final String ORGANIZATIONS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "organizations/";
   public static final String POLINES_COLLECTION = PO_LINES_MOCK_DATA_PATH + "po_line_collection.json";
   private static final String IDENTIFIER_TYPES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "identifierTypes/";
+  private static final String ITEM_REQUESTS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "itemRequests/";
   static final String ACQUISITIONS_UNITS_COLLECTION = ACQUISITIONS_UNITS_MOCK_DATA_PATH + "/units.json";
   static final String ACQUISITIONS_MEMBERSHIPS_COLLECTION = ACQUISITIONS_UNITS_MOCK_DATA_PATH + "/memberships.json";
   static final String ORDER_TEMPLATES_COLLECTION = ORDER_TEMPLATES_MOCK_DATA_PATH + "/orderTemplates.json";
@@ -212,6 +211,7 @@ public class MockServer {
   static final String ORDER_ID_WITH_PO_LINES = "ab18897b-0e40-4f31-896b-9c9adc979a87";
   private static final String PIECE_POLINE_CONSISTENT_RECEIPT_STATUS_ID = "7d0aa803-a659-49f0-8a95-968f277c87d7";
   private static final String PIECE_POLINE_CONSISTENCY_404_POLINE_NOT_FOUND_ID = "5b454292-6aaa-474f-9510-b59a564e0c8d";
+  public static final String PIECE_NOT_FOUND_ID = "5bf8c236-8aec-4545-baa1-29004849276d";
   static final String PO_NUMBER_VALUE = "228D126";
 
   private static final String PO_NUMBER_ERROR_TENANT = "po_number_error_tenant";
@@ -474,6 +474,7 @@ public class MockServer {
     router.get("/organizations-storage/organizations/:id").handler(this::getOrganizationById);
     router.get("/organizations-storage/organizations").handler(this::handleGetAccessProviders);
     router.get("/identifier-types").handler(this::handleGetIdentifierType);
+    router.get("/circulation/requests").handler(this::handleGetItemRequests);
     router.get(resourcesPath(PO_LINES)).handler(ctx -> handleGetPoLines(ctx, PO_LINES));
     router.get(resourcePath(PO_LINES)).handler(this::handleGetPoLineById);
     router.get(resourcePath(ALERTS)).handler(ctx -> handleGetGenericSubObj(ctx, ALERTS));
@@ -884,6 +885,22 @@ public class MockServer {
       } catch (Exception e) {
         serverResponse(ctx, 500, APPLICATION_JSON, INTERNAL_SERVER_ERROR.getReasonPhrase());
       }
+    }
+  }
+
+  private void handleGetItemRequests(RoutingContext ctx) {
+    logger.info("handleGetItemRequests got: " + ctx.request().path());
+    try {
+      String itemId = ctx.request().getParam("query").split("==")[1];
+      JsonObject entries = new JsonObject(ApiTestBase.getMockData(ITEM_REQUESTS_MOCK_DATA_PATH + "itemRequests.json"));
+      filterByKeyValue("itemId", itemId, entries.getJsonArray(REQUESTS));
+      serverResponse(ctx, 200, APPLICATION_JSON, entries.encodePrettily());
+      entries.put("totalRecords", entries.getJsonArray(REQUESTS).size());
+      addServerRqRsData(HttpMethod.GET, REQUESTS, entries);
+    } catch (IOException e) {
+      ctx.response()
+        .setStatusCode(404)
+        .end();
     }
   }
 

--- a/src/test/java/org/folio/rest/impl/PieceApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PieceApiTest.java
@@ -2,20 +2,28 @@ package org.folio.rest.impl;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.folio.orders.utils.ErrorCodes.THERE_ARE_NO_REQUESTS;
+import static org.folio.orders.utils.ResourcePathResolver.*;
 import static org.folio.rest.impl.MockServer.PIECE_RECORDS_MOCK_DATA_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertNull;
 
 import org.folio.HttpStatus;
 import org.folio.rest.acq.model.Piece;
+import org.folio.rest.jaxrs.model.CompositePoLine;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.junit.Test;
 
 import io.restassured.http.Header;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
+import java.util.List;
+import java.util.UUID;
 
 public class PieceApiTest extends ApiTestBase {
 
@@ -125,6 +133,25 @@ public class PieceApiTest extends ApiTestBase {
     logger.info("=== Test delete piece by id ===");
 
     verifyDeleteResponse(String.format(PIECES_ID_PATH, VALID_UUID), "", 204);
+  }
+
+  @Test
+  public void deletePieceByIdWitoutRequestsTest() {
+    logger.info("=== Test delete piece by id without requests ===");
+
+    PurchaseOrder order = new PurchaseOrder().withId(UUID.randomUUID().toString());
+    CompositePoLine poLine = new CompositePoLine().withId(UUID.randomUUID().toString()).withPurchaseOrderId(order.getId());
+    Piece piece = new Piece().withId(UUID.randomUUID().toString()).withItemId(UUID.randomUUID().toString()).withPoLineId(poLine.getId());
+
+    MockServer.addMockEntry(PIECES, JsonObject.mapFrom(piece));
+    MockServer.addMockEntry(PO_LINES, JsonObject.mapFrom(poLine));
+    MockServer.addMockEntry(PURCHASE_ORDER, JsonObject.mapFrom(order));
+
+    Errors response = verifyDeleteResponse(String.format(PIECES_ID_PATH, piece.getId()), "", 422).as(Errors.class);
+    List<Error> errors = response.getErrors();
+    assertThat(errors, hasSize(1));
+    Error error = errors.get(0);
+    assertThat(error.getCode(), is(THERE_ARE_NO_REQUESTS.getCode()));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -5,51 +5,12 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.containsAny;
-import static org.folio.orders.utils.ErrorCodes.COST_UNIT_PRICE_ELECTRONIC_INVALID;
-import static org.folio.orders.utils.ErrorCodes.COST_UNIT_PRICE_INVALID;
-import static org.folio.orders.utils.ErrorCodes.CURRENT_FISCAL_YEAR_NOT_FOUND;
-import static org.folio.orders.utils.ErrorCodes.ELECTRONIC_COST_LOC_QTY_MISMATCH;
-import static org.folio.orders.utils.ErrorCodes.FUNDS_NOT_FOUND;
-import static org.folio.orders.utils.ErrorCodes.FUND_CANNOT_BE_PAID;
-import static org.folio.orders.utils.ErrorCodes.GENERIC_ERROR_CODE;
-import static org.folio.orders.utils.ErrorCodes.INCORRECT_FUND_DISTRIBUTION_TOTAL;
-import static org.folio.orders.utils.ErrorCodes.INSTANCE_ID_NOT_ALLOWED_FOR_PACKAGE_POLINE;
-import static org.folio.orders.utils.ErrorCodes.ISBN_NOT_VALID;
-import static org.folio.orders.utils.ErrorCodes.MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY;
-import static org.folio.orders.utils.ErrorCodes.MISSING_MATERIAL_TYPE;
-import static org.folio.orders.utils.ErrorCodes.MISSING_ONGOING;
-import static org.folio.orders.utils.ErrorCodes.NON_ZERO_COST_ELECTRONIC_QTY;
-import static org.folio.orders.utils.ErrorCodes.ONGOING_NOT_ALLOWED;
-import static org.folio.orders.utils.ErrorCodes.ORDER_CLOSED;
-import static org.folio.orders.utils.ErrorCodes.ORDER_OPEN;
-import static org.folio.orders.utils.ErrorCodes.ORDER_VENDOR_IS_INACTIVE;
-import static org.folio.orders.utils.ErrorCodes.ORDER_VENDOR_NOT_FOUND;
-import static org.folio.orders.utils.ErrorCodes.ORGANIZATION_NOT_A_VENDOR;
-import static org.folio.orders.utils.ErrorCodes.PHYSICAL_COST_LOC_QTY_MISMATCH;
-import static org.folio.orders.utils.ErrorCodes.POL_ACCESS_PROVIDER_IS_INACTIVE;
-import static org.folio.orders.utils.ErrorCodes.POL_ACCESS_PROVIDER_NOT_FOUND;
-import static org.folio.orders.utils.ErrorCodes.POL_LINES_LIMIT_EXCEEDED;
-import static org.folio.orders.utils.ErrorCodes.VENDOR_ISSUE;
-import static org.folio.orders.utils.ErrorCodes.ZERO_COST_ELECTRONIC_QTY;
-import static org.folio.orders.utils.ErrorCodes.ZERO_COST_PHYSICAL_QTY;
-import static org.folio.orders.utils.ErrorCodes.ZERO_LOCATION_QTY;
+import static org.folio.orders.utils.ErrorCodes.*;
 import static org.folio.orders.utils.HelperUtils.COMPOSITE_PO_LINES;
-import static org.folio.orders.utils.HelperUtils.INSTANCE_ID;
 import static org.folio.orders.utils.HelperUtils.calculateInventoryItemsQuantity;
 import static org.folio.orders.utils.HelperUtils.calculateTotalEstimatedPrice;
 import static org.folio.orders.utils.HelperUtils.calculateTotalQuantity;
-import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_MEMBERSHIPS;
-import static org.folio.orders.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
-import static org.folio.orders.utils.ResourcePathResolver.FUNDS;
-import static org.folio.orders.utils.ResourcePathResolver.PAYMENT_STATUS;
-import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
-import static org.folio.orders.utils.ResourcePathResolver.PO_LINE_NUMBER;
-import static org.folio.orders.utils.ResourcePathResolver.PO_NUMBER;
-import static org.folio.orders.utils.ResourcePathResolver.PURCHASE_ORDER;
-import static org.folio.orders.utils.ResourcePathResolver.RECEIPT_STATUS;
-import static org.folio.orders.utils.ResourcePathResolver.SEARCH_ORDERS;
-import static org.folio.orders.utils.ResourcePathResolver.TITLES;
-import static org.folio.orders.utils.ResourcePathResolver.VENDOR_ID;
+import static org.folio.orders.utils.ResourcePathResolver.*;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_PERMISSIONS;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.impl.AbstractHelper.MAX_IDS_FOR_GET_RQ;
@@ -64,34 +25,8 @@ import static org.folio.rest.impl.InventoryHelper.INSTANCE_STATUS_ID;
 import static org.folio.rest.impl.InventoryHelper.INSTANCE_TYPE_ID;
 import static org.folio.rest.impl.InventoryHelper.ITEMS;
 import static org.folio.rest.impl.InventoryHelper.ITEM_MATERIAL_TYPE_ID;
-import static org.folio.rest.impl.InventoryInteractionTestHelper.joinExistingAndNewItems;
-import static org.folio.rest.impl.InventoryInteractionTestHelper.verifyInstanceLinksForUpdatedOrder;
-import static org.folio.rest.impl.InventoryInteractionTestHelper.verifyInventoryInteraction;
-import static org.folio.rest.impl.InventoryInteractionTestHelper.verifyPiecesCreated;
-import static org.folio.rest.impl.InventoryInteractionTestHelper.verifyPiecesQuantityForSuccessCase;
-import static org.folio.rest.impl.MockServer.BUDGET_IS_INACTIVE_TENANT;
-import static org.folio.rest.impl.MockServer.BUDGET_NOT_FOUND_FOR_TRANSACTION_TENANT;
-import static org.folio.rest.impl.MockServer.FUND_CANNOT_BE_PAID_TENANT;
-import static org.folio.rest.impl.MockServer.ITEM_RECORDS;
-import static org.folio.rest.impl.MockServer.LEDGER_NOT_FOUND_FOR_TRANSACTION_TENANT;
-import static org.folio.rest.impl.MockServer.addMockEntry;
-import static org.folio.rest.impl.MockServer.getContributorNameTypesSearches;
-import static org.folio.rest.impl.MockServer.getCreatedEncumbrances;
-import static org.folio.rest.impl.MockServer.getCreatedHoldings;
-import static org.folio.rest.impl.MockServer.getCreatedInstances;
-import static org.folio.rest.impl.MockServer.getCreatedItems;
-import static org.folio.rest.impl.MockServer.getCreatedOrderSummaries;
-import static org.folio.rest.impl.MockServer.getCreatedPieces;
-import static org.folio.rest.impl.MockServer.getHoldingsSearches;
-import static org.folio.rest.impl.MockServer.getInstanceStatusesSearches;
-import static org.folio.rest.impl.MockServer.getInstanceTypesSearches;
-import static org.folio.rest.impl.MockServer.getInstancesSearches;
-import static org.folio.rest.impl.MockServer.getItemUpdates;
-import static org.folio.rest.impl.MockServer.getItemsSearches;
-import static org.folio.rest.impl.MockServer.getLoanTypesSearches;
-import static org.folio.rest.impl.MockServer.getPieceSearches;
-import static org.folio.rest.impl.MockServer.getPurchaseOrderUpdates;
-import static org.folio.rest.impl.MockServer.getQueryParams;
+import static org.folio.rest.impl.InventoryInteractionTestHelper.*;
+import static org.folio.rest.impl.MockServer.*;
 import static org.folio.rest.impl.PoNumberApiTest.EXISTING_PO_NUMBER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -131,6 +66,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.folio.HttpStatus;
 import org.folio.orders.utils.AcqDesiredPermissions;
 import org.folio.orders.utils.ErrorCodes;
@@ -139,27 +75,13 @@ import org.folio.orders.utils.POLineProtectedFields;
 import org.folio.orders.utils.POProtectedFields;
 import org.folio.rest.acq.model.Ongoing;
 import org.folio.rest.acq.model.finance.Fund;
-import org.folio.rest.jaxrs.model.AcquisitionsUnitMembershipCollection;
-import org.folio.rest.jaxrs.model.CloseReason;
-import org.folio.rest.jaxrs.model.CompositePoLine;
+import org.folio.rest.jaxrs.model.*;
 import org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat;
 import org.folio.rest.jaxrs.model.CompositePoLine.ReceiptStatus;
-import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
-import org.folio.rest.jaxrs.model.Contributor;
-import org.folio.rest.jaxrs.model.Cost;
-import org.folio.rest.jaxrs.model.Eresource;
 import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.FundDistribution.DistributionType;
-import org.folio.rest.jaxrs.model.Location;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.Physical.CreateInventory;
-import org.folio.rest.jaxrs.model.PoLine;
-import org.folio.rest.jaxrs.model.PurchaseOrder;
-import org.folio.rest.jaxrs.model.PurchaseOrders;
-import org.folio.rest.jaxrs.model.Title;
 import org.hamcrest.beans.HasPropertyWithValue;
 import org.hamcrest.core.Every;
 import org.hamcrest.core.Is;
@@ -256,7 +178,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     reqData.getCompositePoLines().get(0).getFundDistribution().get(1).setValue(50d);
 
     final CompositePurchaseOrder resp = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-        prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
     assertThat(resp.getCompositePoLines().get(0).getCost().getPoLineEstimatedPrice(), equalTo(47.98));
   }
@@ -285,7 +207,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     // Amount < 0 is not allowed
     Errors errorResponse = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-        prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422).as(Errors.class);
+      prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(errorResponse.getErrors(), hasSize(1));
 
@@ -316,7 +238,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     reqData.getCompositePoLines().get(0).getFundDistribution().get(1).setValue(85d);
 
     Errors errorResponse = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-        prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422).as(Errors.class);
+      prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(errorResponse.getErrors(), hasSize(1));
 
@@ -348,7 +270,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     // Amount < 0 is not allowed
     Errors errorResponse = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
-        prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422).as(Errors.class);
+      prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(errorResponse.getErrors(), hasSize(1));
 
@@ -425,8 +347,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     // the sum might be wrong if using regular double e.g. 44.41d + 32.98d results to 77.38999999999999
     double expectedTotal = BigDecimal.valueOf(expectedTotalPoLine1)
-                                     .add(BigDecimal.valueOf(expectedTotalPoLine2))
-                                     .doubleValue();
+      .add(BigDecimal.valueOf(expectedTotalPoLine2))
+      .doubleValue();
     assertThat(resp.getTotalEstimatedPrice(), equalTo(expectedTotal));
 
     List<JsonObject> poLines = MockServer.serverRqRs.get(PO_LINES, HttpMethod.POST);
@@ -479,17 +401,17 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 422).as(Errors.class);
     assertThat(response.getErrors(), hasSize(11));
     Set<String> errorCodes = response.getErrors()
-                                     .stream()
-                                     .map(Error::getCode)
-                                     .collect(Collectors.toSet());
+      .stream()
+      .map(Error::getCode)
+      .collect(Collectors.toSet());
 
     assertThat(errorCodes, containsInAnyOrder(ZERO_COST_PHYSICAL_QTY.getCode(),
-                                              ZERO_COST_ELECTRONIC_QTY.getCode(),
-                                              NON_ZERO_COST_ELECTRONIC_QTY.getCode(),
-                                              PHYSICAL_COST_LOC_QTY_MISMATCH.getCode(),
-                                              ELECTRONIC_COST_LOC_QTY_MISMATCH.getCode(),
-                                              COST_UNIT_PRICE_ELECTRONIC_INVALID.getCode(),
-                                              COST_UNIT_PRICE_INVALID.getCode()));
+      ZERO_COST_ELECTRONIC_QTY.getCode(),
+      NON_ZERO_COST_ELECTRONIC_QTY.getCode(),
+      PHYSICAL_COST_LOC_QTY_MISMATCH.getCode(),
+      ELECTRONIC_COST_LOC_QTY_MISMATCH.getCode(),
+      COST_UNIT_PRICE_ELECTRONIC_INVALID.getCode(),
+      COST_UNIT_PRICE_INVALID.getCode()));
 
     // Check that no other calls are made by the business logic to other services, except for ISBN validation
     assertEquals(2, MockServer.serverRqRs.size());
@@ -599,24 +521,24 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     });
 
     firstPoLine.getLocations().add(new Location()
-                                    .withQuantityElectronic(0)
-                                    .withQuantityPhysical(0)
-                                    .withLocationId(firstPoLine.getLocations().get(0).getLocationId()));
+      .withQuantityElectronic(0)
+      .withQuantityPhysical(0)
+      .withLocationId(firstPoLine.getLocations().get(0).getLocationId()));
     final Errors response = verifyPut(COMPOSITE_ORDERS_PATH + "/" + reqData.getId(), JsonObject.mapFrom(reqData),
 
       APPLICATION_JSON, 422).as(Errors.class);
 
     assertThat(response.getErrors(), hasSize(5));
     Set<String> errorCodes = response.getErrors()
-                                     .stream()
-                                     .map(Error::getCode)
-                                     .collect(Collectors.toSet());
+      .stream()
+      .map(Error::getCode)
+      .collect(Collectors.toSet());
 
     assertThat(errorCodes, containsInAnyOrder(ZERO_COST_ELECTRONIC_QTY.getCode(),
-                                              ZERO_COST_PHYSICAL_QTY.getCode(),
-                                              ELECTRONIC_COST_LOC_QTY_MISMATCH.getCode(),
-                                              PHYSICAL_COST_LOC_QTY_MISMATCH.getCode(),
-                                              ZERO_LOCATION_QTY.getCode()));
+      ZERO_COST_PHYSICAL_QTY.getCode(),
+      ELECTRONIC_COST_LOC_QTY_MISMATCH.getCode(),
+      PHYSICAL_COST_LOC_QTY_MISMATCH.getCode(),
+      ZERO_LOCATION_QTY.getCode()));
 
     // Check that no any calls made by the business logic to other services
     assertEquals(2, MockServer.serverRqRs.size());
@@ -888,6 +810,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     removeAllEncumbranceLinks(reqData);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     MockServer.addMockTitles(reqData.getCompositePoLines());
+    preparePiecesForCompositePo(reqData);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
 
     List<JsonObject> createdPieces = getCreatedPieces();
@@ -918,8 +841,10 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     removeAllEncumbranceLinks(reqData);
     compositePoLine.getFundDistribution().get(0).setFundId(ID_DOES_NOT_EXIST);
+    compositePoLine.setId(UUID.randomUUID().toString());
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
 
+    preparePiecesForCompositePo(reqData);
     Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), APPLICATION_JSON, 400).as(Errors.class);
 
     assertThat(errors.getErrors(), hasSize(1));
@@ -943,7 +868,9 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     addMockEntry(FUNDS, fund);
     removeAllEncumbranceLinks(reqData);
     compositePoLine.getFundDistribution().forEach(fundDistribution -> fundDistribution.setFundId(fund.getId()));
+    compositePoLine.setId(UUID.randomUUID().toString());
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    preparePiecesForCompositePo(reqData);
 
     Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), APPLICATION_JSON, 400).as(Errors.class);
 
@@ -968,6 +895,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     addMockEntry(FUNDS, fund);
     removeAllEncumbranceLinks(reqData);
     compositePoLine.getFundDistribution().forEach(fundDistribution -> fundDistribution.setFundId(fund.getId()));
+    compositePoLine.setId(UUID.randomUUID().toString());
+    preparePiecesForCompositePo(reqData);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
 
     Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), APPLICATION_JSON, 500).as(Errors.class);
@@ -988,9 +917,11 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     CompositePoLine compositePoLine = reqData.getCompositePoLines().get(0);
 
+    compositePoLine.setId(UUID.randomUUID().toString());
     compositePoLine.getFundDistribution().clear();
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
 
+    preparePiecesForCompositePo(reqData);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
 
     assertThat(getCreatedOrderSummaries(), hasSize(0));
@@ -1009,6 +940,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     reqData.getCompositePoLines().get(1).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    preparePiecesForCompositePo(reqData);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
     List<JsonObject> items = joinExistingAndNewItems();
     List<JsonObject> createdPieces = getCreatedPieces();
@@ -1056,8 +988,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     request.put("poNumber", "1234");
     String body= request.toString();
 
-     verifyPostResponse(COMPOSITE_ORDERS_PATH, body,
-       prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422);
+    verifyPostResponse(COMPOSITE_ORDERS_PATH, body,
+      prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT), APPLICATION_JSON, 422);
 
   }
 
@@ -1071,8 +1003,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     request.put("vendor", EXISTING_REQUIRED_VENDOR_UUID);
     String body = request.toString();
 
-     verifyPostResponse(COMPOSITE_ORDERS_PATH, body,
-       prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT, X_OKAPI_USER_ID), APPLICATION_JSON, 400);
+    verifyPostResponse(COMPOSITE_ORDERS_PATH, body,
+      prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT, X_OKAPI_USER_ID), APPLICATION_JSON, 400);
 
   }
 
@@ -1542,6 +1474,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     // Make sure that mock PO has 2 po lines
     assertEquals(2, reqData.getCompositePoLines().size());
 
+    preparePiecesForCompositePo(reqData);
+
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     // MODORDERS-178 guarantee electronic resource for the second PO Line but set "create items" to NONE
     reqData.getCompositePoLines().get(1).setOrderFormat(CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE);
@@ -1555,10 +1489,32 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     int polCount = reqData.getCompositePoLines().size();
 
+    System.out.println(MockServer.serverRqRs);
+
     verifyInstanceLinksForUpdatedOrder(reqData);
     verifyInventoryInteraction(reqData, polCount - 1);
     verifyReceiptStatusChangedTo(CompositePoLine.ReceiptStatus.AWAITING_RECEIPT.value(), reqData.getCompositePoLines().size());
     verifyPaymentStatusChangedTo(CompositePoLine.PaymentStatus.PAYMENT_NOT_REQUIRED.value(), reqData.getCompositePoLines().size());
+  }
+
+  @Test
+  public void testPutOrdersByIdToChangeStatusToOpenRestricted() throws Exception {
+    logger.info("=== Test Put Order By Id to change status of Order to Open ===");
+
+    CompositePurchaseOrder reqData = getMockDraftOrder().mapTo(CompositePurchaseOrder.class);
+    reqData.setId(ID_FOR_PRINT_MONOGRAPH_ORDER);
+    assertEquals(2, reqData.getCompositePoLines().size());
+
+    reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+
+    Errors response = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 422).as(Errors.class);
+
+    verifyInventoryNonInteraction();
+
+    List<Error> errors = response.getErrors();
+    assertThat(errors, hasSize(1));
+    Error error = errors.get(0);
+    assertThat(error.getCode(), is(PIECES_NEED_TO_BE_DELETED.getCode()));
   }
 
   @Test
@@ -1575,21 +1531,22 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     line.setPoLineNumber(reqData.getPoNumber() + "-1");
 
     line.setLocations(Collections.singletonList(new Location().withLocationId(UUID.randomUUID()
-        .toString())
-        .withQuantityElectronic(2)
-        .withQuantityPhysical(2)));
+      .toString())
+      .withQuantityElectronic(2)
+      .withQuantityPhysical(2)));
 
     line.setCost(new Cost().withCurrency("USD")
-        .withListUnitPrice(1.0)
-        .withListUnitPriceElectronic(1.0)
-        .withQuantityElectronic(2)
-        .withQuantityPhysical(2));
+      .withListUnitPrice(1.0)
+      .withListUnitPriceElectronic(1.0)
+      .withQuantityElectronic(2)
+      .withQuantityPhysical(2));
 
     addMockEntry(PURCHASE_ORDER, reqData);
     addMockEntry(PO_LINES, line);
     createMockTitle(line);
 
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    preparePiecesForCompositePo(reqData);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
 
     List<JsonObject> createdPieces = getCreatedPieces();
@@ -1609,6 +1566,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     Map<String, String> uuids = new HashMap<>();
     // Populate instanceIds
     reqData.getCompositePoLines().forEach(p -> p.setInstanceId(uuids.compute(p.getId(), (k, v) -> UUID.randomUUID().toString())));
+    MockServer.addMockTitles(reqData.getCompositePoLines());
+    preparePiecesForCompositePo(reqData);
     // Update order
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
     verifyInstanceLinksForUpdatedOrder(reqData);
@@ -1705,7 +1664,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     Errors errors = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData)
       .toString(), prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_TOKEN, X_OKAPI_USER_ID), APPLICATION_JSON, 422)
-        .as(Errors.class);
+      .as(Errors.class);
 
     assertEquals(FUND_CANNOT_BE_PAID.getCode(), errors.getErrors().get(0).getCode());
 
@@ -1898,6 +1857,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     reqData.getCompositePoLines().get(1).setCheckinItems(true);
     reqData.getCompositePoLines().forEach(s -> s.setReceiptStatus(CompositePoLine.ReceiptStatus.PENDING));
 
+    preparePiecesForCompositePo(reqData);
+
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
 
     int polCount = reqData.getCompositePoLines().size();
@@ -1917,6 +1878,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     reqData.getCompositePoLines().clear();
     reqData.setId(ID_FOR_PRINT_MONOGRAPH_ORDER);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    preparePiecesForCompositePo(reqData);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), "", 204);
     verifyReceiptStatusChangedTo(CompositePoLine.ReceiptStatus.AWAITING_RECEIPT.value(), reqData.getCompositePoLines().size());
     verifyPaymentStatusChangedTo(CompositePoLine.PaymentStatus.AWAITING_PAYMENT.value(), reqData.getCompositePoLines().size());
@@ -1963,6 +1925,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     // Assert that only one PO line presents
     assertEquals(1, polCount);
 
+    preparePiecesForCompositePo(reqData);
+
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), APPLICATION_JSON, 500);
 
     // Verify inventory GET and POST requests for instance, holding and item records
@@ -1984,10 +1948,12 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     MockServer.addMockTitles(reqData.getCompositePoLines());
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
 
+    preparePiecesForCompositePo(reqData);
+
     final Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData),
       APPLICATION_JSON, 500)
-        .body()
-          .as(Errors.class);
+      .body()
+      .as(Errors.class);
 
     logger.info(JsonObject.mapFrom(errors).encodePrettily());
     assertEquals(2, errors.getErrors().size());
@@ -2016,7 +1982,11 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     }
 
     // Set location ids to one which emulates item creation failure
-    reqData.getCompositePoLines().get(1).getLocations().forEach(location -> location.setLocationId(ID_FOR_INTERNAL_SERVER_ERROR));
+    reqData.getCompositePoLines().get(1).getLocations().forEach(location -> location.withLocationId(ID_FOR_INTERNAL_SERVER_ERROR));
+
+    reqData.getCompositePoLines().get(1).getLocations().get(0).setLocationId(UUID.randomUUID().toString());
+
+    preparePiecesForCompositePo(reqData);
 
     String path = String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId());
 
@@ -2046,9 +2016,28 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     verifyInstanceLinksNotCreatedForPoLine();
 
     // Verify pieces were created
-    assertEquals(calculateTotalQuantity(reqData.getCompositePoLines().get(0)), createdPieces.size());
+    assertEquals(calculateTotalQuantity(reqData.getCompositePoLines().get(0))
+      + calculateTotalQuantity(reqData.getCompositePoLines().get(1)) - 1, createdPieces.size());
 
-    verifyPiecesCreated(items, reqData.getCompositePoLines().subList(0, 1), createdPieces);
+    // Effectively remove non-processed locations with ID_FOR_INTERNAL_SERVER_ERROR to exclude them from
+    // created pieces verification
+    reqData.getCompositePoLines().forEach(poLine -> {
+      poLine.getLocations().removeIf(l -> {
+        if (l.getLocationId().equals(ID_FOR_INTERNAL_SERVER_ERROR)) {
+          if (poLine.getCost().getQuantityElectronic() != null) {
+            poLine.getCost().setQuantityElectronic(poLine.getCost().getQuantityElectronic() - l.getQuantityElectronic());
+          }
+          if (poLine.getCost().getQuantityPhysical() != null) {
+            poLine.getCost().setQuantityPhysical(poLine.getCost().getQuantityPhysical() - l.getQuantityPhysical());
+          }
+          return true;
+        } else {
+          return false;
+        }
+      });
+    });
+
+    verifyPiecesCreated(items, reqData.getCompositePoLines(), createdPieces);
   }
 
   private void verifyInstanceLinksNotCreatedForPoLine() {
@@ -2380,6 +2369,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     reqData.setVendor(INACTIVE_VENDOR_ID);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.PENDING);
+    preparePiecesForCompositePo(reqData);
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), EMPTY, 204);
 
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
@@ -2469,7 +2459,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
 
     Errors errors = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()),
-        JsonObject.mapFrom(reqData), EMPTY, 422).as(Errors.class);
+      JsonObject.mapFrom(reqData), EMPTY, 422).as(Errors.class);
 
     assertThat(errors.getErrors(), hasSize(1));
 
@@ -2719,7 +2709,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
       .toString());
     allProtectedFieldsModification.put(POProtectedFields.VENDOR.getFieldName(), "d1b79c8d-4950-482f-8e42-04f9aae3cb40");
     allProtectedFieldsModification.put(POProtectedFields.ORDER_TYPE.getFieldName(),
-        CompositePurchaseOrder.OrderType.ONGOING.value());
+      CompositePurchaseOrder.OrderType.ONGOING.value());
     Ongoing ongoing = new Ongoing();
     ongoing.setManualRenewal(true);
     allProtectedFieldsModification.put(POProtectedFields.ONGOING.getFieldName(), JsonObject.mapFrom(ongoing));
@@ -2755,11 +2745,11 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
 
     allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineProtectedFields.CHECKIN_ITEMS.getFieldName()), true);
     allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineProtectedFields.ACQUISITION_METHOD.getFieldName()),
-        "Depository");
+      "Depository");
     allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineProtectedFields.COST_ADDITIONAL_COST.getFieldName()),
-        10.32);
+      10.32);
     allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineProtectedFields.ERESOURCE_USER_LIMIT.getFieldName()),
-        100);
+      100);
 
     checkPreventProtectedFieldsModificationRule(COMPOSITE_ORDERS_BY_ID_PATH, reqData, allProtectedFieldsModification);
   }
@@ -2781,7 +2771,7 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
       .toString());
     allProtectedFieldsModification.put(POProtectedFields.VENDOR.getFieldName(), "d1b79c8d-4950-482f-8e42-04f9aae3cb40");
     allProtectedFieldsModification.put(POProtectedFields.ORDER_TYPE.getFieldName(),
-        CompositePurchaseOrder.OrderType.ONE_TIME.value());
+      CompositePurchaseOrder.OrderType.ONE_TIME.value());
     allProtectedFieldsModification.put(POProtectedFields.ONGOING.getFieldName(), null);
     CloseReason closeReason = new CloseReason();
     closeReason.setNote("testing reason on Closed Order");
@@ -2989,9 +2979,9 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 400);
 
     Error err = resp.getBody()
-        .as(Errors.class)
-        .getErrors()
-        .get(0);
+      .as(Errors.class)
+      .getErrors()
+      .get(0);
 
     assertThat(err.getMessage(), equalTo(ISBN_NOT_VALID.getDescription()));
     assertThat(err.getCode(), equalTo(ISBN_NOT_VALID.getCode()));
@@ -3026,9 +3016,9 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     Response resp = verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData), APPLICATION_JSON, 400);
 
     Error err = resp.getBody()
-        .as(Errors.class)
-        .getErrors()
-        .get(0);
+      .as(Errors.class)
+      .getErrors()
+      .get(0);
 
 
     assertThat(err.getMessage(), equalTo(ISBN_NOT_VALID.getDescription()));
@@ -3065,9 +3055,9 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_1, X_OKAPI_USER_ID), APPLICATION_JSON, 403);
 
     Error err = resp.getBody()
-        .as(Errors.class)
-        .getErrors()
-        .get(0);
+      .as(Errors.class)
+      .getErrors()
+      .get(0);
 
     assertThat(err.getCode(), equalTo(ErrorCodes.USER_HAS_NO_APPROVAL_PERMISSIONS.getCode()));
   }
@@ -3085,9 +3075,9 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_1, X_OKAPI_USER_ID, APPROVAL_PERMISSIONS_HEADER), APPLICATION_JSON, 400);
 
     Error err = resp.getBody()
-        .as(Errors.class)
-        .getErrors()
-        .get(0);
+      .as(Errors.class)
+      .getErrors()
+      .get(0);
 
     assertThat(err.getCode(), equalTo(ErrorCodes.APPROVAL_REQUIRED_TO_OPEN.getCode()));
   }
@@ -3105,8 +3095,8 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     assertThat(pendingData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.PENDING));
 
     CompositePurchaseOrder responseData = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(pendingData)
-      .encodePrettily(), prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_1, X_OKAPI_USER_ID, APPROVAL_PERMISSIONS_HEADER),
-        APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+        .encodePrettily(), prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_1, X_OKAPI_USER_ID, APPROVAL_PERMISSIONS_HEADER),
+      APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
     assertThat(responseData.getApprovalDate(), notNullValue());
     assertThat(responseData.getApprovedById(), notNullValue());
@@ -3116,18 +3106,18 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     // -- test config set to "isApprovalRequired":false, approval details are not set when order is approved in PENDING state
 
     CompositePurchaseOrder reqData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, PO_ID_PENDING_STATUS_WITHOUT_PO_LINES)
-        .mapTo(CompositePurchaseOrder.class);
+      .mapTo(CompositePurchaseOrder.class);
     reqData.setVendor(ACTIVE_VENDOR_ID);
     reqData.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.PENDING);
-      assertThat(reqData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.PENDING));
+    assertThat(reqData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.PENDING));
 
-      CompositePurchaseOrder respData = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData)
+    CompositePurchaseOrder respData = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData)
         .encodePrettily(), prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID, APPROVAL_PERMISSIONS_HEADER),
-          APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
-      assertThat(respData.getApprovalDate(), nullValue());
-      assertThat(respData.getApprovedById(), nullValue());
-      assertThat(respData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.PENDING));
+    assertThat(respData.getApprovalDate(), nullValue());
+    assertThat(respData.getApprovedById(), nullValue());
+    assertThat(respData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.PENDING));
   }
 
 
@@ -3142,10 +3132,10 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     assertThat(reqData.getWorkflowStatus(), is(CompositePurchaseOrder.WorkflowStatus.OPEN));
 
     CompositePurchaseOrder respData = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).encodePrettily(),
-        prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
 
-      assertThat(respData.getApprovalDate(), notNullValue());
-      assertThat(respData.getApprovedById(), notNullValue());
+    assertThat(respData.getApprovalDate(), notNullValue());
+    assertThat(respData.getApprovedById(), notNullValue());
   }
 
   @Test
@@ -3402,5 +3392,15 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
     order.put("workflowStatus", "Pending");
 
     return order;
+  }
+
+  private void preparePiecesForCompositePo(CompositePurchaseOrder reqData) {
+    reqData.getCompositePoLines().forEach(poLine -> {
+      poLine.getLocations().forEach(location -> {
+        for (int i = 0; i < location.getQuantity(); i++) {
+          addMockEntry(PIECES, new Piece().withPoLineId(poLine.getId()).withLocationId(location.getLocationId()).withFormat(Piece.Format.OTHER).withReceivingStatus(Piece.ReceivingStatus.EXPECTED));
+        }
+      });
+    });
   }
 }

--- a/src/test/resources/mockdata/itemRequests/itemRequests.json
+++ b/src/test/resources/mockdata/itemRequests/itemRequests.json
@@ -1,0 +1,43 @@
+{
+  "requests": [
+    {
+      "id": "89105c06-dbdb-4aa0-9695-d4d19c733270",
+      "requestType": "Recall",
+      "requestDate": "2017-07-29T22:25:37Z",
+      "requesterId": "21932a85-bd00-446b-9565-46e0c1a5490b",
+      "itemId": "522a501a-56b5-48d9-b28a-3a8f02482d97",
+      "fulfilmentPreference": "Hold Shelf",
+      "position": 1
+    },
+    {
+      "id": "f5cec279-0da6-4b44-a3df-f49b0903f325",
+      "requestType": "Hold",
+      "requestDate": "2017-08-05T11:43:23Z",
+      "requesterId": "61d939e4-f2ae-4c53-95d2-224a802fa2a6",
+      "itemId": "3e5d5433-a271-499c-94f4-5f3e4652e537",
+      "fulfilmentPreference": "Delivery",
+      "requestExpirationDate": "2017-08-31T22:25:37Z",
+      "holdShelfExpirationDate": "2017-09-01T22:25:37Z",
+      "position": 1,
+      "item": {
+        "status": "Checked out",
+        "title": "Children of Time",
+        "barcode": "760932543816",
+        "copyNumber": "cp2"
+      },
+      "requester": {
+        "firstName": "Stephen",
+        "lastName": "Jones",
+        "middleName": "Anthony",
+        "barcode": "567023127436"
+      },
+      "tags": {
+        "tagList": [
+          "new",
+          "important"
+        ]
+      }
+    }
+  ],
+  "totalRecords": 2
+}

--- a/src/test/resources/mockdata/itemsRecords/inventoryItemsCollection.json
+++ b/src/test/resources/mockdata/itemsRecords/inventoryItemsCollection.json
@@ -1,6 +1,44 @@
 {
   "items": [
     {
+      "id": "522a501a-56b5-48d9-b28a-3a8f02482d97",
+      "status": {
+        "name": "On order"
+      },
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "hrid": "it00000252",
+      "formerIds": [],
+      "discoverySuppress": null,
+      "holdingsRecordId": "26b512a8-80b5-45a9-be13-e3b0f3cfde7f",
+      "notes": [],
+      "circulationNotes": [],
+      "yearCaption": [],
+      "electronicAccess": [],
+      "statisticalCodeIds": [],
+      "purchaseOrderLineIdentifier": "0dd8f1d2-ac2e-4155-a407-72071f6d5f4a",
+      "materialType": {
+        "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "name": "book"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "metadata": {
+        "createdDate": "2019-02-20T19:49:44.672+0000",
+        "createdByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb",
+        "updatedDate": "2019-02-20T19:49:44.672+0000",
+        "updatedByUserId": "a6ff14ad-8a65-57f9-bb89-f4654a3923fb"
+      },
+      "links": {
+        "self": "http://10.0.2.15:9130/inventory/items/98eba19f-11c6-4a45-b4c0-0b9f30148f22"
+      },
+      "effectiveLocation": {
+        "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+        "name": "Main Library"
+      }
+    },
+    {
       "id": "98eba19f-11c6-4a45-b4c0-0b9f30148f22",
       "status": {
         "name": "On order"


### PR DESCRIPTION
[MODORDERS-335](https://issues.folio.org/browse/MODORDERS-335) - Edit quantity when Order is re-opened
## Purpose

When Order is re opened (Order moved from Open to Pending and then to Open), the user is allowed to edit quantity. When the order is re-opened after the edit, 
For PUT Orders call, while Re-Opening an order
- check if there are more pieces than required or the location has been modified, throw an error stating that pieces need to be deleted. 
- Leave the Order in pending state, if there are pieces to be deleted

When the extra pieces are to be deleted 
DELETE /pieces call,
- Delete the corresponding Item, if there are no requests on the item
 -- throw an error if there is an open request, and do not delete the piece or item

## Approach
PUT and DELETE orders were modified.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
