### PR TITLE
MODORDERS-430: Can't Unopen order - error response 2

### DIFF
--- a/src/main/java/org/folio/helper/FinanceHelper.java
+++ b/src/main/java/org/folio/helper/FinanceHelper.java
@@ -213,10 +213,14 @@ public class FinanceHelper extends AbstractHelper {
   }
 
   public CompletableFuture<Void> updateOrderTransactionSummary(String orderId, int number) {
-    OrderTransactionSummary summary = new OrderTransactionSummary()
-      .withId(orderId)
-      .withNumTransactions(number);
-    return handleUpdateRequest(resourceByIdPath(ORDER_TRANSACTION_SUMMARIES, orderId), summary);
+    if (number > 0) {
+      OrderTransactionSummary summary = new OrderTransactionSummary()
+          .withId(orderId)
+          .withNumTransactions(number);
+      return handleUpdateRequest(resourceByIdPath(ORDER_TRANSACTION_SUMMARIES, orderId), summary);
+    } else {
+      return CompletableFuture.completedFuture(null);
+    }
   }
 
   public CompletableFuture<List<EncumbranceRelationsHolder>> prepareEncumbrances(List<EncumbranceRelationsHolder> encumbranceHolders) {

--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -630,14 +630,8 @@ public class PurchaseOrderHelper extends AbstractHelper {
     updateAndGetOrderWithLines(compPO)
       .thenCompose(compositePO -> financeHelper.getOrderEncumbrances(compPO.getId()))
       .thenApply(financeHelper::makeEncumbrancesPending)
-      .thenCompose(encumbrances -> {
-        if (encumbrances.size() > 0) {
-          return financeHelper.updateOrderTransactionSummary(compPO.getId(), encumbrances.size())
-              .thenApply(v -> encumbrances);
-        } else {
-          return CompletableFuture.completedFuture(encumbrances);
-        }
-      })
+      .thenCompose(encumbrances -> financeHelper.updateOrderTransactionSummary(compPO.getId(), encumbrances.size())
+                                                .thenApply(v -> encumbrances))
       .thenCompose(financeHelper::updateTransactions)
       .thenAccept(ok -> orderLineHelper.makePoLinesPending(compPO.getCompositePoLines()))
       .thenCompose(ok -> orderLineHelper.updatePoLinesSummary(compPO.getCompositePoLines()))

--- a/src/test/java/org/folio/helper/FinanceHelperTest.java
+++ b/src/test/java/org/folio/helper/FinanceHelperTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -441,6 +442,34 @@ public class FinanceHelperTest extends ApiTestBase {
         .join();
       assertNotNull(budget);
     });
+  }
+
+  @Test
+  public void testShouldNotTransactionsCreatedWhenNoEncumbrances() {
+    //Given
+    FinanceHelper financeHelper = spy(new FinanceHelper(httpClient, okapiHeadersMock, ctxMock, "en", transactionService));
+    CompositePurchaseOrder order = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
+    CompositePoLine line = order.getCompositePoLines().get(0);
+    List<Transaction> emptyEncumbrances = Collections.emptyList();
+    //When
+    financeHelper.updateOrderTransactionSummary(order.getId(), emptyEncumbrances.size());
+    //Then
+    assertNull(transactionService.getOrderTransactionSummary(order.getId()));
+  }
+
+  @Test
+  public void testShouldTransactionsCreatedForEncumbrances() {
+    //Given
+    FinanceHelper financeHelper = spy(new FinanceHelper(httpClient, okapiHeadersMock, ctxMock, "en", transactionService));
+    CompositePurchaseOrder order = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
+    CompositePoLine line = order.getCompositePoLines().get(0);
+    Transaction encumbrance = getMockAsJson(ENCUMBRANCE_PATH).getJsonArray( "transactions").getJsonObject(0).mapTo(Transaction.class);
+    FundDistribution fundDistribution = order.getCompositePoLines().get(0).getFundDistribution().get(0);
+    financeHelper.updateEncumbrance(fundDistribution, line, encumbrance);
+    //When
+    financeHelper.updateOrderTransactionSummary(order.getId(), 1);
+    //Then
+    assertNull(transactionService.getOrderTransactionSummary(order.getId()));
   }
 
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
[MODORDERS-430](https://issues.folio.org/browse/MODORDERS-430)
User gets error response when clicks Unopen button for opened order with PO line without any fund distribution added.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
Number of order transactions have to be greater than 0
Add additional checking of amount of pending encumbrances to avoid transaction creating when there are no encumbrances at all. 
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
