### PR TITLE
MODORDERS-511 Do not allow changing the quantity or location of the P…

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -5,11 +5,10 @@ import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.collections15.CollectionUtils.isEqualCollection;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.folio.orders.utils.ErrorCodes.PIECES_TO_BE_CREATED;
-import static org.folio.orders.utils.ErrorCodes.PIECES_TO_BE_DELETED;
+import static org.folio.orders.utils.ErrorCodes.LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN;
 import static org.folio.orders.utils.HelperUtils.URL_WITH_LANG_PARAM;
 import static org.folio.orders.utils.HelperUtils.calculateEstimatedPrice;
 import static org.folio.orders.utils.HelperUtils.calculateTotalLocationQuantity;
@@ -21,8 +20,6 @@ import static org.folio.orders.utils.HelperUtils.getPoLineLimit;
 import static org.folio.orders.utils.HelperUtils.getPurchaseOrderById;
 import static org.folio.orders.utils.HelperUtils.handleGetRequest;
 import static org.folio.orders.utils.HelperUtils.inventoryUpdateNotRequired;
-import static org.folio.orders.utils.HelperUtils.numOfLocationsByPoLineIdAndLocationId;
-import static org.folio.orders.utils.HelperUtils.numOfPiecesByPoLineAndLocationId;
 import static org.folio.orders.utils.HelperUtils.operateOnObject;
 import static org.folio.orders.utils.HelperUtils.verifyProtectedFieldsChanged;
 import static org.folio.orders.utils.ProtectedOperationType.DELETE;
@@ -40,12 +37,10 @@ import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.P
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -406,14 +401,14 @@ public class PurchaseOrderLineHelper extends AbstractHelper {
             validatePOLineProtectedFieldsChanged(compOrderLine, lineFromStorage, compOrder);
             updateLocationsQuantity(compOrderLine.getLocations());
             updateEstimatedPrice(compOrderLine);
+            checkLocationCanBeModified(compOrderLine, lineFromStorage.mapTo(PoLine.class), compOrder);
 
-            return checkLocationsAndPiecesConsistency(compOrderLine, lineFromStorage.mapTo(PoLine.class), compOrder, requestContext)
-              .thenCompose(vVoid -> protectionService.isOperationRestricted(compOrder.getAcqUnitIds(), UPDATE, requestContext)
+            return protectionService.isOperationRestricted(compOrder.getAcqUnitIds(), UPDATE, requestContext)
                 .thenCompose(v -> validateAndNormalizeISBN(compOrderLine, requestContext))
                 .thenCompose(v -> validateAccessProviders(compOrderLine))
                 .thenCompose(v -> expenseClassValidationService.validateExpenseClassesForOpenedOrder(compOrder, Collections.singletonList(compOrderLine), requestContext))
                 .thenCompose(v -> processOpenedPoLine(compOrder, compOrderLine, lineFromStorage))
-                .thenApply(v -> lineFromStorage));
+                .thenApply(v -> lineFromStorage);
           }))
         .thenCompose(lineFromStorage -> {
           // override PO line number in the request with one from the storage, because it's not allowed to change it during PO line
@@ -985,70 +980,14 @@ public class PurchaseOrderLineHelper extends AbstractHelper {
     return Objects.equals(productId.getProductIdType(), isbnTypeId);
   }
 
-  private CompletableFuture<Void> checkLocationsAndPiecesConsistency(CompositePoLine poLine, PoLine lineFromStorage, CompositePurchaseOrder order,
-                                                                     RequestContext requestContext) {
-      if (isLocationsAndPiecesConsistencyNeedToBeVerified(poLine, order)) {
-      return inventoryManager.getExpectedPiecesByLineId(poLine.getId(), requestContext)
-        .thenCompose(existingExpectedPieces -> verifyLocationAndPieceConsistency(Collections.singletonList(poLine), existingExpectedPieces))
-        .thenCompose(errorCode -> {
-          if (PIECES_TO_BE_DELETED.equals(errorCode)) {
-            throw new HttpException(422, PIECES_TO_BE_DELETED);
-          } else if (PIECES_TO_BE_CREATED.equals(errorCode)){
-            return getTitleForPoLine(poLine)
-              .thenCompose(title -> updateInventory(poLine, lineFromStorage, title.getId(), false, requestContext));
-          }
-          return CompletableFuture.completedFuture(null);
-        });
+  private void checkLocationCanBeModified(CompositePoLine poLine, PoLine lineFromStorage, CompositePurchaseOrder order) {
+    boolean isOrderOpenAndNoNeedToManualAddPiecesForCreationAndLocationModified = order.getWorkflowStatus() == OPEN
+      && Boolean.FALSE.equals(poLine.getCheckinItems())
+      && !isEqualCollection(poLine.getLocations(), lineFromStorage.getLocations());
+
+    if (isOrderOpenAndNoNeedToManualAddPiecesForCreationAndLocationModified) {
+      throw new HttpException(400, LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN);
     }
-    return CompletableFuture.completedFuture(null);
   }
 
-  private CompletableFuture<ErrorCodes> verifyLocationAndPieceConsistency(List<CompositePoLine> poLines, PieceCollection pieces) {
-    if (CollectionUtils.isEmpty(poLines)) {
-      return CompletableFuture.completedFuture(null);
-    }
-
-    CompletableFuture<ErrorCodes> future = new CompletableFuture<>();
-
-    Map<String, Map<String, Integer>> numOfLocationsByPoLineIdAndLocationId = numOfLocationsByPoLineIdAndLocationId(poLines);
-    Map<String, Map<String, Integer>> numOfPiecesByPoLineIdAndLocationId = numOfPiecesByPoLineAndLocationId(pieces);
-
-    Set<String> pieceLocations = pieces.getPieces().stream().map(Piece::getLocationId).collect(toSet());
-    Set<String> poexistingPieceLocations = poLines.stream().flatMap(poLine -> poLine.getLocations().stream()).map(Location::getLocationId)
-      .collect(toSet());
-
-    if (!pieceLocations.containsAll(poexistingPieceLocations)) {
-      future.complete(PIECES_TO_BE_CREATED);
-    } else {
-      Set<ErrorCodes> resultErrorCodes = new HashSet<>();
-      numOfPiecesByPoLineIdAndLocationId.forEach((poLineId, numOfPiecesByLocationId) -> numOfPiecesByLocationId
-        .forEach((locationId, quantity) -> {
-
-          Integer numOfPieces = Optional.ofNullable(numOfLocationsByPoLineIdAndLocationId)
-            .map(map -> map.get(poLineId))
-            .map(map -> map.get(locationId))
-            .orElse(0);
-
-          if (quantity > numOfPieces) {
-            resultErrorCodes.add(PIECES_TO_BE_DELETED);
-          } else if (quantity < numOfPieces) {
-            resultErrorCodes.add(PIECES_TO_BE_CREATED);
-          }
-        }));
-
-      if (resultErrorCodes.contains(PIECES_TO_BE_DELETED)) {
-        future.complete(PIECES_TO_BE_DELETED);
-      } else if (resultErrorCodes.contains(PIECES_TO_BE_CREATED)) {
-        future.complete(PIECES_TO_BE_CREATED);
-      } else {
-        future.complete(null);
-      }
-    }
-    return future;
-  }
-
-  private boolean isLocationsAndPiecesConsistencyNeedToBeVerified(CompositePoLine poLine, CompositePurchaseOrder order) {
-    return order.getWorkflowStatus() == OPEN && Boolean.FALSE.equals(poLine.getCheckinItems())
-      && poLine.getReceiptStatus() != ReceiptStatus.RECEIPT_NOT_REQUIRED && Boolean.FALSE.equals(poLine.getIsPackage());
-  }
 }

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -655,17 +655,6 @@ public class PurchaseOrderLineHelper extends AbstractHelper {
       .thenCompose(this::getLineWithInstanceId);
   }
 
-  private CompletableFuture<Title> getTitleForPoLine(CompositePoLine line) {
-    return titlesService.getTitles(1, 0, QUERY_BY_PO_LINE_ID + line.getId(), getRequestContext())
-      .thenCompose(titleCollection -> {
-        List<Title> titles = titleCollection.getTitles();
-        if (!titles.isEmpty()) {
-          return CompletableFuture.completedFuture(titles.get(0));
-        }
-        throw new HttpException(422, ErrorCodes.TITLE_NOT_FOUND);
-      });
-  }
-
   private CompletableFuture<CompositePoLine> getLineWithInstanceId(CompositePoLine line) {
      if (!Boolean.TRUE.equals(line.getIsPackage())) {
        return titlesService.getTitles(1, 0, QUERY_BY_PO_LINE_ID + line.getId(), getRequestContext())

--- a/src/main/java/org/folio/orders/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/orders/utils/ErrorCodes.java
@@ -72,6 +72,7 @@ public enum ErrorCodes {
   SUFFIX_IS_USED("suffixIsUsed", "The suffix cannot be deleted as it is used by one or more orders"),
   PIECES_TO_BE_DELETED("piecesNeedToBeDeleted", "Pieces need to be deleted"),
   PIECES_TO_BE_CREATED("piecesNeedToBeCreated", "Pieces need to be created"),
+  LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN("locationCannotBeModifiedAfterOpen", "Please use the receiving App to update pieces and locations"),
   REQUEST_FOUND("thereAreRequestsOnItem", "There are requests on item"),
   BUDGET_EXPENSE_CLASS_NOT_FOUND("budgetExpenseClassNotFound", "Budget expense class not found"),
   INACTIVE_EXPENSE_CLASS("inactiveExpenseClass", "Expense class is Inactive"),

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
@@ -31,8 +31,11 @@ import static org.folio.TestConstants.PO_LINE_ID_FOR_SUCCESS_CASE;
 import static org.folio.TestConstants.PO_LINE_NUMBER_VALUE;
 import static org.folio.TestConstants.PROTECTED_READ_ONLY_TENANT;
 import static org.folio.TestConstants.X_OKAPI_USER_ID;
+import static org.folio.TestUtils.getMinimalContentCompositePoLine;
 import static org.folio.TestUtils.getMockAsJson;
 import static org.folio.TestUtils.getMockData;
+import static org.folio.TestUtils.validatePoLineCreationErrorForNonPendingOrder;
+import static org.folio.TestUtils.verifyLocationQuantity;
 import static org.folio.orders.utils.ErrorCodes.COST_ADDITIONAL_COST_INVALID;
 import static org.folio.orders.utils.ErrorCodes.COST_DISCOUNT_INVALID;
 import static org.folio.orders.utils.ErrorCodes.COST_UNIT_PRICE_ELECTRONIC_INVALID;
@@ -41,12 +44,12 @@ import static org.folio.orders.utils.ErrorCodes.ELECTRONIC_COST_LOC_QTY_MISMATCH
 import static org.folio.orders.utils.ErrorCodes.INACTIVE_EXPENSE_CLASS;
 import static org.folio.orders.utils.ErrorCodes.INSTANCE_ID_NOT_ALLOWED_FOR_PACKAGE_POLINE;
 import static org.folio.orders.utils.ErrorCodes.ISBN_NOT_VALID;
+import static org.folio.orders.utils.ErrorCodes.LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN;
 import static org.folio.orders.utils.ErrorCodes.NON_ZERO_COST_ELECTRONIC_QTY;
 import static org.folio.orders.utils.ErrorCodes.NON_ZERO_COST_PHYSICAL_QTY;
 import static org.folio.orders.utils.ErrorCodes.ORDER_CLOSED;
 import static org.folio.orders.utils.ErrorCodes.ORDER_OPEN;
 import static org.folio.orders.utils.ErrorCodes.PHYSICAL_COST_LOC_QTY_MISMATCH;
-import static org.folio.orders.utils.ErrorCodes.PIECES_TO_BE_DELETED;
 import static org.folio.orders.utils.ErrorCodes.POL_ACCESS_PROVIDER_IS_INACTIVE;
 import static org.folio.orders.utils.ErrorCodes.POL_LINES_LIMIT_EXCEEDED;
 import static org.folio.orders.utils.ErrorCodes.ZERO_COST_ELECTRONIC_QTY;
@@ -64,9 +67,6 @@ import static org.folio.orders.utils.ResourcePathResolver.PURCHASE_ORDER;
 import static org.folio.orders.utils.ResourcePathResolver.REPORTING_CODES;
 import static org.folio.orders.utils.ResourcePathResolver.TITLES;
 import static org.folio.orders.utils.ResourcePathResolver.TRANSACTIONS_STORAGE_ENDPOINT;
-import static org.folio.TestUtils.getMinimalContentCompositePoLine;
-import static org.folio.TestUtils.validatePoLineCreationErrorForNonPendingOrder;
-import static org.folio.TestUtils.verifyLocationQuantity;
 import static org.folio.rest.impl.MockServer.BASE_MOCK_DATA_PATH;
 import static org.folio.rest.impl.MockServer.ORDER_ID_WITH_PO_LINES;
 import static org.folio.rest.impl.MockServer.PO_NUMBER_ERROR_X_OKAPI_TENANT;
@@ -98,6 +98,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.restassured.response.Response;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -108,8 +111,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -139,10 +140,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import io.restassured.response.Response;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonObject;
 
 public class PurchaseOrderLinesApiTest {
 
@@ -597,7 +594,7 @@ public class PurchaseOrderLinesApiTest {
   }
 
   @Test
-  void testPutOrderLineByIdPiecesWillBeCreated() {
+  void testPutOrderLineByIdPiecesWillNotBeCreated() {
     logger.info("=== Test PUT Order Line By Id - Pieces will be created ===");
 
     String lineId = PO_LINE_ID_FOR_SUCCESS_CASE;
@@ -621,47 +618,10 @@ public class PurchaseOrderLinesApiTest {
     verifyPut(url, JsonObject.mapFrom(body), "", 204);
 
     Map<String, List<JsonObject>> mockServerData = MockServer.serverRqRs.column(HttpMethod.GET);
-    assertThat(mockServerData.get(PIECES), hasSize(3));
+    assertThat(mockServerData.get(PIECES), nullValue());
 
     mockServerData = MockServer.serverRqRs.column(HttpMethod.POST);
-    assertThat(mockServerData.get(PIECES), hasSize(1));
-  }
-
-  @Test
-  void testPutOrderLineByIdPiecesNeedToBeDeleted() {
-    logger.info("=== Test PUT Order Line By Id - Pieces need to be deleted ===");
-
-    String lineId = PO_LINE_ID_FOR_SUCCESS_CASE;
-    CompositePoLine body = getMockAsJson(COMP_PO_LINES_MOCK_DATA_PATH, lineId).mapTo(CompositePoLine.class);
-
-    body.setCheckinItems(false);
-    body.setIsPackage(false);
-    body.setReceiptStatus(ReceiptStatus.AWAITING_RECEIPT);
-    body.setReportingCodes(null);
-    MockServer.addMockEntry(PO_LINES, body);
-    MockServer.addMockEntry(PURCHASE_ORDER, new CompositePurchaseOrder()
-      .withId(ID_FOR_PRINT_MONOGRAPH_ORDER)
-      .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN));
-    String url = String.format(LINE_BY_ID_PATH, lineId);
-
-    // Adding number of pieces more then poLine.location.quantity
-    for (int i = 0; i < 2; i++) {
-      MockServer.addMockEntry(PIECES, new Piece()
-        .withPoLineId(body.getId())
-        .withLocationId(body.getLocations().get(0).getLocationId()));
-    }
-
-    Errors errors = verifyPut(url, JsonObject.mapFrom(body), "", 422).as(Errors.class);
-    assertThat(errors.getErrors().get(0).getCode(), equalTo(PIECES_TO_BE_DELETED.getCode()));
-
-    Map<String, List<JsonObject>> retrieves = MockServer.serverRqRs.column(HttpMethod.GET);
-    assertEquals(3, retrieves.size());
-    assertThat(retrieves, hasKey(PIECES));
-    assertThat(retrieves, hasKey(PO_LINES));
-    assertThat(retrieves, hasKey(PURCHASE_ORDER));
-
-    Map<String, List<JsonObject>> updates = MockServer.serverRqRs.column(HttpMethod.PUT);
-    assertEquals(0, updates.size());
+    assertThat(mockServerData.get(PIECES), nullValue());
   }
 
   @Test
@@ -1293,9 +1253,8 @@ public class PurchaseOrderLinesApiTest {
     reqData.getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_B);
     reqData.getEresource().setCreateInventory(INSTANCE_HOLDING_ITEM);
     reqData.getLocations().get(0).setLocationId("758258bc-ecc1-41b8-abca-f7b610822fff");
-    String pieceId = UUID.randomUUID().toString();
+
     addMockEntry(PIECES, new Piece()
-      .withId(pieceId)
       .withPoLineId(reqData.getId())
       .withLocationId(reqData.getLocations().get(0).getLocationId()));
 
@@ -1304,43 +1263,75 @@ public class PurchaseOrderLinesApiTest {
     String newLocationId = "fcd64ce1-6995-48f0-840e-89ffa2288371";
     reqData.getLocations().get(0).setLocationId(newLocationId);
 
-    verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
-      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 204);
+    Errors response = verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 400).as(Errors.class);
 
-    assertEquals(newLocationId, getRqRsEntries(HttpMethod.PUT, PIECES).get(0).getString("locationId"), "Location updated");
+    assertThat(response.getErrors(), hasSize(1));
+    List<String> errorCodes = response.getErrors()
+      .stream()
+      .map(Error::getCode)
+      .collect(Collectors.toList());
+
+    assertThat(errorCodes, containsInAnyOrder(LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN.getCode()));
   }
 
   @Test
-  void testUpdatePolineForOpenedOrderWithUpdatingInventoryAndCreateNewPieces() {
+  void testUpdatePolineForOpenedOrderWithChangingQuantity() {
+    logger.info("=== Test update poline for opened order with changed quantity ===");
+
     CompositePoLine reqData = getMockAsJson(COMP_PO_LINES_MOCK_DATA_PATH, "c2755a78-2f8d-47d0-a218-059a9b7391b4").mapTo(CompositePoLine.class);
     String poLineId = "c0d08448-347b-418a-8c2f-5fb50248d67e";
     reqData.setId(poLineId);
     reqData.setPurchaseOrderId("9d56b621-202d-414b-9e7f-5fefe4422ab3");
     reqData.getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_B);
     reqData.getEresource().setCreateInventory(INSTANCE_HOLDING_ITEM);
+    reqData.getLocations().get(0).setLocationId("758258bc-ecc1-41b8-abca-f7b610822fff");
 
-    int expQtyElectronic = 3;
-    IntStream.range(0, 2).forEach(i -> {
-      addMockEntry(PIECES, new Piece()
-        .withId(UUID.randomUUID().toString())
-        .withFormat(Piece.Format.ELECTRONIC)
-        .withPoLineId(reqData.getId())
-        .withLocationId(reqData.getLocations().get(0).getLocationId()));
-    });
-
-    reqData.getLocations().get(0).setQuantityElectronic(expQtyElectronic);
-    reqData.getLocations().get(0).setQuantity(expQtyElectronic);
-    reqData.getCost().setQuantityElectronic(expQtyElectronic);
+    addMockEntry(PIECES, new Piece()
+      .withPoLineId(reqData.getId())
+      .withLocationId(reqData.getLocations().get(0).getLocationId()));
 
     addMockEntry(PO_LINES, reqData);
 
+    reqData.getLocations().get(0).setQuantityElectronic(3);
+    reqData.getCost().setQuantityElectronic(3);
+
+    Errors response = verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 400).as(Errors.class);
+
+    assertThat(response.getErrors(), hasSize(1));
+    List<String> errorCodes = response.getErrors()
+      .stream()
+      .map(Error::getCode)
+      .collect(Collectors.toList());
+
+    assertThat(errorCodes, containsInAnyOrder(LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN.getCode()));
+  }
+
+  @Test
+  void testUpdatePolineForOpenedOrderWithChangingQuantityAndCheckinItems() {
+    logger.info("=== Test update poline for opened order with changed quantity and checkin items ===");
+
+    CompositePoLine reqData = getMockAsJson(COMP_PO_LINES_MOCK_DATA_PATH, "c2755a78-2f8d-47d0-a218-059a9b7391b4").mapTo(CompositePoLine.class);
+    String poLineId = "c0d08448-347b-418a-8c2f-5fb50248d67e";
+    reqData.setId(poLineId);
+    reqData.setCheckinItems(true);
+    reqData.setPurchaseOrderId("9d56b621-202d-414b-9e7f-5fefe4422ab3");
+    reqData.getEresource().setAccessProvider(ACTIVE_ACCESS_PROVIDER_B);
+    reqData.getEresource().setCreateInventory(INSTANCE_HOLDING_ITEM);
+    reqData.getLocations().get(0).setLocationId("758258bc-ecc1-41b8-abca-f7b610822fff");
+
+    addMockEntry(PIECES, new Piece()
+      .withPoLineId(reqData.getId())
+      .withLocationId(reqData.getLocations().get(0).getLocationId()));
+
+    addMockEntry(PO_LINES, reqData);
+
+    reqData.getLocations().get(0).setQuantityElectronic(3);
+    reqData.getCost().setQuantityElectronic(3);
+
     verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 204);
-
-    assertEquals(expQtyElectronic, getRqRsEntries(HttpMethod.POST, PIECES).size(), "Location matched");
-    assertEquals(reqData.getLocations().get(0).getLocationId(), getRqRsEntries(HttpMethod.POST, PIECES).get(0).getString("locationId"), "Location matched");
-    assertEquals(poLineId, getRqRsEntries(HttpMethod.POST, PIECES).get(0).getString("poLineId"), "Line id matched");
-    assertEquals("Expected", getRqRsEntries(HttpMethod.POST, PIECES).get(0).getString("receivingStatus"), "Expected status");
   }
 
   @Test
@@ -1363,8 +1354,16 @@ public class PurchaseOrderLinesApiTest {
     reqData.getLocations().get(0).setQuantityElectronic(expQtyElectronic);
     reqData.getLocations().get(0).setQuantity(expQtyElectronic);
     reqData.getCost().setQuantityElectronic(expQtyElectronic);
-    verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
-      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 204);
+    Errors response = verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 400).as(Errors.class);
+
+    assertThat(response.getErrors(), hasSize(1));
+    List<String> errorCodes = response.getErrors()
+      .stream()
+      .map(Error::getCode)
+      .collect(Collectors.toList());
+
+    assertThat(errorCodes, containsInAnyOrder(LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN.getCode()));
 
     assertEquals(0, getRqRsEntries(HttpMethod.POST, TITLES).size(), "Items should not created");
     assertEquals(0, getRqRsEntries(HttpMethod.PUT, TITLES).size(), "Items should not updated");
@@ -1390,9 +1389,16 @@ public class PurchaseOrderLinesApiTest {
     String newLocationId = "fcd64ce1-6995-48f0-840e-89ffa2288371";
     reqData.getLocations().get(0).setLocationId(newLocationId);
 
-    verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
-      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 204);
+    Errors response = verifyPut(String.format(LINE_BY_ID_PATH, reqData.getId()), JsonObject.mapFrom(reqData).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), "", 400).as(Errors.class);
 
+    assertThat(response.getErrors(), hasSize(1));
+    List<String> errorCodes = response.getErrors()
+      .stream()
+      .map(Error::getCode)
+      .collect(Collectors.toList());
+
+    assertThat(errorCodes, containsInAnyOrder(LOCATION_CAN_NOT_BE_MODIFIER_AFTER_OPEN.getCode()));
     assertEquals(0, getRqRsEntries(HttpMethod.PUT, TITLES).size(), "Items should not updated");
   }
 


### PR DESCRIPTION
## Purpose
[MODORDERS-511](https://issues.folio.org/browse/MODORDERS-511)
Do not allow changing the quantity or location of the POL, if the order already opened
## Approach
- Update logic to restrict update location if order is opened
- Add tests
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
