### PR TITLE
[MODORDERS-610] Fixed po line query using acqUnitIds

### DIFF
--- a/src/main/java/org/folio/service/AcquisitionsUnitsService.java
+++ b/src/main/java/org/folio/service/AcquisitionsUnitsService.java
@@ -28,7 +28,7 @@ public class AcquisitionsUnitsService {
   private static final Logger logger = LogManager.getLogger();
 
   public static final String ACQUISITIONS_UNIT_IDS = "acqUnitIds";
-  private static final String NO_ACQ_UNIT_ASSIGNED_CQL = "cql.allRecords=1 not " + ACQUISITIONS_UNIT_IDS + " <> []";
+  private static final String NO_ACQ_UNIT_ASSIGNED_CQL = "cql.allRecords=1 not %s" + ACQUISITIONS_UNIT_IDS + " <> []";
 
   private static final String IS_DELETED_PROP = "isDeleted";
   private static final String ACTIVE_UNITS_CQL = IS_DELETED_PROP + "==false";
@@ -89,10 +89,13 @@ public class AcquisitionsUnitsService {
 
   public CompletableFuture<String> buildAcqUnitsCqlExprToSearchRecords(String tableAlias, RequestContext requestContext) {
     return getAcqUnitIdsForSearch(requestContext).thenApply(ids -> {
+      String noAcqUnitAssignedQuery = String.format(NO_ACQ_UNIT_ASSIGNED_CQL, tableAlias);
       if (ids.isEmpty()) {
-        return NO_ACQ_UNIT_ASSIGNED_CQL;
+        return noAcqUnitAssignedQuery;
       }
-      return String.format("%s or (%s)", HelperUtils.convertFieldListToCqlQuery(ids, tableAlias + ACQUISITIONS_UNIT_IDS, false), NO_ACQ_UNIT_ASSIGNED_CQL);
+      return String.format("%s or (%s)",
+        HelperUtils.convertFieldListToCqlQuery(ids, tableAlias + ACQUISITIONS_UNIT_IDS, false),
+        noAcqUnitAssignedQuery);
     });
   }
 

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
@@ -153,7 +153,7 @@ public class PurchaseOrderLinesApiTest {
   private static final String PO_LINE_MIN_CONTENT_PATH = COMP_PO_LINES_MOCK_DATA_PATH + "minimalContent.json";
   public static final String ISBN_PRODUCT_TYPE_ID = "8261054f-be78-422d-bd51-4ed9f33c3422";
   public static final String INVALID_ISBN = "1234";
-  private static final String ACQUISITIONS_UNIT_IDS = "acqUnitIds";
+  private static final String ACQUISITIONS_UNIT_IDS = "purchaseOrder.acqUnitIds";
   private static final String NO_ACQ_UNIT_ASSIGNED_CQL = "cql.allRecords=1 not " + ACQUISITIONS_UNIT_IDS + " <> []";
 
   private static boolean runningOnOwn;


### PR DESCRIPTION
## Purpose
[MODORDERS-610](https://issues.folio.org/browse/MODORDERS-610) - PoLine search querying non-existing poLine.acqUnitIds

## Approach
- Added `tableAlias` to `NO_ACQ_UNIT_ASSIGNED_CQL`
- Fixed unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
