### PR TITLE
[MODORDERS-359] Support "title" and "package" order lines

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -479,6 +479,7 @@
           "pathPattern": "/orders/titles",
           "permissionsRequired": ["orders.titles.item.post"],
           "modulePermissions": [
+            "orders-storage.titles.collection.get",
             "orders-storage.titles.item.post",
             "orders-storage.po-lines.item.get"
           ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -466,7 +466,7 @@
     },
     {
       "id": "titles",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": ["GET"],
@@ -478,7 +478,10 @@
           "methods": ["POST"],
           "pathPattern": "/orders/titles",
           "permissionsRequired": ["orders.titles.item.post"],
-          "modulePermissions": ["orders-storage.titles.item.post"]
+          "modulePermissions": [
+            "orders-storage.titles.item.post",
+            "orders-storage.po-lines.item.get"
+          ]
         },
         {
           "methods": ["GET"],

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -56,6 +56,7 @@ public enum ErrorCodes {
   FUNDS_NOT_FOUND("fundsNotFound", "The fund records are not found"),
   CURRENT_FISCAL_YEAR_NOT_FOUND("currentFYearNotFound", "Current fiscal year not found for ledger"),
   TITLE_NOT_FOUND("titleNotFound", "Associated title not found for non package PO Line"),
+  TITLE_EXIST("titleExist", "The title for poLine already exist"),
   MULTIPLE_NONPACKAGE_TITLES("multipleNonPackageTitles", "Non package PO Line must contain only one title."),
   BUDGET_NOT_FOUND_FOR_TRANSACTION("budgetNotFoundForTransaction", "Budget not found for transaction"),
   LEDGER_NOT_FOUND_FOR_TRANSACTION("ledgerNotFoundForTransaction", "Ledger not found for transaction"),

--- a/src/test/java/org/folio/rest/impl/TitlesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/TitlesApiTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.orders.utils.ResourcePathResolver.PO_LINES;
+import static org.folio.orders.utils.ResourcePathResolver.TITLES;
 import static org.folio.rest.impl.MockServer.TITLES_MOCK_DATA_PATH;
 import static org.folio.rest.impl.MockServer.addMockEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -15,6 +16,7 @@ import org.folio.HttpStatus;
 import org.folio.rest.acq.model.Title;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Details;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.TitleCollection;
 import org.hamcrest.Matchers;
@@ -39,7 +41,13 @@ public class TitlesApiTest extends ApiTestBase {
   public void testPostTitle() {
     logger.info("=== Test POST Title (Create Title) ===");
 
-    Title postTitleRq = titleJsonReqData.mapTo(Title.class);
+    String poLineId = UUID.randomUUID().toString();
+    CompositePoLine poLine = getMinimalContentCompositePoLine()
+      .withId(poLineId);
+
+    addMockEntry(PO_LINES, JsonObject.mapFrom(poLine));
+
+    Title postTitleRq = titleJsonReqData.mapTo(Title.class).withPoLineId(poLineId);
 
     // Positive cases
     // Title id is null initially
@@ -61,6 +69,15 @@ public class TitlesApiTest extends ApiTestBase {
     int status500 = HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt();
     verifyPostResponse(TITLES_ENDPOINT, JsonObject.mapFrom(postTitleRq).encode(), prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID,
       new Header(X_ECHO_STATUS, String.valueOf(status500))), APPLICATION_JSON, status500);
+
+    addMockEntry(TITLES, JsonObject.mapFrom(postTitleRs));
+
+    Errors errors = verifyPostResponse(TITLES_ENDPOINT, JsonObject.mapFrom(postTitleRq).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON,
+      HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(
+      Errors.class);
+
+    assertEquals(errors.getErrors().get(0).getCode(), "titleExist");
   }
 
   @Test
@@ -84,45 +101,6 @@ public class TitlesApiTest extends ApiTestBase {
       .withPoLineId(packagePoLineId);
 
     addMockEntry(PO_LINES, JsonObject.mapFrom(packagePoLine));
-
-    Title titleWithPackagePoLineRS = verifyPostResponse(TITLES_ENDPOINT, JsonObject.mapFrom(titleWithPackagePoLineRQ).encode(),
-      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, HttpStatus.HTTP_CREATED.toInt()).as(Title.class);
-
-    assertEquals(titleWithPackagePoLineRS.getPackageName(), packageTitleName);
-    assertEquals(titleWithPackagePoLineRS.getExpectedReceiptDate(), packageExpectedDate);
-    assertEquals(titleWithPackagePoLineRS.getPoLineNumber(), packageTestNumber);
-    assertEquals(titleWithPackagePoLineRS.getReceivingNote(), packageNote);
-  }
-
-  @Test
-  public void titleShouldBePopulatedFromPackagePoLineIfPackagePoLineIdExist() {
-
-    String packagePoLineId = UUID.randomUUID().toString();
-    String packageTitleName = "test title name";
-    String packageTestNumber = "test number";
-    Date packageExpectedDate = new Date();
-    String packageNote = "test note";
-
-
-    String secondPoLineId = UUID.randomUUID().toString();
-
-    CompositePoLine packagePoLine = getMinimalContentCompositePoLine()
-      .withId(packagePoLineId)
-      .withTitleOrPackage(packageTitleName)
-      .withPoLineNumber(packageTestNumber)
-      .withPhysical(new Physical().withExpectedReceiptDate(packageExpectedDate))
-      .withDetails(new Details().withReceivingNote(packageNote))
-      .withIsPackage(true);
-
-    CompositePoLine poLineWithPackagePoLineId = getMinimalContentCompositePoLine()
-      .withId(secondPoLineId)
-      .withPackagePoLineId(packagePoLineId);
-
-    Title titleWithPackagePoLineRQ = titleJsonReqData.mapTo(Title.class)
-      .withPoLineId(secondPoLineId);
-
-    addMockEntry(PO_LINES, JsonObject.mapFrom(packagePoLine));
-    addMockEntry(PO_LINES, JsonObject.mapFrom(poLineWithPackagePoLineId));
 
     Title titleWithPackagePoLineRS = verifyPostResponse(TITLES_ENDPOINT, JsonObject.mapFrom(titleWithPackagePoLineRQ).encode(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, HttpStatus.HTTP_CREATED.toInt()).as(Title.class);


### PR DESCRIPTION
## Purpose
[MODORDERS-359](https://issues.folio.org/browse/MODORDERS-359)
There's a new requirement that we support the ability for a poLine to represent a single title, that's part of a package represented by another POL.
Upon title creation copy over information from POL -> Title for new fields poLineNumber, receivingNote and expectedReceiptDate
## Approach
- Title population has been extended based on described business logic
- Tests has been updated
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
