### PR TITLE
[MODORDERS-649] - Some fields of the piece are not populated when receiving/unreceiving

### DIFF
--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -252,6 +252,7 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
     piece.setChronology(checkinPiece.getChronology());
     piece.setDisplayOnHolding(checkinPiece.getDisplayOnHolding());
     piece.setDiscoverySuppress(checkinPiece.getDiscoverySuppress());
+    piece.setSupplement(checkinPiece.getSupplement());
     // Piece record might be received or rolled-back to Expected
     if (inventoryManager.isOnOrderPieceStatus(checkinPiece)) {
       piece.setReceivedDate(null);

--- a/src/main/java/org/folio/helper/ReceivingHelper.java
+++ b/src/main/java/org/folio/helper/ReceivingHelper.java
@@ -312,7 +312,6 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
     piece.setEnumeration(receivedItem.getEnumeration());
     piece.setChronology(receivedItem.getChronology());
     piece.setDisplayOnHolding(receivedItem.getDisplayOnHolding());
-  //  piece.setDiscoverySuppress(receivedItem.getDiscoverySuppress());
     // Piece record might be received or rolled-back to Expected
     if (inventoryManager.isOnOrderItemStatus(receivedItem)) {
       piece.setReceivedDate(null);

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
@@ -118,7 +118,7 @@ public class OpenCompositeOrderPieceService {
     CompletableFuture<Void> future = new CompletableFuture<>();
     purchaseOrderStorageService.getCompositeOrderByPoLineId(piece.getPoLineId(), requestContext)
       .thenCompose(order -> protectionService.isOperationRestricted(order.getAcqUnitIds(), ProtectedOperationType.UPDATE, requestContext))
-      .thenCompose(v -> inventoryManager.updateItemWithPoLineId(piece, requestContext))
+      .thenCompose(v -> inventoryManager.updateItemWithPieceFields(piece, requestContext))
       .thenAccept(vVoid ->
         pieceStorageService.getPieceById(piece.getId(), requestContext).thenAccept(pieceStorage -> {
             Piece.ReceivingStatus receivingStatusStorage = pieceStorage.getReceivingStatus();
@@ -190,7 +190,7 @@ public class OpenCompositeOrderPieceService {
     }
     else
     {
-      return inventoryManager.updateItemWithPoLineId(piece, requestContext);
+      return inventoryManager.updateItemWithPieceFields(piece, requestContext);
     }
   }
 

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -39,7 +39,7 @@ public class PieceCreateFlowInventoryManager {
     }
     else
     {
-      return nonPackagePoLineUpdateInventory(compPOL, piece, createItem, requestContext);
+       return nonPackagePoLineUpdateInventory(compPOL, piece, createItem, requestContext);
     }
   }
 

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -42,7 +42,7 @@ public class PieceUpdateFlowInventoryManager {
   }
 
   public CompletableFuture<Void> processInventory(PieceUpdateHolder holder, RequestContext requestContext) {
-    return inventoryManager.updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext)
+    return inventoryManager.updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext)
       .thenCompose(aVoid -> {
         if (Boolean.TRUE.equals(holder.getOriginPoLine().getIsPackage())) {
           return packagePoLineUpdateInventory(holder, requestContext);

--- a/src/test/java/org/folio/service/orders/flows/open/OpenCompositeOrderPieceServiceTest.java
+++ b/src/test/java/org/folio/service/orders/flows/open/OpenCompositeOrderPieceServiceTest.java
@@ -139,7 +139,7 @@ public class OpenCompositeOrderPieceServiceTest {
     CompositePurchaseOrder order = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
 
     doReturn(completedFuture(null)).when(protectionService).isOperationRestricted(any(List.class), eq(ProtectedOperationType.UPDATE), eq(requestContext));
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(eq(piece), eq(requestContext));
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(eq(piece), eq(requestContext));
     doReturn(completedFuture(order)).when(purchaseOrderStorageService).getCompositeOrderByPoLineId(eq(piece.getPoLineId()), eq(requestContext));
     doReturn(completedFuture(pieceFromStorage)).when(pieceStorageService).getPieceById(eq(piece.getId()), eq(requestContext));
     doReturn(completedFuture(null)).when(pieceStorageService).updatePiece(eq(piece), eq(requestContext));
@@ -158,7 +158,7 @@ public class OpenCompositeOrderPieceServiceTest {
     CompositePurchaseOrder order = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
 
     doReturn(completedFuture(null)).when(protectionService).isOperationRestricted(any(List.class), eq(ProtectedOperationType.UPDATE), eq(requestContext));
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(eq(piece), eq(requestContext));
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(eq(piece), eq(requestContext));
     doReturn(completedFuture(order)).when(purchaseOrderStorageService).getCompositeOrderByPoLineId(eq(piece.getPoLineId()), eq(requestContext));
     doReturn(completedFuture(pieceFromStorage)).when(pieceStorageService).getPieceById(eq(piece.getId()), eq(requestContext));
     doReturn(completedFuture(null)).when(pieceStorageService).updatePiece(eq(piece), eq(requestContext));
@@ -174,7 +174,7 @@ public class OpenCompositeOrderPieceServiceTest {
     CompositePoLine line = getMockAsJson(COMPOSITE_LINES_PATH, LINE_ID).mapTo(CompositePoLine.class);
     Title title = getMockAsJson(TILES_PATH,"title").mapTo(Title.class);
     Piece piece = createPieceWithLocationId(line, title);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(piece, requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(piece, requestContext);
     doReturn(completedFuture(title)).when(inventoryManager).openOrderHandlePackageLineInstance(title, false, requestContext);
     //When
     openCompositeOrderPieceService.openOrderUpdateInventory(line, piece, false, requestContext).get();

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManagerTest.java
@@ -141,7 +141,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(completedFuture(new JsonObject())).when(inventoryManager).getItemRecordById(pieceToUpdate.getItemId(), true, requestContext);
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
       .createMissingElectronicItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -152,7 +152,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
   }
 
@@ -189,7 +189,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(completedFuture(new JsonObject())).when(inventoryManager).getItemRecordById(pieceToUpdate.getItemId(), true, requestContext);
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
       .createMissingPhysicalItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -200,7 +200,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
   }
 
@@ -238,7 +238,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(completedFuture(new JsonObject())).when(inventoryManager).getItemRecordById(pieceToUpdate.getItemId(), true, requestContext);
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
       .createMissingPhysicalItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -249,7 +249,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
   }
 
@@ -291,7 +291,7 @@ public class PieceUpdateFlowInventoryManagerTest {
 
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
       .createMissingPhysicalItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -303,7 +303,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(inventoryManager,times(0)).createMissingElectronicItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
     verify(inventoryManager,times(0)).createMissingPhysicalItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
     verify(inventoryManager).updateItem(item, requestContext);
@@ -342,7 +342,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(completedFuture(new JsonObject())).when(inventoryManager).getItemRecordById(pieceToUpdate.getItemId(), true, requestContext);
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
                                   .createMissingElectronicItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -353,7 +353,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
   }
 
@@ -390,7 +390,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(completedFuture(new JsonObject())).when(inventoryManager).getItemRecordById(pieceToUpdate.getItemId(), true, requestContext);
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
       .createMissingPhysicalItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -401,7 +401,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
   }
 
@@ -437,7 +437,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(completedFuture(new JsonObject())).when(inventoryManager).getItemRecordById(pieceToUpdate.getItemId(), true, requestContext);
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
       .createMissingPhysicalItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -448,7 +448,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService, times(0)).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
   }
 
@@ -489,7 +489,7 @@ public class PieceUpdateFlowInventoryManagerTest {
 
     doReturn(completedFuture(List.of(itemId))).when(inventoryManager)
       .createMissingPhysicalItems(holder.getPoLineToSave(), pieceToUpdate, 1, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     doReturn(completedFuture(holding)).when(inventoryManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(completedFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
@@ -501,7 +501,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     verify(titlesService, times(0)).getTitleById(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    verify(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    verify(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
     verify(pieceUpdateInventoryService, times(0)).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
     verify(inventoryManager).updateItem(item, requestContext);
   }
@@ -535,7 +535,7 @@ public class PieceUpdateFlowInventoryManagerTest {
     holder.withOrderInformation(purchaseOrder, poLine);
 
     doReturn(completedFuture(new JsonObject())).when(inventoryManager).getItemRecordById(null, true, requestContext);
-    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPoLineId(holder.getPieceToUpdate(), requestContext);
+    doReturn(completedFuture(null)).when(inventoryManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).join();
 


### PR DESCRIPTION
## Purpose
Fix an issue with fields of the piece are not populated when receiving/unreceiving

## Approach
Piece and Item updated from receive and unreceive model

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
