### PR TITLE
[MODORDERS-636] Update po lines when an order is closed as Cancelled

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -71,6 +71,7 @@ import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.PoLine.PaymentStatus;
 import org.folio.rest.jaxrs.model.PoLine.ReceiptStatus;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.ReportingCode;
@@ -649,8 +650,8 @@ public class HelperUtils {
   private static boolean isCompletedPoLine(PoLine line) {
     PoLine.PaymentStatus paymentStatus = line.getPaymentStatus();
     PoLine.ReceiptStatus receiptStatus = line.getReceiptStatus();
-    return (paymentStatus == PAYMENT_NOT_REQUIRED || paymentStatus == FULLY_PAID)
-      && (receiptStatus == FULLY_RECEIVED || receiptStatus == RECEIPT_NOT_REQUIRED);
+    return (paymentStatus == PAYMENT_NOT_REQUIRED || paymentStatus == FULLY_PAID || paymentStatus == PaymentStatus.CANCELLED)
+      && (receiptStatus == FULLY_RECEIVED || receiptStatus == RECEIPT_NOT_REQUIRED || receiptStatus == ReceiptStatus.CANCELLED);
   }
 
   public static PoLine convertToPoLine(CompositePoLine compPoLine) {

--- a/src/test/java/org/folio/TestConstants.java
+++ b/src/test/java/org/folio/TestConstants.java
@@ -36,6 +36,7 @@ public final class TestConstants {
   public static final String PO_WFD_ID_OPEN_STATUS = "a1465131-ed35-4308-872c-d7cdf0afc5f7";
   public static final String PO_ID_CLOSED_STATUS = "07f65192-44a4-483d-97aa-b137bbd96390";
   public static final String PO_ID_OPEN_TO_BE_CLOSED = "9d56b621-202d-414b-9e7f-5fefe4422ab3";
+  public static final String PO_ID_OPEN_TO_CANCEL = "f56c70bc-8a31-4f56-b606-c6d8e597b7c1";
   public static final String PO_LINE_ID_FOR_SUCCESS_CASE = "fca5fa9e-15cb-4a3d-ab09-eeea99b97a47";
   public static final String PO_LINE_ID_WRONG_EXPENSE_CLASS = "bd8f1901-c768-4bb1-b650-8c12c5f42fd8";
   public static final String MIN_PO_ID = UUID.randomUUID().toString();

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -3457,6 +3457,7 @@ public class PurchaseOrdersApiTest {
     CloseReason closeReason = new CloseReason();
     closeReason.setReason("Cancelled");
     reqData.put("closeReason", JsonObject.mapFrom(closeReason));
+    reqData.remove("compositePoLines");
 
     verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, reqData.getString("id")), JsonObject.mapFrom(reqData), "", 204);
     assertThat(getPurchaseOrderUpdates().get(0).mapTo(PurchaseOrder.class).getWorkflowStatus(),

--- a/src/test/resources/mockdata/compositeOrders/f56c70bc-8a31-4f56-b606-c6d8e597b7c1.json
+++ b/src/test/resources/mockdata/compositeOrders/f56c70bc-8a31-4f56-b606-c6d8e597b7c1.json
@@ -1,0 +1,90 @@
+{
+  "id": "f56c70bc-8a31-4f56-b606-c6d8e597b7c1",
+  "approved": false,
+  "notes": [],
+  "manualPo": false,
+  "poNumber": "268s879",
+  "orderType": "One-Time",
+  "reEncumber": false,
+  "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflowStatus": "Open",
+  "compositePoLines": [
+    {
+      "id": "e92ef562-c77d-4306-8089-2607eff9b921",
+      "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
+      "collection" : false,
+      "eresource":{
+        "createInventory": "None"
+      },
+      "poLineDescription": "PO Line description",
+      "poLineNumber": "268s879-1",
+      "orderFormat": "Electronic Resource",
+      "cost":{
+        "listUnitPriceElectronic": 0,
+        "currency" : "USD",
+        "quantityElectronic": 1
+      },
+      "purchaseOrderId": "f56c70bc-8a31-4f56-b606-c6d8e597b7c1",
+      "rush" : false,
+      "source": "User",
+      "titleOrPackage": "Kayak Fishing in the Northern Gulf Coast",
+      "isPackage": false
+    },
+    {
+      "id": "d3fb56ac-918e-4d5f-b84d-ce121f9f8a21",
+      "checkinItems": false,
+      "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
+      "collection" : false,
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 1.0
+      },
+      "orderFormat": "Physical Resource",
+      "paymentStatus": "Payment Not Required",
+      "physical": {
+        "createInventory": "None",
+        "materialSupplier": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1"
+      },
+      "poLineNumber": "10000-1",
+      "purchaseOrderId": "f56c70bc-8a31-4f56-b606-c6d8e597b7c1",
+      "receiptDate": "2019-04-24T14:22:29.087+0000",
+      "receiptStatus": "Awaiting Receipt",
+      "rush" : false,
+      "source": "EDI",
+      "titleOrPackage": "Title",
+      "isPackage": false
+    },
+    {
+      "id": "1b02d557-c7c5-418b-a61a-077f804b630b",
+      "checkinItems": false,
+      "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
+      "collection" : false,
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 1.0
+      },
+      "orderFormat": "Physical Resource",
+      "paymentStatus": "Awaiting Payment",
+      "physical": {
+        "createInventory": "None",
+        "materialSupplier": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1"
+      },
+      "poLineNumber": "10000-1",
+      "purchaseOrderId": "f56c70bc-8a31-4f56-b606-c6d8e597b7c1",
+      "receiptDate": "2019-04-24T14:22:29.087+0000",
+      "receiptStatus": "Fully Received",
+      "rush" : false,
+      "source": "EDI",
+      "titleOrPackage": "Title",
+      "isPackage": false
+    }
+  ],
+  "metadata": {
+    "createdDate": "2022-04-06T00:00:00.000",
+    "createdByUserId": "28d10cfc-d137-11e8-a8d5-f2801f1b9fd1"
+  }
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-636](https://issues.folio.org/browse/MODORDERS-636) - Update po lines when an order is closed with the "Cancelled" reason

## Approach
- Update paymentStatus and receiptStatus for POLs when an order is closed with the "Cancelled" reason, with the exceptions given in the story.
- Changed `isCompletedPoLine()` to take into account the new values for paymentStatus and receiptStatus.
- Added a new unit test.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
