### PR TITLE
[MODORDERS-626] Delete the encumbrance reference when a transaction is deleted

### DIFF
--- a/src/main/java/org/folio/models/EncumbrancesProcessingHolder.java
+++ b/src/main/java/org/folio/models/EncumbrancesProcessingHolder.java
@@ -11,7 +11,7 @@ public class EncumbrancesProcessingHolder {
   private List<Transaction> encumbrancesFromStorage;
   private List<Transaction> encumbrancesForRelease;
   private List<EncumbranceRelationsHolder> encumbrancesForCreate;
-  private List<Transaction> encumbrancesForDelete;
+  private List<EncumbranceRelationsHolder> encumbrancesForDelete;
   private List<EncumbranceRelationsHolder> encumbrancesForUpdate;
   private List<Transaction> encumbrancesForUnrelease;
 
@@ -44,7 +44,7 @@ public class EncumbrancesProcessingHolder {
     return this;
   }
 
-  public EncumbrancesProcessingHolder withEncumbrancesForDelete(List<Transaction> encumbrancesForDelete) {
+  public EncumbrancesProcessingHolder withEncumbrancesForDelete(List<EncumbranceRelationsHolder> encumbrancesForDelete) {
     this.encumbrancesForDelete = new ArrayList<>(encumbrancesForDelete);
     return this;
   }
@@ -73,7 +73,7 @@ public class EncumbrancesProcessingHolder {
     return encumbrancesForCreate;
   }
 
-  public List<Transaction> getEncumbrancesForDelete() {
+  public List<EncumbranceRelationsHolder> getEncumbrancesForDelete() {
     return encumbrancesForDelete;
   }
 

--- a/src/main/java/org/folio/service/finance/transaction/EncumbranceService.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbranceService.java
@@ -185,8 +185,15 @@ public class EncumbranceService {
     return transactionService.updateTransactions(transactions, requestContext);
   }
 
-  public CompletableFuture<Void> deleteEncumbrances(List<Transaction> encumbrances, RequestContext requestContext) {
-    return transactionService.deleteTransactions(encumbrances, requestContext);
+  public CompletableFuture<Void> deleteEncumbrances(List<EncumbranceRelationsHolder> holders, RequestContext requestContext) {
+    // before deleting encumbrances, set the fund distribution encumbrance to null if a new encumbrance has not been created
+    // (as with pending->pending)
+    holders.stream()
+      .filter(erh -> erh.getFundDistribution() != null &&
+        erh.getOldEncumbrance().getId().equals(erh.getFundDistribution().getEncumbrance()))
+      .forEach(erh -> erh.getFundDistribution().setEncumbrance(null));
+    List<Transaction> transactions = holders.stream().map(EncumbranceRelationsHolder::getOldEncumbrance).collect(toList());
+    return transactionService.deleteTransactions(transactions, requestContext);
   }
 
   public CompletableFuture<Void> deletePoLineEncumbrances(PoLine poline, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
@@ -16,9 +16,11 @@ public class EncumbrancesProcessingHolderBuilder {
     EncumbrancesProcessingHolder holder = new EncumbrancesProcessingHolder();
     holder.withEncumbrancesForCreate(getToBeCreatedHolders(encumbranceRelationsHolders));
     holder.withEncumbrancesForUpdate(getToBeUpdatedHolders(encumbranceRelationsHolders));
-    holder.withEncumbrancesForDelete(getTransactionsToDelete(encumbranceRelationsHolders));
+    List<EncumbranceRelationsHolder> toDelete = getTransactionsToDelete(encumbranceRelationsHolders);
+    holder.withEncumbrancesForDelete(toDelete);
     // also release transaction before delete
-    holder.withEncumbrancesForRelease(getTransactionsToDelete(encumbranceRelationsHolders));
+    List<Transaction> toRelease = toDelete.stream().map(EncumbranceRelationsHolder::getOldEncumbrance).collect(toList());
+    holder.withEncumbrancesForRelease(toRelease);
     holder.withEncumbrancesFromStorage(encumbranceRelationsHolders.stream()
       .map(EncumbranceRelationsHolder::getOldEncumbrance)
       .filter(Objects::nonNull)
@@ -52,10 +54,9 @@ public class EncumbrancesProcessingHolderBuilder {
       .collect(toList());
   }
 
-  private List<Transaction> getTransactionsToDelete(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {
+  private List<EncumbranceRelationsHolder> getTransactionsToDelete(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {
     return encumbranceRelationsHolders.stream()
       .filter(holder -> Objects.isNull(holder.getNewEncumbrance()))
-      .map(EncumbranceRelationsHolder::getOldEncumbrance)
       .collect(toList());
   }
 }

--- a/src/main/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategy.java
@@ -47,15 +47,16 @@ public class PendingToPendingEncumbranceStrategy implements EncumbranceWorkflowS
       .map(EncumbranceRelationsHolder::getOldEncumbrance)
       .filter(Objects::nonNull)
       .collect(toList()));
-    holder.withEncumbrancesForRelease(getTransactionsToDelete(encumbranceRelationsHolders));
-    holder.withEncumbrancesForDelete(getTransactionsToDelete(encumbranceRelationsHolders));
+    List<EncumbranceRelationsHolder> toDelete = getTransactionsToDelete(encumbranceRelationsHolders);
+    List<Transaction> toRelease = toDelete.stream().map(EncumbranceRelationsHolder::getOldEncumbrance).collect(toList());
+    holder.withEncumbrancesForRelease(toRelease);
+    holder.withEncumbrancesForDelete(toDelete);
     return holder;
   }
 
-  private List<Transaction> getTransactionsToDelete(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {
+  private List<EncumbranceRelationsHolder> getTransactionsToDelete(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {
     return encumbranceRelationsHolders.stream()
       .filter(holder -> Objects.isNull(holder.getNewEncumbrance()))
-      .map(EncumbranceRelationsHolder::getOldEncumbrance)
       .collect(toList());
   }
 


### PR DESCRIPTION
## Purpose
[MODORDERS-626](https://issues.folio.org/browse/MODORDERS-626) - Can't reopen an order after changing the expense class

## Approach
- Save the whole encumbrance relation holder for encumbrances to delete
- When creating a new holder for a transaction without a matching fund distribution, look if there is a fund distribution that has the reference to that transaction
- If the transaction is deleted (rather than replaced), remove the reference in the matching fund distribution

#### TODOS and Open Questions
I thought of using the occasion to set the fiscal year id in buildToBeReleasedHolder, but realized this could break workflows for [code](https://github.com/folio-org/mod-orders/blob/1991c506cf109c1510b5ae895b7379765cb8287f/src/main/java/org/folio/service/finance/transaction/EncumbranceRelationsHoldersBuilder.java#L281) filtering out holders with null fiscal year ids.
I feel like the current code is brittle, but I didn't want to refactor because this fix should be included at the last minute into Kiwi, and I wanted to avoid large changes.

## Learning
One tricky think in the current implementation for encumbrance changes is that the purchase order line fund distribution is modified within the code that is supposed to handle encumbrances (processEncumbrances), by saving the reference to the fund distribution and changing it later. The code would be easier to understand if such modifications to the order line (to update the reference to the encumbrance) where placed outside of processEncumbrances() and called explicitely.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
