### PR TITLE
[MODORDERS-616] Make sure a piece has the latest holdingId when received

### DIFF
--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -245,6 +245,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends AbstractHelper {
       return inventoryManager.getOrCreateHoldingsRecord(instanceId, receivedPieceLocation, requestContext)
         .thenCompose(holdingId -> {
           processedHoldings.put(holdingKey, holdingId);
+          piece.setHoldingId(holdingId);
           return completedFuture(true);
         })
         .exceptionally(t -> {


### PR DESCRIPTION
## Purpose
[MODORDERS-616](https://issues.folio.org/browse/MODORDERS-616) - New holdingId is not saved into piece when location is changed during receiving

## Approach
When a piece is received with a new location, a new holding is created. When this happens, update the piece object to have the new holding id. Pieces are saved afterwards.

#### TODOS and Open Questions
[MODORDERS-522](https://issues.folio.org/browse/MODORDERS-522) - Receiving API is confusing and implementation is redundant
It would be easier to check this change cannot have side effects with a better API.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
