### PR TITLE
MODORDERS-634 Support circulation interface v13

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1001,7 +1001,7 @@
     },
     {
       "id": "circulation",
-      "version": "10.0 11.0 12.0"
+      "version": "10.0 11.0 12.0 13.0"
     },
     {
       "id": "finance-storage.budget-expense-classes",


### PR DESCRIPTION
### Purpose
Adapt the module to changed interface of mod-circulation from v12.0 to v13.0
### Approach
Adapt ModuleDescriptor-template to circulation interface v13.0;
### Learning
https://issues.folio.org/browse/MODORDERS-634