### PR TITLE
[MODORDERS-445] titleOrPackage is no longer a protected field

### DIFF
--- a/src/main/java/org/folio/orders/utils/POLineProtectedFields.java
+++ b/src/main/java/org/folio/orders/utils/POLineProtectedFields.java
@@ -25,7 +25,6 @@ public enum POLineProtectedFields {
   REQUESTER("requester"),
   RUSH("rush"),
   SELECTOR("selector"),
-  TITLE_OR_PACKAGE("titleOrPackage"),
   VENDORDETAIL_INSTRUCTION_TO_VENDOR("vendorDetail.instructions");
 
 

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
@@ -682,7 +682,6 @@ public class PurchaseOrderLinesApiTest {
 
     allProtectedFieldsModification.put(POLineProtectedFields.ACQUISITION_METHOD.getFieldName(),
         CompositePoLine.AcquisitionMethod.APPROVAL_PLAN.value());
-    allProtectedFieldsModification.put(POLineProtectedFields.TITLE_OR_PACKAGE.getFieldName(), "Testing ProtectedFields");
     allProtectedFieldsModification.put(POLineProtectedFields.DONOR.getFieldName(), "Donor");
     allProtectedFieldsModification.put(POLineProtectedFields.ERESOURCE_USER_LIMIT.getFieldName(), 100);
     // adding trial because a default value is added while sending the request


### PR DESCRIPTION
## Purpose
[MODORDERS-445](https://issues.folio.org/browse/MODORDERS-445) - Delete "titleOrPackage" from protected field

## Approach
Removed `titleOrPackage` from the list of protected fields and removed the related test.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
