### PR TITLE
MODORDERS-542 Unopen fails after a rollover for an order created in the previous year

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -147,8 +147,11 @@ public class ApplicationConfig {
   }
 
   @Bean
-  EncumbranceWorkflowStrategy openToPendingEncumbranceStrategy(EncumbranceService encumbranceService, TransactionSummariesService transactionSummariesService) {
-    return new OpenToPendingEncumbranceStrategy(encumbranceService, transactionSummariesService);
+  EncumbranceWorkflowStrategy openToPendingEncumbranceStrategy(EncumbranceService encumbranceService,
+      TransactionSummariesService transactionSummariesService,
+      EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder) {
+    return new OpenToPendingEncumbranceStrategy(encumbranceService, transactionSummariesService,
+        encumbranceRelationsHoldersBuilder);
   }
 
   @Bean

--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -230,7 +230,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
         .thenCompose(v -> processPoLineTags(compPO))
         .thenCompose(v -> createPOandPOLines(compPO))
         .thenCompose(this::populateOrderSummary))
-        .thenCompose(compOrder -> encumbranceService.updateEncumbrancesOrderStatus(compOrder.getId(), compOrder.getWorkflowStatus(), getRequestContext())
+        .thenCompose(compOrder -> encumbranceService.updateEncumbrancesOrderStatus(compOrder, getRequestContext())
                 .thenApply(v -> compOrder));
   }
 
@@ -327,7 +327,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
             }
           })
           .thenCompose(ok -> handleFinalOrderStatus(compPO, poFromStorage.getWorkflowStatus().value()))
-          .thenCompose(v -> encumbranceService.updateEncumbrancesOrderStatus(compPO.getId(), compPO.getWorkflowStatus(), getRequestContext()));
+          .thenCompose(v -> encumbranceService.updateEncumbrancesOrderStatus(compPO, getRequestContext()));
       });
   }
 
@@ -488,7 +488,7 @@ public class PurchaseOrderHelper extends AbstractHelper {
         CompositePurchaseOrder compPo = convertToCompositePurchaseOrder(purchaseOrder);
         protectionHelper.isOperationRestricted(compPo.getAcqUnitIds(), DELETE)
           .thenCompose(v -> orderInvoiceRelationService.checkOrderInvoiceRelationship(id, new RequestContext(ctx, okapiHeaders)))
-          .thenAccept(aVoid -> encumbranceService.deleteOrderEncumbrances(id, getRequestContext())
+          .thenAccept(aVoid -> encumbranceService.deleteOrderEncumbrances(compPo.getId(), getRequestContext())
             .thenCompose(v -> deletePoLines(id, lang, httpClient, okapiHeaders, logger))
             .thenRun(() -> {
               logger.info("Successfully deleted poLines, proceeding with purchase order");

--- a/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
+++ b/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
@@ -96,7 +96,7 @@ public abstract class AbstractOrderStatusHandler extends AbstractHelper implemen
         if (Boolean.TRUE.equals(isStatusChanged)) {
           return helper.handleFinalOrderItemsStatus(purchaseOrder, poLines, initialStatus.value())
             .thenCompose(aVoid -> helper.updateOrderSummary(purchaseOrder))
-            .thenCompose(purchaseOrderParam -> encumbranceService.updateEncumbrancesOrderStatus(purchaseOrder.getId(), convert(purchaseOrder.getWorkflowStatus()), new RequestContext(ctx, okapiHeaders)));
+            .thenCompose(purchaseOrderParam -> encumbranceService.updateEncumbrancesOrderStatus(convert(purchaseOrder), new RequestContext(ctx, okapiHeaders)));
         }
         return CompletableFuture.completedFuture(null);
       });
@@ -108,8 +108,8 @@ public abstract class AbstractOrderStatusHandler extends AbstractHelper implemen
     return body.getJsonArray(rootElement);
   }
 
-  protected CompositePurchaseOrder.WorkflowStatus convert(PurchaseOrder.WorkflowStatus workflowStatus) {
-    return CompositePurchaseOrder.WorkflowStatus.fromValue(workflowStatus.value());
+  protected CompositePurchaseOrder convert(PurchaseOrder po) {
+    return JsonObject.mapFrom(po).mapTo(CompositePurchaseOrder.class);
   }
 
   protected abstract boolean isOrdersStatusChangeSkip(PurchaseOrder purchaseOrder, JsonObject ordersPayload);

--- a/src/main/java/org/folio/service/finance/transaction/EncumbranceService.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbranceService.java
@@ -70,13 +70,13 @@ public class EncumbranceService {
     );
   }
 
-  public CompletionStage<Void> updateEncumbrancesOrderStatus(String orderId, CompositePurchaseOrder.WorkflowStatus orderStatus, RequestContext requestContext) {
-    return getOrderEncumbrances(orderId, requestContext)
+  public CompletionStage<Void> updateEncumbrancesOrderStatus(CompositePurchaseOrder compPo, RequestContext requestContext) {
+    return getOrderEncumbrances(compPo.getId(), requestContext)
             .thenCompose(encumbrs -> {
-              if (isEncumbrancesOrderStatusUpdateNeeded(orderStatus, encumbrs)) {
-                return transactionSummariesService.updateOrderTransactionSummary(orderId, encumbrs.size(), requestContext)
+              if (isEncumbrancesOrderStatusUpdateNeeded(compPo.getWorkflowStatus(), encumbrs)) {
+                return transactionSummariesService.updateOrderTransactionSummary(compPo.getId(), encumbrs.size(), requestContext)
                         .thenApply(v -> {
-                          syncEncumbrancesOrderStatus(orderStatus, encumbrs);
+                          syncEncumbrancesOrderStatus(compPo.getWorkflowStatus(), encumbrs);
                           return encumbrs;
                         })
                         .thenCompose(transactions -> transactionService.updateTransactions(transactions, requestContext));

--- a/src/main/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategy.java
@@ -73,7 +73,7 @@ public class OpenToPendingEncumbranceStrategy implements EncumbranceWorkflowStra
       .thenApply(ehList -> ehList.stream().collect(groupingBy(EncumbranceRelationsHolder::getCurrentFiscalYearId,
       mapping(EncumbranceRelationsHolder::getPoLine, toList()))))
       .thenCompose(poLinesByCurrentFy -> getEncumbrancesByPoLinesFromCurrentFy(poLinesByCurrentFy, requestContext))
-      .thenApply(pols -> pols.stream().flatMap(Collection::stream).collect(Collectors.toList()));
+      .thenApply(trs -> trs.stream().flatMap(Collection::stream).collect(Collectors.toList()));
   }
 
   public CompletableFuture<List<List<Transaction>>> getEncumbrancesByPoLinesFromCurrentFy(

--- a/src/main/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategy.java
@@ -1,27 +1,42 @@
 package org.folio.service.finance.transaction;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
+import org.folio.models.EncumbranceRelationsHolder;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.service.finance.WorkflowStatusName;
 
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
+
 public class OpenToPendingEncumbranceStrategy implements EncumbranceWorkflowStrategy {
 
-    private final EncumbranceService encumbranceService;
-    private final TransactionSummariesService transactionSummariesService;
+  private final EncumbranceService encumbranceService;
+  private final TransactionSummariesService transactionSummariesService;
+  private final EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder;
 
-    public OpenToPendingEncumbranceStrategy(EncumbranceService encumbranceService, TransactionSummariesService transactionSummariesService) {
-        this.encumbranceService = encumbranceService;
-        this.transactionSummariesService = transactionSummariesService;
-    }
+  public OpenToPendingEncumbranceStrategy(EncumbranceService encumbranceService,
+      TransactionSummariesService transactionSummariesService,
+      EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder) {
+    this.encumbranceService = encumbranceService;
+    this.transactionSummariesService = transactionSummariesService;
+    this.encumbranceRelationsHoldersBuilder = encumbranceRelationsHoldersBuilder;
+
+  }
 
     @Override
     public CompletableFuture<Void> processEncumbrances(CompositePurchaseOrder compPO, RequestContext requestContext) {
-        return encumbranceService.getOrderEncumbrances(compPO.getId(), requestContext)
+      return getOrderEncumbrances(compPO, requestContext)
                 .thenApply(this::makeEncumbrancesPending)
                 .thenCompose(transactions -> transactionSummariesService.updateOrderTransactionSummary(compPO.getId(), transactions.size(), requestContext)
                     .thenApply(vVoid -> transactions))
@@ -38,8 +53,34 @@ public class OpenToPendingEncumbranceStrategy implements EncumbranceWorkflowStra
         return encumbrances;
     }
 
-    @Override
-    public WorkflowStatusName getStrategyName() {
-        return WorkflowStatusName.OPEN_TO_PENDING;
-    }
+  @Override
+  public WorkflowStatusName getStrategyName() {
+    return WorkflowStatusName.OPEN_TO_PENDING;
+  }
+
+  public CompletableFuture<List<EncumbranceRelationsHolder>> prepareEncumbranceRelationsHolder(CompositePurchaseOrder compPO,
+      RequestContext requestContext) {
+    List<EncumbranceRelationsHolder> encumbranceRelationsHolders = encumbranceRelationsHoldersBuilder.buildBaseHolders(compPO);
+    return encumbranceRelationsHoldersBuilder.withBudgets(encumbranceRelationsHolders, requestContext)
+      .thenCompose(holders -> encumbranceRelationsHoldersBuilder.withLedgersData(holders, requestContext))
+      .thenCompose(holders -> encumbranceRelationsHoldersBuilder.withFiscalYearData(holders, requestContext))
+      .thenCompose(holders -> encumbranceRelationsHoldersBuilder.withConversion(holders, requestContext))
+      .thenCompose(holders -> encumbranceRelationsHoldersBuilder.withExistingTransactions(holders, requestContext));
+  }
+
+  public CompletableFuture<List<Transaction>> getOrderEncumbrances(CompositePurchaseOrder compPo, RequestContext requestContext) {
+    return prepareEncumbranceRelationsHolder(compPo, requestContext)
+      .thenApply(ehList -> ehList.stream().collect(groupingBy(EncumbranceRelationsHolder::getCurrentFiscalYearId,
+      mapping(EncumbranceRelationsHolder::getPoLine, toList()))))
+      .thenCompose(poLinesByCurrentFy -> getEncumbrancesByPoLinesFromCurrentFy(poLinesByCurrentFy, requestContext))
+      .thenApply(pols -> pols.stream().flatMap(Collection::stream).collect(Collectors.toList()));
+  }
+
+  public CompletableFuture<List<List<Transaction>>> getEncumbrancesByPoLinesFromCurrentFy(
+    Map<String, List<CompositePoLine>> polinesByFy, RequestContext requestContext) {
+    return collectResultsOnSuccess(polinesByFy.entrySet()
+      .stream()
+      .map(entry -> encumbranceService.getCurrentPoLinesEncumbrances(entry.getValue(), entry.getKey(), requestContext))
+      .collect(toList()));
+  }
 }

--- a/src/test/java/org/folio/orders/events/handlers/CheckInOrderStatusChangeChangeHandlerTest.java
+++ b/src/test/java/org/folio/orders/events/handlers/CheckInOrderStatusChangeChangeHandlerTest.java
@@ -88,7 +88,7 @@ public class CheckInOrderStatusChangeChangeHandlerTest {
 
     SpringContextUtil.init(vertx, vertx.getOrCreateContext(), ApplicationConfig.class);
     EncumbranceService encumbranceService = mock(EncumbranceService.class);
-    doReturn(CompletableFuture.completedFuture(null)).when(encumbranceService).updateEncumbrancesOrderStatus(any(), any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(encumbranceService).updateEncumbrancesOrderStatus(any(), any());
     vertx.eventBus().consumer(MessageAddress.CHECKIN_ORDER_STATUS_UPDATE.address, new CheckInOrderStatusChangeChangeHandler(vertx, encumbranceService));
   }
 

--- a/src/test/java/org/folio/orders/events/handlers/ReceiveOrderStatusChangeHandlerTest.java
+++ b/src/test/java/org/folio/orders/events/handlers/ReceiveOrderStatusChangeHandlerTest.java
@@ -89,7 +89,7 @@ public class ReceiveOrderStatusChangeHandlerTest {
     vertx = Vertx.vertx();
     SpringContextUtil.init(vertx, vertx.getOrCreateContext(), ApplicationConfig.class);
     EncumbranceService encumbranceService = mock(EncumbranceService.class);
-    doReturn(CompletableFuture.completedFuture(null)).when(encumbranceService).updateEncumbrancesOrderStatus(any(), any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(encumbranceService).updateEncumbrancesOrderStatus(any(), any());
     vertx.eventBus().consumer(MessageAddress.RECEIVE_ORDER_STATUS_UPDATE.address, new ReceiveOrderStatusChangeHandler(vertx, encumbranceService));
   }
 

--- a/src/test/java/org/folio/service/finance/transaction/EncumbranceServiceTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/EncumbranceServiceTest.java
@@ -105,14 +105,13 @@ public class EncumbranceServiceTest {
   @Test
   void shouldReleaseEncumbrancesBeforeDeletionWhenDeleteOrderEncumbrances() {
     //Given
-
-    String orderId = UUID.randomUUID().toString();
+    var compOrder = new CompositePurchaseOrder().withId(UUID.randomUUID().toString());
     Transaction encumbrance = new Transaction()
             .withId(UUID.randomUUID().toString())
-            .withEncumbrance(new Encumbrance().withSourcePurchaseOrderId(orderId));
+            .withEncumbrance(new Encumbrance().withSourcePurchaseOrderId(compOrder.getId()));
     Transaction encumbrance2 = new Transaction()
             .withId(UUID.randomUUID().toString())
-            .withEncumbrance(new Encumbrance().withSourcePurchaseOrderId(orderId));
+            .withEncumbrance(new Encumbrance().withSourcePurchaseOrderId(compOrder.getId()));
     List<Transaction> transactions = new ArrayList<>();
     transactions.add(encumbrance);
     transactions.add(encumbrance2);
@@ -122,11 +121,11 @@ public class EncumbranceServiceTest {
     doReturn(CompletableFuture.completedFuture(null)).when(transactionSummariesService).updateOrderTransactionSummary(anyString(), anyInt(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(transactionService).deleteTransactions(any(), eq(requestContextMock));
     //When
-    encumbranceService.deleteOrderEncumbrances(orderId, requestContextMock).join();
+    encumbranceService.deleteOrderEncumbrances(compOrder.getId(), requestContextMock).join();
 
     //Then
     InOrder inOrder = inOrder(transactionSummariesService, transactionService);
-    inOrder.verify(transactionSummariesService).updateOrderTransactionSummary(eq(orderId), eq(2), eq(requestContextMock));
+    inOrder.verify(transactionSummariesService).updateOrderTransactionSummary(eq(compOrder.getId()), eq(2), eq(requestContextMock));
     inOrder.verify(transactionService).updateTransactions(any(), eq(requestContextMock));
     inOrder.verify(transactionService).deleteTransactions(any(), eq(requestContextMock));
 

--- a/src/test/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategyTest.java
@@ -1,6 +1,7 @@
 package org.folio.service.finance.transaction;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.TestConfig.initSpringContext;
 import static org.folio.TestUtils.getMockAsJson;
 import static org.folio.helper.PurchaseOrderHelperTest.ORDER_PATH;
 import static org.folio.rest.impl.MockServer.ENCUMBRANCE_PATH;
@@ -10,15 +11,17 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
+import org.folio.config.ApplicationConfig;
+import org.folio.models.EncumbranceRelationsHolder;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
-import org.folio.service.finance.transaction.EncumbranceService;
-import org.folio.service.finance.transaction.OpenToPendingEncumbranceStrategy;
-import org.folio.service.finance.transaction.TransactionSummariesService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -36,23 +39,42 @@ public class OpenToPendingEncumbranceStrategyTest {
     private TransactionSummariesService transactionSummariesService;
 
     @Mock
+    EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder;
+
+  @Mock
     private RequestContext requestContext;
+
 
     @BeforeEach
     public void initMocks() {
-        MockitoAnnotations.openMocks(this);
+      MockitoAnnotations.openMocks(this);
+      initSpringContext(ApplicationConfig.class);
+
     }
 
     @Test
     void testShouldSetEncumbrancesToPending() {
         //given
         CompositePurchaseOrder order = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
-
         Transaction encumbrance = getMockAsJson(ENCUMBRANCE_PATH).getJsonArray("transactions").getJsonObject(0).mapTo(Transaction.class);
 
         doReturn(completedFuture(Collections.singletonList(encumbrance))).when(encumbranceService).getOrderEncumbrances(any(), any());
         doReturn(completedFuture(null)).when(encumbranceService).updateEncumbrances(any(), any());
         doReturn(completedFuture(null)).when(transactionSummariesService).updateOrderTransactionSummary(anyString(), anyInt(), any());
+
+        List<EncumbranceRelationsHolder> encumbranceRelationsHolders = new ArrayList<>();
+        encumbranceRelationsHolders.add(new EncumbranceRelationsHolder()
+          .withOldEncumbrance(encumbrance)
+          .withCurrentFiscalYearId(UUID.randomUUID().toString()));
+
+        doReturn(new ArrayList<EncumbranceRelationsHolder>()).when(encumbranceRelationsHoldersBuilder).buildBaseHolders(any());
+        doReturn(completedFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withBudgets(any(), any());
+        doReturn(completedFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withLedgersData(any(),any());
+        doReturn(completedFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withFiscalYearData(any(), any());
+        doReturn(completedFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withConversion(any(), any());
+        doReturn(completedFuture(encumbranceRelationsHolders)).when(encumbranceRelationsHoldersBuilder).withExistingTransactions(any(), any());
+        doReturn(completedFuture(Collections.singletonList(encumbrance))).when(encumbranceService).getCurrentPoLinesEncumbrances(any(), anyString(), any());
+
         //When
         openToPendingEncumbranceStrategy.processEncumbrances(order, requestContext).join();
         //Then


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDERS-542

## Approach
* updated encumbrances processing to use only transactions from current fiscal year

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
