### PR TITLE
MODORDERS-512 Update circulation interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -876,7 +876,7 @@
     },
     {
       "id": "circulation",
-      "version": "10.0"
+      "version": "10.0 11.0"
     },
     {
       "id": "finance-storage.budget-expense-classes",


### PR DESCRIPTION
Resolves [MODORDERS-512](https://issues.folio.org/browse/MODORDERS-512).

### Purpose
There is a breaking change in `mod-circulaion` that will be merge soon. Modules that have a dependency on `circulation` interface need to be updated to support version `11.0`.

### Warning
There are multiple PRs with `circulation` interface version update, they all should be merged on the same day. 
**DO NOT MERGE** this PR until then.