### PR TITLE
[MODORDERS-699] Delete all encumbrances when an order or line is deleted

### DIFF
--- a/src/main/java/org/folio/service/finance/transaction/TransactionService.java
+++ b/src/main/java/org/folio/service/finance/transaction/TransactionService.java
@@ -67,20 +67,12 @@ public class TransactionService {
 
   private CompletableFuture<List<Transaction>> getTransactionsChunksByPoLineIds(Collection<String> ids, String criteria, RequestContext requestContext) {
     String query = convertIdsToCqlQuery(ids, "encumbrance.sourcePoLineId") + " AND " + criteria;
-    return getTransactionsChunksByIds(query, requestContext);
+    return getTransactions(query, requestContext);
   }
 
   private CompletableFuture<List<Transaction>> getTransactionsChunksByIds(Collection<String> ids, RequestContext requestContext) {
     String query = convertIdsToCqlQuery(ids) ;
-    return getTransactionsChunksByIds(query, requestContext);
-  }
-
-  private CompletableFuture<List<Transaction>> getTransactionsChunksByIds(String query, RequestContext requestContext) {
-    RequestEntry requestEntry = new RequestEntry(ENDPOINT).withQuery(query)
-      .withOffset(0)
-      .withLimit(Integer.MAX_VALUE);
-    return restClient.get(requestEntry, requestContext, TransactionCollection.class)
-      .thenApply(TransactionCollection::getTransactions);
+    return getTransactions(query, requestContext);
   }
 
   public CompletableFuture<Transaction> createTransaction(Transaction transaction, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/finance/transaction/TransactionService.java
+++ b/src/main/java/org/folio/service/finance/transaction/TransactionService.java
@@ -33,13 +33,12 @@ public class TransactionService {
     this.restClient = restClient;
   }
 
-  public CompletableFuture<TransactionCollection> getTransactions(String query, int offset, int limit,
-                                                                  RequestContext requestContext) {
+  public CompletableFuture<List<Transaction>> getTransactions(String query, RequestContext requestContext) {
     RequestEntry requestEntry = new RequestEntry(ENDPOINT).withQuery(query)
-      .withOffset(offset)
-      .withLimit(limit);
-
-    return restClient.get(requestEntry, requestContext, TransactionCollection.class);
+      .withOffset(0)
+      .withLimit(Integer.MAX_VALUE);
+    return restClient.get(requestEntry, requestContext, TransactionCollection.class)
+      .thenApply(TransactionCollection::getTransactions);
   }
 
   public CompletableFuture<List<Transaction>> getTransactionsByPoLinesIds(List<String> trIds, String searchCriteria, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -35,7 +35,6 @@ import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.EncumbranceRollover;
@@ -252,8 +251,7 @@ public class OrderRolloverService {
   private CompletableFuture<List<Transaction>> getEncumbrancesForRollover(List<String> orderIds, LedgerFiscalYearRollover ledgerFYRollover,
                                                                           RequestContext requestContext) {
     String query = buildQueryEncumbrancesForRollover(orderIds, ledgerFYRollover);
-    return transactionService.getTransactions(query, 0, Integer.MAX_VALUE, requestContext)
-                                .thenApply(TransactionCollection::getTransactions);
+    return transactionService.getTransactions(query, requestContext);
   }
 
   private String buildQueryEncumbrancesForRollover(List<String> orderIds, LedgerFiscalYearRollover ledgerFYRollover) {

--- a/src/main/java/org/folio/service/orders/ReEncumbranceHoldersBuilder.java
+++ b/src/main/java/org/folio/service/orders/ReEncumbranceHoldersBuilder.java
@@ -25,7 +25,6 @@ import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.Ledger;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
@@ -260,8 +259,7 @@ public class ReEncumbranceHoldersBuilder {
         reEncumbranceHolder.getPurchaseOrder()
           .getId());
 
-    return transactionService.getTransactions(toQuery, 0, Integer.MAX_VALUE, requestContext)
-      .thenApply(TransactionCollection::getTransactions)
+    return transactionService.getTransactions(toQuery, requestContext)
       .thenApply(transactions -> {
         populateExistingToFYEncumbrances(holders, transactions);
         populateNonExistingToFYEncumbrances(holders);
@@ -311,8 +309,7 @@ public class ReEncumbranceHoldersBuilder {
       .findFirst()
       .map(holder -> String.format(GET_ORDER_TRANSACTIONS_QUERY_TEMPLATE, holder.getRollover()
         .getFromFiscalYearId(), holder.getPurchaseOrder().getId()))
-      .map(fromQuery -> transactionService.getTransactions(fromQuery, 0, Integer.MAX_VALUE, requestContext)
-        .thenApply(TransactionCollection::getTransactions)
+      .map(fromQuery -> transactionService.getTransactions(fromQuery, requestContext)
         .thenApply(transactions -> {
           var idTransactionMap = transactions.stream().collect(toMap(Transaction::getId, Function.identity()));
           return holders.stream()

--- a/src/main/java/org/folio/service/orders/TransactionsTotalFieldsPopulateService.java
+++ b/src/main/java/org/folio/service/orders/TransactionsTotalFieldsPopulateService.java
@@ -7,7 +7,6 @@ import java.util.function.ToDoubleFunction;
 
 import org.folio.models.CompositeOrderRetrieveHolder;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.service.finance.transaction.TransactionService;
 import org.javamoney.moneta.Money;
@@ -45,8 +44,7 @@ public class TransactionsTotalFieldsPopulateService implements CompositeOrderDyn
       RequestContext requestContext) {
     String query = String.format("transactionType==Encumbrance AND encumbrance.sourcePurchaseOrderId==%s AND fiscalYearId==%s",
         holder.getOrderId(), holder.getFiscalYearId());
-    return transactionService.getTransactions(query, 0, Integer.MAX_VALUE, requestContext)
-      .thenApply(TransactionCollection::getTransactions);
+    return transactionService.getTransactions(query, requestContext);
   }
 
   private double getTransactionsTotal(List<Transaction> transactions, ToDoubleFunction<Transaction> getAmount) {

--- a/src/test/java/org/folio/service/finance/transaction/EncumbranceServiceTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/EncumbranceServiceTest.java
@@ -6,7 +6,6 @@ import io.vertx.core.Vertx;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.FiscalYear;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.acq.model.invoice.Adjustment;
 import org.folio.rest.acq.model.invoice.InvoiceLine;
 import org.folio.rest.core.models.RequestContext;
@@ -128,10 +127,9 @@ public class EncumbranceServiceTest {
     List<Transaction> transactions = new ArrayList<>();
     transactions.add(encumbrance);
     transactions.add(encumbrance2);
-    TransactionCollection transactionCollection = new TransactionCollection().withTransactions(transactions).withTotalRecords(1);
 
     doReturn(completedFuture(fiscalYear)).when(fiscalYearService).getCurrentFiscalYearByFundId(anyString(), eq(requestContextMock));
-    doReturn(CompletableFuture.completedFuture(transactionCollection)).when(transactionService).getTransactions(anyString(), anyInt(), anyInt(), eq(requestContextMock));
+    doReturn(CompletableFuture.completedFuture(transactions)).when(transactionService).getTransactions(anyString(), eq(requestContextMock));
 
     //When
     CompletableFuture<List<Transaction>> result = encumbranceService.getPoLineReleasedEncumbrances(poLine, requestContextMock);
@@ -139,7 +137,7 @@ public class EncumbranceServiceTest {
     result.join();
 
     //Then
-    verify(transactionService, times(1)).getTransactions(anyString(), anyInt(), anyInt(), eq(requestContextMock));
+    verify(transactionService, times(1)).getTransactions(anyString(), eq(requestContextMock));
   }
 
   @Test
@@ -171,8 +169,7 @@ public class EncumbranceServiceTest {
     List<Transaction> transactions = new ArrayList<>();
     transactions.add(encumbrance);
     transactions.add(encumbrance2);
-    TransactionCollection transactionCollection = new TransactionCollection().withTransactions(transactions).withTotalRecords(1);
-    doReturn(CompletableFuture.completedFuture(transactionCollection)).when(transactionService).getTransactions(anyString(), anyInt(), anyInt(), eq(requestContextMock));
+    doReturn(CompletableFuture.completedFuture(transactions)).when(transactionService).getTransactions(anyString(), eq(requestContextMock));
 
     doReturn(CompletableFuture.completedFuture(null)).when(transactionSummariesService).updateOrderTransactionSummary(anyString(), anyInt(), eq(requestContextMock));
     doReturn(CompletableFuture.completedFuture(null)).when(transactionService).updateTransactions(any(), eq(requestContextMock));
@@ -205,8 +202,7 @@ public class EncumbranceServiceTest {
     List<Transaction> transactions = new ArrayList<>();
     transactions.add(encumbrance);
     transactions.add(encumbrance2);
-    TransactionCollection transactionCollection = new TransactionCollection().withTransactions(transactions).withTotalRecords(1);
-    doReturn(CompletableFuture.completedFuture(transactionCollection)).when(transactionService).getTransactions(anyString(), anyInt(), anyInt(), any());
+    doReturn(CompletableFuture.completedFuture(transactions)).when(transactionService).getTransactions(anyString(), any());
 
     doReturn(CompletableFuture.completedFuture(null)).when(transactionSummariesService).updateOrderTransactionSummary(any(), anyInt(), eq(requestContextMock));
     doReturn(CompletableFuture.completedFuture(null)).when(transactionService).updateTransactions(any(), eq(requestContextMock));

--- a/src/test/java/org/folio/service/orders/OrderReEncumberServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderReEncumberServiceTest.java
@@ -49,7 +49,6 @@ import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverError;
 import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverErrorCollection;
 import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgress;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
@@ -447,9 +446,9 @@ public class OrderReEncumberServiceTest {
     when(purchaseOrderLineService.saveOrderLines(anyList(), any())).thenReturn(completedFuture(null));
 
     CompletableFuture<Void> future = orderReEncumberService.reEncumber(orderId, requestContext);
-    TransactionCollection toTransactionCollection = new TransactionCollection().withTransactions(Collections.EMPTY_LIST).withTotalRecords(0);
-    when(transactionService.getTransactions(anyString(), eq(0), eq(Integer.MAX_VALUE), eq(requestContext)))
-        .thenReturn(completedFuture(toTransactionCollection));
+    List<Transaction> toTransactionList = Collections.emptyList();
+    when(transactionService.getTransactions(anyString(), eq(requestContext)))
+        .thenReturn(completedFuture(toTransactionList));
     when(transactionSummaryService.updateOrderTransactionSummary(eq(orderId), anyInt(), eq(requestContext))).thenReturn(completedFuture(null));
     when(transactionService.createTransaction(any(), eq(requestContext))).thenReturn(completedFuture(new Transaction()));
     future.join();
@@ -539,7 +538,7 @@ public class OrderReEncumberServiceTest {
         .withCurrency("USD");
 
 
-    TransactionCollection toTransactionCollection = new TransactionCollection().withTransactions(Collections.EMPTY_LIST).withTotalRecords(0);
+    List<Transaction> toTransactionList = Collections.emptyList();
 
     FundDistribution fundDistribution1 = new FundDistribution()
         .withDistributionType(FundDistribution.DistributionType.PERCENTAGE)
@@ -615,8 +614,8 @@ public class OrderReEncumberServiceTest {
 
     when(exchangeRateProviderResolver.resolve(conversionPoLineToFyQuery, requestContext)).thenReturn(exchangeRateProvider);
     when(exchangeRateProviderResolver.resolve(conversionFyToPoLineQuery, requestContext)).thenReturn(exchangeRateProvider);
-    when(transactionService.getTransactions(anyString(), eq(0), eq(Integer.MAX_VALUE), eq(requestContext)))
-        .thenReturn(completedFuture(toTransactionCollection));
+    when(transactionService.getTransactions(anyString(), eq(requestContext)))
+        .thenReturn(completedFuture(toTransactionList));
     when(transactionSummaryService.updateOrderTransactionSummary(eq(orderId), anyInt(), eq(requestContext))).thenReturn(completedFuture(null));
     when(transactionService.createTransaction(any(), eq(requestContext))).thenReturn(completedFuture(new Transaction()));
 

--- a/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
@@ -29,7 +29,6 @@ import javax.money.convert.ExchangeRateProvider;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.EncumbranceRollover;
@@ -170,8 +169,7 @@ public class OrderRolloverServiceTest {
       .withEncumbrance(encumbranceOngoing3).withExpenseClassId(expClassId3);
 
     List<Transaction> encumbrances = List.of(transactionOneTime, transactionOngoing2, transactionOngoing3);
-    TransactionCollection encumbranceCollection = new TransactionCollection().withTransactions(encumbrances).withTotalRecords(3);
-    doReturn(completedFuture(encumbranceCollection)).when(transactionService).getTransactions(anyString(), anyInt(), anyInt(), any());
+    doReturn(completedFuture(encumbrances)).when(transactionService).getTransactions(anyString(), any());
 
     double exchangeEurToUsdRate = 1.0d;
     doReturn(completedFuture(systemCurrency)).when(configurationEntriesService).getSystemCurrency(requestContext);
@@ -269,8 +267,7 @@ public class OrderRolloverServiceTest {
     Transaction transactionOneTime = new Transaction().withId(currEncumbrId1).withFromFundId(fundId1)
       .withEncumbrance(encumbranceOneTime);
     List<Transaction> encumbrances = List.of(transactionOneTime);
-    TransactionCollection encumbranceCollection = new TransactionCollection().withTransactions(encumbrances).withTotalRecords(1);
-    doReturn(completedFuture(encumbranceCollection)).when(transactionService).getTransactions(anyString(), anyInt(), anyInt(), any());
+    doReturn(completedFuture(encumbrances)).when(transactionService).getTransactions(anyString(), any());
 
     double exchangeEurToUsdRate = 1.0d;
     doReturn(completedFuture(systemCurrency)).when(configurationEntriesService).getSystemCurrency(requestContext);
@@ -387,8 +384,7 @@ public class OrderRolloverServiceTest {
       .withEncumbrance(encumbranceOngoing3).withExpenseClassId(expClassId3);
 
     List<Transaction> encumbrances = List.of(transactionOneTime, transactionOngoing2, transactionOngoing3);
-    TransactionCollection encumbranceCollection = new TransactionCollection().withTransactions(encumbrances).withTotalRecords(3);
-    doReturn(completedFuture(encumbranceCollection)).when(transactionService).getTransactions(anyString(), anyInt(), anyInt(), any());
+    doReturn(completedFuture(encumbrances)).when(transactionService).getTransactions(anyString(), any());
 
     double exchangeEurToUsdRate = 0.82858d;
     doReturn(completedFuture(systemCurrency)).when(configurationEntriesService).getSystemCurrency(requestContext);

--- a/src/test/java/org/folio/service/orders/ReEncumbranceHoldersBuilderTest.java
+++ b/src/test/java/org/folio/service/orders/ReEncumbranceHoldersBuilderTest.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
@@ -44,7 +43,6 @@ import org.folio.rest.acq.model.finance.FiscalYear;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.Ledger;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
@@ -680,11 +678,11 @@ public class ReEncumbranceHoldersBuilderTest {
 
     List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
 
-    TransactionCollection fromTransactionCollection = new TransactionCollection().withTransactions(Arrays.asList(fromEncumbrance1, fromEncumbrance2)).withTotalRecords(2);
-    TransactionCollection toTransactionCollection = new TransactionCollection().withTransactions(Collections.singletonList(toEncumbrance1)).withTotalRecords(1);
+    List<Transaction> fromTransactionList = Arrays.asList(fromEncumbrance1, fromEncumbrance2);
+    List<Transaction> toTransactionList = Collections.singletonList(toEncumbrance1);
 
-    when(transactionService.getTransactions(contains(fromFyId), anyInt(), anyInt(), any())).thenReturn(CompletableFuture.completedFuture(fromTransactionCollection));
-    when(transactionService.getTransactions(contains(toFyId), anyInt(), anyInt(), any())).thenReturn(CompletableFuture.completedFuture(toTransactionCollection));
+    when(transactionService.getTransactions(contains(fromFyId), any())).thenReturn(CompletableFuture.completedFuture(fromTransactionList));
+    when(transactionService.getTransactions(contains(toFyId), any())).thenReturn(CompletableFuture.completedFuture(toTransactionList));
 
     List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withPreviousFyEncumbrances(holders, requestContext).join();
 
@@ -761,11 +759,11 @@ public class ReEncumbranceHoldersBuilderTest {
 
     List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
 
-    TransactionCollection fromTransactionCollection = new TransactionCollection().withTransactions(Arrays.asList(fromEncumbrance1, fromEncumbrance2)).withTotalRecords(2);
-    TransactionCollection toTransactionCollection = new TransactionCollection().withTransactions(Collections.emptyList()).withTotalRecords(0);
+    List<Transaction> fromTransactionList = Arrays.asList(fromEncumbrance1, fromEncumbrance2);
+    List<Transaction> toTransactionList = Collections.emptyList();
 
-    when(transactionService.getTransactions(contains(fromFyId), anyInt(), anyInt(), any())).thenReturn(CompletableFuture.completedFuture(fromTransactionCollection));
-    when(transactionService.getTransactions(contains(toFyId), anyInt(), anyInt(), any())).thenReturn(CompletableFuture.completedFuture(toTransactionCollection));
+    when(transactionService.getTransactions(contains(fromFyId), any())).thenReturn(CompletableFuture.completedFuture(fromTransactionList));
+    when(transactionService.getTransactions(contains(toFyId), any())).thenReturn(CompletableFuture.completedFuture(toTransactionList));
 
     List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withPreviousFyEncumbrances(holders, requestContext).join();
 
@@ -837,7 +835,7 @@ public class ReEncumbranceHoldersBuilderTest {
     ManualCurrencyConversion poLineToFyConversion = mock(ManualCurrencyConversion.class, withSettings().name("poLineToFyConversion"));
     ManualCurrencyConversion poFyToPoLineConversion = mock(ManualCurrencyConversion.class, withSettings().name("poFyToPoLineConversion"));
 
-    TransactionCollection toTransactionCollection = new TransactionCollection().withTransactions(Collections.emptyList()).withTotalRecords(0);
+    List<Transaction> toTransactionList = Collections.emptyList();
 
     ReEncumbranceHolder holder1 = new ReEncumbranceHolder()
             .withPurchaseOrder(compPO)
@@ -862,7 +860,7 @@ public class ReEncumbranceHoldersBuilderTest {
 
     List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
 
-    when(transactionService.getTransactions(contains(toFyId), anyInt(), anyInt(), any())).thenReturn(CompletableFuture.completedFuture(toTransactionCollection));
+    when(transactionService.getTransactions(contains(toFyId), any())).thenReturn(CompletableFuture.completedFuture(toTransactionList));
 
     when(poLineToFyConversion.with(any())).thenReturn(poLineToFyConversion);
     when(poLineToFyConversion.apply(any(MonetaryAmount.class))).thenAnswer(invocation -> {

--- a/src/test/java/org/folio/service/orders/TransactionsTotalFieldsPopulateServiceTest.java
+++ b/src/test/java/org/folio/service/orders/TransactionsTotalFieldsPopulateServiceTest.java
@@ -2,10 +2,10 @@ package org.folio.service.orders;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -14,7 +14,6 @@ import org.folio.models.CompositeOrderRetrieveHolder;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.FiscalYear;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.service.finance.transaction.TransactionService;
@@ -61,9 +60,8 @@ public class TransactionsTotalFieldsPopulateServiceTest {
             .withEncumbrance(new Encumbrance().withAmountExpended(0d));
 
     List<Transaction> transactions = List.of(paidEncumbrance, notPaidEncumbrance);
-    TransactionCollection transactionCollection = new TransactionCollection().withTransactions(transactions);
 
-    when(transactionService.getTransactions(anyString(), anyInt(), anyInt(), any())).thenReturn(CompletableFuture.completedFuture(transactionCollection));
+    when(transactionService.getTransactions(anyString(), any())).thenReturn(CompletableFuture.completedFuture(transactions));
 
     CompositeOrderRetrieveHolder resultHolder = populateService.populate(holder, requestContext)
       .join();
@@ -92,7 +90,7 @@ public class TransactionsTotalFieldsPopulateServiceTest {
     CompositeOrderRetrieveHolder holder = new CompositeOrderRetrieveHolder(order)
             .withFiscalYear(new FiscalYear().withId(UUID.randomUUID().toString()));
 
-    when(transactionService.getTransactions(anyString(), anyInt(), anyInt(), any())).thenReturn(CompletableFuture.completedFuture(new TransactionCollection()));
+    when(transactionService.getTransactions(anyString(), any())).thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
 
     CompositeOrderRetrieveHolder resultHolder = populateService.populate(holder, requestContext).join();
 


### PR DESCRIPTION
## Purpose
[MODORDERS-699](https://issues.folio.org/browse/MODORDERS-699) - Encumbrances are not deleted after deleting Cancelled order

## Approach
- Delete all related encumbrances when an order or an order line is deleted, not just unreleased ones.
- Simplified the use of `getTransactions()`, as all calls were using `0, Integer.MAX_VALUE` and `TransactionCollection::getTransactions`. This is now returning a list of all matching transactions.
- Updated unit tests. No new unit test, but a new integration test is checking for the use case.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
