### PR TITLE
[MODORDERS-700] - Receive 'protected fields can’t be modified' error for eresource fields on PO line that is a Physical Resource

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -62,7 +62,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.completablefuture.FolioVertxCompletableFuture;
 import org.folio.orders.events.handlers.MessageAddress;
 import org.folio.orders.utils.HelperUtils;
-import org.folio.orders.utils.POLineProtectedFields;
+import org.folio.orders.utils.POLineProtectedFieldsUtil;
 import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.orders.utils.ProtectedOperationType;
 import org.folio.rest.RestConstants;
@@ -597,7 +597,7 @@ public class PurchaseOrderLineHelper {
     List<PoLine> existingPoLines) {
     if (poFromStorage.getWorkflowStatus() != PENDING) {
       compPO.getCompositePoLines()
-        .forEach(poLine -> verifyProtectedFieldsChanged(POLineProtectedFields.getFieldNames(poLine.getOrderFormat().value()),
+        .forEach(poLine -> verifyProtectedFieldsChanged(POLineProtectedFieldsUtil.getFieldNames(poLine.getOrderFormat().value()),
           findCorrespondingCompositePoLine(poLine, existingPoLines), JsonObject.mapFrom(poLine)));
     }
   }
@@ -930,7 +930,7 @@ public class PurchaseOrderLineHelper {
 
   private void validatePOLineProtectedFieldsChanged(CompositePoLine compOrderLine, JsonObject lineFromStorage, CompositePurchaseOrder purchaseOrder) {
     if (purchaseOrder.getWorkflowStatus() != PENDING) {
-      verifyProtectedFieldsChanged(POLineProtectedFields.getFieldNames(compOrderLine.getOrderFormat().value()), JsonObject.mapFrom(lineFromStorage.mapTo(PoLine.class)), JsonObject.mapFrom(compOrderLine));
+      verifyProtectedFieldsChanged(POLineProtectedFieldsUtil.getFieldNames(compOrderLine.getOrderFormat().value()), JsonObject.mapFrom(lineFromStorage.mapTo(PoLine.class)), JsonObject.mapFrom(compOrderLine));
     }
   }
 

--- a/src/main/java/org/folio/orders/utils/POLineFieldNames.java
+++ b/src/main/java/org/folio/orders/utils/POLineFieldNames.java
@@ -1,14 +1,6 @@
 package org.folio.orders.utils;
 
-import static org.folio.helper.PurchaseOrderLineHelper.ERESOURCE;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.folio.rest.jaxrs.model.CompositePoLine;
-
-public enum POLineProtectedFields {
+public enum POLineFieldNames {
 
   ACQUISITION_METHOD("acquisitionMethod"),
   CHECKIN_ITEMS("checkinItems"),
@@ -33,7 +25,7 @@ public enum POLineProtectedFields {
   LAST_EDI_EXPORT_DATE("lastEDIExportDate");
 
 
-  POLineProtectedFields(String field) {
+  POLineFieldNames(String field) {
     this.field = field;
   }
 
@@ -42,16 +34,4 @@ public enum POLineProtectedFields {
   }
 
   private String field;
-
-  public static List<String> getFieldNames(String orderFormat) {
-    if (!CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE.value().equals(orderFormat)) {
-      return Arrays.stream(POLineProtectedFields.values())
-                      .map(POLineProtectedFields::getFieldName)
-                      .filter(protectedPath -> !protectedPath.contains(ERESOURCE))
-                      .collect(Collectors.toList());
-    }
-    return Arrays.stream(POLineProtectedFields.values())
-                 .map(POLineProtectedFields::getFieldName)
-                 .collect(Collectors.toList());
-  }
 }

--- a/src/main/java/org/folio/orders/utils/POLineProtectedFieldsUtil.java
+++ b/src/main/java/org/folio/orders/utils/POLineProtectedFieldsUtil.java
@@ -36,22 +36,22 @@ import java.util.stream.Stream;
 import org.apache.commons.collections4.ListUtils;
 
 public class POLineProtectedFieldsUtil {
-  private final static List<String> commonProtectedFieldNames = Stream.of(ACQUISITION_METHOD, CHECKIN_ITEMS,
+  private static final List<String> commonProtectedFieldNames = Stream.of(ACQUISITION_METHOD, CHECKIN_ITEMS,
       COLLECTION, CONTRIBUTORS, DONOR, DETAILS_PRODUCT_IDS, DETAILS_SUBSCRIPTION_INTERVAL,
       ORDER_FORMAT, RUSH, SELECTOR, VENDORDETAIL_INSTRUCTION_TO_VENDOR, LAST_EDI_EXPORT_DATE)
     .map(POLineFieldNames::getFieldName).collect(Collectors.toList());
 
-  private final static List<String> elecProtectedFieldNames = Stream.of(ERESOURCE_CREATE_INVENTORY,
+  private static final List<String> elecProtectedFieldNames = Stream.of(ERESOURCE_CREATE_INVENTORY,
       ERESOURCE_TRIAL, ERESOURCE_LICENSE, ERESOURCE_MATERIAL_TYPE, ERESOURCE_USER_LIMIT)
     .map(POLineFieldNames::getFieldName).collect(Collectors.toList());
 
-  private final static List<String> physProtectedFieldNames = Stream.of(PHYSICAL_CREATE_INVENTORY,
+  private static final List<String> physProtectedFieldNames = Stream.of(PHYSICAL_CREATE_INVENTORY,
       PHYSICAL_VOLUMES, PHYSICAL_MATERIAL_TYPE)
     .map(POLineFieldNames::getFieldName).collect(Collectors.toList());
 
-  private final static List<String> physVsElecProtectedFieldNames = ListUtils.union(elecProtectedFieldNames, physProtectedFieldNames);
+  private static final List<String> physVsElecProtectedFieldNames = ListUtils.union(elecProtectedFieldNames, physProtectedFieldNames);
 
-  private final static Map<String, List<String>> protectedFieldsMap;
+  private static final Map<String, List<String>> protectedFieldsMap;
   static {
     protectedFieldsMap = new HashMap<>();
     protectedFieldsMap.put(P_E_MIX.value(), ListUtils.union(commonProtectedFieldNames, physVsElecProtectedFieldNames));

--- a/src/main/java/org/folio/orders/utils/POLineProtectedFieldsUtil.java
+++ b/src/main/java/org/folio/orders/utils/POLineProtectedFieldsUtil.java
@@ -1,0 +1,70 @@
+package org.folio.orders.utils;
+
+import static org.folio.orders.utils.POLineFieldNames.ACQUISITION_METHOD;
+import static org.folio.orders.utils.POLineFieldNames.CHECKIN_ITEMS;
+import static org.folio.orders.utils.POLineFieldNames.COLLECTION;
+import static org.folio.orders.utils.POLineFieldNames.CONTRIBUTORS;
+import static org.folio.orders.utils.POLineFieldNames.DETAILS_PRODUCT_IDS;
+import static org.folio.orders.utils.POLineFieldNames.DETAILS_SUBSCRIPTION_INTERVAL;
+import static org.folio.orders.utils.POLineFieldNames.DONOR;
+import static org.folio.orders.utils.POLineFieldNames.ERESOURCE_CREATE_INVENTORY;
+import static org.folio.orders.utils.POLineFieldNames.ERESOURCE_LICENSE;
+import static org.folio.orders.utils.POLineFieldNames.ERESOURCE_MATERIAL_TYPE;
+import static org.folio.orders.utils.POLineFieldNames.ERESOURCE_TRIAL;
+import static org.folio.orders.utils.POLineFieldNames.ERESOURCE_USER_LIMIT;
+import static org.folio.orders.utils.POLineFieldNames.LAST_EDI_EXPORT_DATE;
+import static org.folio.orders.utils.POLineFieldNames.ORDER_FORMAT;
+import static org.folio.orders.utils.POLineFieldNames.PHYSICAL_CREATE_INVENTORY;
+import static org.folio.orders.utils.POLineFieldNames.PHYSICAL_MATERIAL_TYPE;
+import static org.folio.orders.utils.POLineFieldNames.PHYSICAL_VOLUMES;
+import static org.folio.orders.utils.POLineFieldNames.RUSH;
+import static org.folio.orders.utils.POLineFieldNames.SELECTOR;
+import static org.folio.orders.utils.POLineFieldNames.VENDORDETAIL_INSTRUCTION_TO_VENDOR;
+import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE;
+import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.OTHER;
+import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.PHYSICAL_RESOURCE;
+import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.P_E_MIX;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.ListUtils;
+
+public class POLineProtectedFieldsUtil {
+  private final static List<String> commonProtectedFieldNames = Stream.of(ACQUISITION_METHOD, CHECKIN_ITEMS,
+      COLLECTION, CONTRIBUTORS, DONOR, DETAILS_PRODUCT_IDS, DETAILS_SUBSCRIPTION_INTERVAL,
+      ORDER_FORMAT, RUSH, SELECTOR, VENDORDETAIL_INSTRUCTION_TO_VENDOR, LAST_EDI_EXPORT_DATE)
+    .map(POLineFieldNames::getFieldName).collect(Collectors.toList());
+
+  private final static List<String> elecProtectedFieldNames = Stream.of(ERESOURCE_CREATE_INVENTORY,
+      ERESOURCE_TRIAL, ERESOURCE_LICENSE, ERESOURCE_MATERIAL_TYPE, ERESOURCE_USER_LIMIT)
+    .map(POLineFieldNames::getFieldName).collect(Collectors.toList());
+
+  private final static List<String> physProtectedFieldNames = Stream.of(PHYSICAL_CREATE_INVENTORY,
+      PHYSICAL_VOLUMES, PHYSICAL_MATERIAL_TYPE)
+    .map(POLineFieldNames::getFieldName).collect(Collectors.toList());
+
+  private final static List<String> physVsElecProtectedFieldNames = ListUtils.union(elecProtectedFieldNames, physProtectedFieldNames);
+
+  private final static Map<String, List<String>> protectedFieldsMap;
+  static {
+    protectedFieldsMap = new HashMap<>();
+    protectedFieldsMap.put(P_E_MIX.value(), ListUtils.union(commonProtectedFieldNames, physVsElecProtectedFieldNames));
+    protectedFieldsMap.put(ELECTRONIC_RESOURCE.value(), ListUtils.union(commonProtectedFieldNames, elecProtectedFieldNames));
+    protectedFieldsMap.put(PHYSICAL_RESOURCE.value(), ListUtils.union(commonProtectedFieldNames, physProtectedFieldNames));
+    protectedFieldsMap.put(OTHER.value(), ListUtils.union(commonProtectedFieldNames, physProtectedFieldNames));
+  }
+
+  private POLineProtectedFieldsUtil() {
+
+  }
+
+  public static List<String> getFieldNames(String orderFormat) {
+    return Optional.ofNullable(protectedFieldsMap.get(orderFormat)).orElse(Collections.emptyList());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -202,7 +202,7 @@ import org.folio.TestUtils;
 import org.folio.config.ApplicationConfig;
 import org.folio.orders.utils.AcqDesiredPermissions;
 import org.folio.orders.utils.HelperUtils;
-import org.folio.orders.utils.POLineProtectedFields;
+import org.folio.orders.utils.POLineFieldNames;
 import org.folio.orders.utils.POProtectedFields;
 import org.folio.rest.acq.model.Ongoing;
 import org.folio.rest.acq.model.PaymentStatus;
@@ -3497,10 +3497,10 @@ public class PurchaseOrdersApiTest {
 
     Map<String, Object> allProtectedFieldsModification = new HashMap<>();
 
-    allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineProtectedFields.CHECKIN_ITEMS.getFieldName()), true);
-    allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineProtectedFields.ACQUISITION_METHOD.getFieldName()),
+    allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineFieldNames.CHECKIN_ITEMS.getFieldName()), true);
+    allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineFieldNames.ACQUISITION_METHOD.getFieldName()),
       TestUtils.DEPOSITORY_METHOD);
-    allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineProtectedFields.ERESOURCE_USER_LIMIT.getFieldName()),
+    allProtectedFieldsModification.put(COMPOSITE_PO_LINES_PREFIX.concat(POLineFieldNames.ERESOURCE_USER_LIMIT.getFieldName()),
       100);
 
     checkPreventProtectedFieldsModificationRule(COMPOSITE_ORDERS_BY_ID_PATH, reqData, allProtectedFieldsModification);


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDERS-700

## Approach
1. Static lists of protected fields created in the class instead of building in each request new one.
2. Logic to retrieve list of fields moved to utility class

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
