### PR TITLE
[MODORDERS-578] Only take createInventory into account with a matching orderFormat

### DIFF
--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -271,9 +271,9 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
   private boolean holdingUpdateOnCheckinReceiveRequired(Piece piece, Location location, CompositePoLine poLine) {
     boolean isHoldingUpdateRequired;
     if (piece.getFormat() == Piece.Format.ELECTRONIC) {
-      isHoldingUpdateRequired = PoLineCommonUtil.isHoldingUpdateRequiredForEresource(poLine.getEresource());
+      isHoldingUpdateRequired = PoLineCommonUtil.isHoldingUpdateRequiredForEresource(poLine);
     } else {
-      isHoldingUpdateRequired = PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(poLine.getPhysical());
+      isHoldingUpdateRequired = PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(poLine);
     }
     return isHoldingUpdateRequired && (StringUtils.isNotEmpty(location.getLocationId()) || StringUtils.isNotEmpty(location.getHoldingId()));
   }

--- a/src/main/java/org/folio/orders/utils/validators/CompositePoLineValidationUtil.java
+++ b/src/main/java/org/folio/orders/utils/validators/CompositePoLineValidationUtil.java
@@ -140,12 +140,12 @@ public final class CompositePoLineValidationUtil {
 
   private static boolean isLocationsPhysicalQuantityNotValid(CompositePoLine compPOL) {
     int physicalQuantity = HelperUtils.getPhysicalLocationsQuantity(compPOL.getLocations());
-    return (isHoldingUpdateRequiredForPhysical(compPOL.getPhysical()) || physicalQuantity > 0) && (physicalQuantity != getPhysicalCostQuantity(compPOL));
+    return (isHoldingUpdateRequiredForPhysical(compPOL) || physicalQuantity > 0) && (physicalQuantity != getPhysicalCostQuantity(compPOL));
   }
 
   private static boolean isLocationsEresourceQuantityNotValid(CompositePoLine compPOL) {
     int electronicQuantity = HelperUtils.getElectronicLocationsQuantity(compPOL.getLocations());
-    return (isHoldingUpdateRequiredForEresource(compPOL.getEresource()) || electronicQuantity > 0) && (electronicQuantity != getElectronicCostQuantity(compPOL));
+    return (isHoldingUpdateRequiredForEresource(compPOL) || electronicQuantity > 0) && (electronicQuantity != getElectronicCostQuantity(compPOL));
   }
 
   private static List<Error> validatePoLineWithPhysicalFormat(CompositePoLine compPOL) {

--- a/src/main/java/org/folio/service/inventory/InventoryManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryManager.java
@@ -183,7 +183,7 @@ public class InventoryManager {
     boolean isItemsUpdateRequired = PoLineCommonUtil.isItemsUpdateRequired(compPOL);
 
     // Group all locations by location id because the holding should be unique for different locations
-    if (PoLineCommonUtil.isHoldingsUpdateRequired(compPOL.getEresource(), compPOL.getPhysical())) {
+    if (PoLineCommonUtil.isHoldingsUpdateRequired(compPOL)) {
       compPOL.getLocations().forEach(location -> {
           itemsPerHolding.add(
             // Search for or create a new holdings record and then create items for it if required

--- a/src/main/java/org/folio/service/orders/flows/unopen/UnOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/unopen/UnOpenCompositeOrderManager.java
@@ -117,7 +117,7 @@ public class UnOpenCompositeOrderManager {
       });
     } else if (PoLineCommonUtil.isItemsUpdateRequired(compPOL)) {
       return processInventoryWithItems(compPOL, rqContext);
-    } else if (PoLineCommonUtil.isHoldingsUpdateRequired(compPOL.getEresource(), compPOL.getPhysical())) {
+    } else if (PoLineCommonUtil.isHoldingsUpdateRequired(compPOL)) {
       return processInventoryOnlyWithHolding(compPOL, rqContext);
     }
     return completedFuture(null);

--- a/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
@@ -95,7 +95,7 @@ public class PieceUpdateInventoryService {
   public CompletableFuture<String> handleHoldingsRecord(final CompositePoLine compPOL, Location location, String instanceId,
     RequestContext requestContext) {
     try {
-      if (PoLineCommonUtil.isHoldingsUpdateRequired(compPOL.getEresource(), compPOL.getPhysical())) {
+      if (PoLineCommonUtil.isHoldingsUpdateRequired(compPOL)) {
         return inventoryManager.getOrCreateHoldingsRecord(instanceId, location, requestContext);
       } else {
         return CompletableFuture.completedFuture(null);

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowValidator.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowValidator.java
@@ -54,9 +54,9 @@ public class PieceCreateFlowValidator {
 
   public static boolean isCreateHoldingForPiecePossible(Piece pieceToCreate, CompositePoLine originPoLine) {
     Piece.Format pieceFormat = pieceToCreate.getFormat();
-    return (pieceFormat == Piece.Format.ELECTRONIC && PoLineCommonUtil.isHoldingUpdateRequiredForEresource(originPoLine.getEresource())) ||
+    return (pieceFormat == Piece.Format.ELECTRONIC && PoLineCommonUtil.isHoldingUpdateRequiredForEresource(originPoLine)) ||
               ((pieceFormat == Piece.Format.PHYSICAL || pieceFormat == Piece.Format.OTHER)
-                        && PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(originPoLine.getPhysical()));
+                        && PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(originPoLine));
   }
 
   public static boolean isCreateItemForPiecePossible(Piece pieceToCreate, CompositePoLine originPoLine) {

--- a/src/test/java/org/folio/orders/utils/PoLineCommonUtilTest.java
+++ b/src/test/java/org/folio/orders/utils/PoLineCommonUtilTest.java
@@ -73,6 +73,7 @@ public class PoLineCommonUtilTest {
     //given
     CompositePurchaseOrder order = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     order.getCompositePoLines().forEach(line -> {
+      line.setOrderFormat(CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE);
       line.setPaymentStatus(CompositePoLine.PaymentStatus.FULLY_PAID);
       line.setReceiptStatus(CompositePoLine.ReceiptStatus.FULLY_RECEIVED);
       line.setPhysical(null);

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -79,6 +79,7 @@ import org.folio.ApiTestSuite;
 import org.folio.HttpStatus;
 import org.folio.config.ApplicationConfig;
 import org.folio.helper.AbstractHelper;
+import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.rest.acq.model.PieceCollection;
 import org.folio.rest.jaxrs.model.CheckInPiece;
 import org.folio.rest.jaxrs.model.CheckinCollection;
@@ -794,6 +795,7 @@ public class CheckinReceivingApiTest {
           .getPoLineId()))
       .findFirst()
       .get();
+    CompositePoLine compPOL = PoLineCommonUtil.convertToCompositePoLine(poline);
 
     // get processed pieces for receiving
     PieceCollection pieces = new JsonObject(getMockData(PIECE_RECORDS_MOCK_DATA_PATH + "pieceRecordsCollection.json"))
@@ -818,7 +820,7 @@ public class CheckinReceivingApiTest {
           .equals(piece.getId())
             && !receivedItem.getLocationId()
               .equals(piece.getLocationId())
-            && isHoldingsUpdateRequired(piece, poline)) {
+            && isHoldingsUpdateRequired(piece, compPOL)) {
           expectedHoldings.add(getInstanceId(poline) + receivedItem.getLocationId());
         }
       }
@@ -826,11 +828,11 @@ public class CheckinReceivingApiTest {
     assertEquals(expectedHoldings.size(), getCreatedHoldings().size());
   }
 
-  private boolean isHoldingsUpdateRequired(org.folio.rest.acq.model.Piece piece, PoLine poLine) {
+  private boolean isHoldingsUpdateRequired(org.folio.rest.acq.model.Piece piece, CompositePoLine compPOL) {
     if (piece.getFormat() == org.folio.rest.acq.model.Piece.PieceFormat.ELECTRONIC) {
-     return isHoldingUpdateRequiredForEresource(poLine.getEresource());
+     return isHoldingUpdateRequiredForEresource(compPOL);
     } else {
-      return isHoldingUpdateRequiredForPhysical(poLine.getPhysical());
+      return isHoldingUpdateRequiredForPhysical(compPOL);
     }
   }
 

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -618,7 +618,7 @@ public class PurchaseOrdersApiTest {
 
     final Errors response = verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).encode(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, 422).as(Errors.class);
-    assertThat(response.getErrors(), hasSize(11));
+    assertThat(response.getErrors(), hasSize(10));
     Set<String> errorCodes = response.getErrors()
                                      .stream()
                                      .map(Error::getCode)


### PR DESCRIPTION
## Purpose
[MODORDERS-578](https://issues.folio.org/browse/MODORDERS-578) - Holding is created for order line when Create inventory is None/Instance

## Approach
Only take createInventory into account with a matching orderFormat.
In principle this can also affect instance and item creations (in practice the UI limits possibilities). Validation is also changed, as createInventory for non-matching orderFormat is no longer checked.

#### TODOS and Open Questions
New stories should be created to improve validation and reject inconsistent order lines.
Created https://issues.folio.org/browse/MODORDERS-585

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
