### PR TITLE
MODORDERS-391 Release all encumbrances when order is closed

### DIFF
--- a/src/main/java/org/folio/orders/utils/OrderStatusTransitionUtil.java
+++ b/src/main/java/org/folio/orders/utils/OrderStatusTransitionUtil.java
@@ -34,4 +34,8 @@ public final class OrderStatusTransitionUtil {
   public static boolean isTransitionToPending(CompositePurchaseOrder poFromStorage, CompositePurchaseOrder compPO) {
     return poFromStorage.getWorkflowStatus() == OPEN && compPO.getWorkflowStatus() == PENDING;
   }
+
+  public static boolean isTransitionToClosed(CompositePurchaseOrder poFromStorage, CompositePurchaseOrder compPO) {
+    return poFromStorage.getWorkflowStatus() == OPEN && compPO.getWorkflowStatus() == CLOSED;
+  }
 }

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -110,6 +110,7 @@ public class ApiTestBase {
   protected static final String PO_ID_PENDING_STATUS_WITH_PO_LINES = "e5ae4afd-3fa9-494e-a972-f541df9b877e";
   protected static final String PO_ID_PENDING_STATUS_WITHOUT_PO_LINES = "50fb922c-3fa9-494e-a972-f2801f1b9fd1";
   protected static final String PO_ID_OPEN_STATUS = "c1465131-ed35-4308-872c-d7cdf0afc5f7";
+  protected static final String PO_WFD_ID_OPEN_STATUS = "a1465131-ed35-4308-872c-d7cdf0afc5f7";
   protected static final String PO_ID_CLOSED_STATUS = "07f65192-44a4-483d-97aa-b137bbd96390";
   protected static final String PO_ID_OPEN_TO_BE_CLOSED = "9d56b621-202d-414b-9e7f-5fefe4422ab3";
   static final String PO_LINE_ID_FOR_SUCCESS_CASE = "fca5fa9e-15cb-4a3d-ab09-eeea99b97a47";

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -2976,6 +2976,22 @@ public class PurchaseOrdersApiTest extends ApiTestBase {
   }
 
   @Test
+  public void testUpdateOrderCloseOrderWithCloseReasonAndFundDistribution() {
+    logger.info("=== Test case: Able to Close Order with close Reason and fund distribution ===");
+
+    JsonObject reqData = getMockAsJson(COMP_ORDER_MOCK_DATA_PATH, PO_WFD_ID_OPEN_STATUS);
+    assertThat(reqData.getString("workflowStatus"), is(CompositePurchaseOrder.WorkflowStatus.OPEN.value()));
+    reqData.put("workflowStatus", "Closed");
+    // close reason must not be checked if the Order is in OPEN status in storage
+    CloseReason closeReason = new CloseReason();
+    closeReason.setNote("can set close reason");
+    closeReason.setReason("Complete");
+    reqData.put("closeReason", JsonObject.mapFrom(closeReason));
+
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getString("id")), JsonObject.mapFrom(reqData), "", 204);
+  }
+
+  @Test
   public void testUpdateOrderWithLineProtectedFieldsChanging() {
     logger.info("=== Test case when OPEN order errors if protected fields are changed in CompositePoLine===");
 

--- a/src/test/resources/mockdata/compositeOrders/a1465131-ed35-4308-872c-d7cdf0afc5f7.json
+++ b/src/test/resources/mockdata/compositeOrders/a1465131-ed35-4308-872c-d7cdf0afc5f7.json
@@ -1,0 +1,55 @@
+{
+  "id": "a1465131-ed35-4308-872c-d7cdf0afc5f7",
+  "approved": false,
+  "notes": [],
+  "manualPo": false,
+  "poNumber": "268s879",
+  "orderType": "One-Time",
+  "reEncumber": false,
+  "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflowStatus": "Open",
+  "compositePoLines": [
+    {
+      "id": "ed97366a-7f11-4bdc-bc2d-cedc496e2a6e",
+      "acquisitionMethod": "Purchase At Vendor System",
+      "collection": false,
+      "description": "ABCDEFGH",
+      "details": {
+        "productIds": [
+          {
+            "productId": "9781118416068",
+            "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422"
+          }
+        ]
+      },
+      "eresource": {
+        "createInventory": "None"
+      },
+      "poLineDescription": "PO Line description",
+      "poLineNumber": "268s879-1",
+      "orderFormat": "Electronic Resource",
+      "cost": {
+        "listUnitPriceElectronic": 0,
+        "currency": "USD",
+        "quantityElectronic": 1
+      },
+      "fundDistribution": [
+        {
+          "distributionType": "percentage",
+          "code": "AFRICAHIST",
+          "fundId": "a89eccf0-57a6-495e-898d-32b9b2210f2f",
+          "value": 100
+        }
+      ],
+      "purchaseOrderId": "a1465131-ed35-4308-872c-d7cdf0afc5f7",
+      "rush": false,
+      "source": "User",
+      "titleOrPackage": "Kayak Fishing in the Northern Gulf Coast",
+      "isPackage": false
+    }
+  ],
+  "metadata": {
+    "createdDate": "2014-07-06T00:00:00.000",
+    "createdByUserId": "28d10cfc-d137-11e8-a8d5-f2801f1b9fd1"
+  }
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-391](https://issues.folio.org/browse/MODORDERS-391)
Release all encumbrances when order is closed
## Approach
- Add logic to release all encumbrances after Close order
- Add test
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
