### PR TITLE
MODORDERS-435 unable to open order that references Funds from different ledgers

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -63,11 +63,11 @@ import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.helper.AbstractHelper;
 import org.folio.orders.rest.exceptions.HttpException;
 import org.folio.rest.acq.model.Piece;
 import org.folio.rest.acq.model.PieceCollection;
 import org.folio.rest.client.ConfigurationsClient;
-import org.folio.helper.AbstractHelper;
 import org.folio.rest.jaxrs.model.Alert;
 import org.folio.rest.jaxrs.model.CloseReason;
 import org.folio.rest.jaxrs.model.CompositePoLine;
@@ -114,7 +114,7 @@ public class HelperUtils {
   public static final String DEFAULT_POLINE_LIMIT = "1";
   public static final String REASON_COMPLETE = "Complete";
   private static final String MAX_POLINE_LIMIT = "500";
-  public static final String OKAPI_URL = "X-Okapi-Url";
+  public static final String OKAPI_URL = "x-okapi-url";
   private static final String PO_LINES_LIMIT_PROPERTY = "poLines-limit";
   public static final String LANG = "lang";
   public static final String URL_WITH_LANG_PARAM = "%s?" + LANG + "=%s";
@@ -691,7 +691,7 @@ public class HelperUtils {
    * @return resulting objects
    */
   public static <T> CompletableFuture<List<T>> collectResultsOnSuccess(List<CompletableFuture<T>> futures) {
-    return VertxCompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
        .thenApply(v -> futures
          .stream()
          // The CompletableFuture::join can be safely used because the `allOf` guaranties success at this step
@@ -1002,8 +1002,9 @@ public class HelperUtils {
     // Update receipt date and receipt status
     if (status == FULLY_RECEIVED) {
       poLine.setReceiptDate(new Date());
-    } else if (poLine.getCheckinItems() && poLine.getReceiptStatus()
-      .equals(ReceiptStatus.AWAITING_RECEIPT) && status == ReceiptStatus.PARTIALLY_RECEIVED) {
+    } else if (Boolean.TRUE.equals(poLine.getCheckinItems())
+            && poLine.getReceiptStatus() == ReceiptStatus.AWAITING_RECEIPT
+            && status == ReceiptStatus.PARTIALLY_RECEIVED) {
       // if checking in, set the receipt date only for the first piece
       poLine.setReceiptDate(new Date());
     } else {

--- a/src/test/resources/mockdata/configurations.entries/ordertest.json
+++ b/src/test/resources/mockdata/configurations.entries/ordertest.json
@@ -1,0 +1,17 @@
+{
+  "configs": [
+    {
+      "id" : "582ac200-1793-4015-ad80-4dc4b2a1ea82",
+      "module" : "ORG",
+      "configName" : "localeSettings",
+      "enabled" : true,
+      "value" : "{\"locale\":\"en-US\",\"timezone\":\"UTC\",\"currency\":\"USD\"}"
+    }
+  ],
+  "totalRecords": 1,
+  "resultInfo": {
+    "totalRecords": 1,
+    "facets": [],
+    "diagnostics": []
+  }
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-435](https://issues.folio.org/browse/MODORDERS-435)

## Approach
Send only relevant budgets for verification to the `checkEnoughMoneyInBudgets` method


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
