### PR TITLE
[MODORDERS-471] Allowable encumbrance restriction should be based on total funding

### DIFF
--- a/src/test/java/org/folio/service/finance/BudgetRestrictionServiceTest.java
+++ b/src/test/java/org/folio/service/finance/BudgetRestrictionServiceTest.java
@@ -1,0 +1,55 @@
+package org.folio.service.finance;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import javax.money.CurrencyUnit;
+import javax.money.Monetary;
+import javax.money.MonetaryAmount;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.folio.rest.acq.model.finance.Budget;
+
+public class BudgetRestrictionServiceTest {
+
+  @InjectMocks
+  private BudgetRestrictionService restrictionService;
+
+  private final String fundId = UUID.randomUUID().toString();
+  private final String fiscalYearId = UUID.randomUUID().toString();
+  private Budget budget;
+  private final CurrencyUnit currency = Monetary.getCurrency("USD");
+
+  @BeforeEach
+  public void initMocks(){
+    MockitoAnnotations.openMocks(this);
+
+    budget = new Budget()
+      .withFiscalYearId(fiscalYearId)
+      .withAwaitingPayment(0d)
+      .withAllocated(100d)
+      .withAvailable(100d)
+      .withEncumbered(0d)
+      .withUnavailable(0d)
+      .withFundId(fundId);
+  }
+
+  @Test
+  void testGetBudgetRemainingAmountForEncumbrance() {
+    budget.withNetTransfers(20d)
+      .withAllowableEncumbrance(110d)
+      .withEncumbered(10d)
+      .withAwaitingPayment(11d)
+      .withExpenditures(90d)
+      .withAvailable(21d) // should not be used
+      .withUnavailable(22d); // should not be used
+    MonetaryAmount amount = restrictionService.getBudgetRemainingAmountForEncumbrance(budget, currency);
+    assertThat(amount.getNumber().doubleValue(), is(21d));
+  }
+
+}


### PR DESCRIPTION

## Purpose
[MODORDERS-471](https://issues.folio.org/browse/MODORDERS-471)

## Approach
- Updated BudgetRestrictionService to use totalFunding instead of allocated.
- Added a test in BudgetRestrictionServiceTest.

@folio-org/acquisitions

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
