### PR TITLE
[MODORDERS-725] Temporary fix for x-okapi-tenant header

### DIFF
--- a/src/main/java/org/folio/rest/RestConstants.java
+++ b/src/main/java/org/folio/rest/RestConstants.java
@@ -2,6 +2,7 @@ package org.folio.rest;
 
 public final class RestConstants {
   public static final String OKAPI_URL = "x-okapi-url";
+  public static final String OKAPI_TENANT_LOWCASE = "x-okapi-tenant";
   public static final String SEARCH_ENDPOINT = "%s?limit=%s&offset=%s%s";
   public static final int MAX_IDS_FOR_GET_RQ = 15;
   public static final String PATH_PARAM_PLACE_HOLDER = ":id";

--- a/src/main/java/org/folio/rest/core/RestClient.java
+++ b/src/main/java/org/folio/rest/core/RestClient.java
@@ -7,6 +7,7 @@ import static org.folio.orders.utils.HelperUtils.verifyAndExtractBody;
 import static org.folio.orders.utils.HelperUtils.verifyResponse;
 import static org.folio.rest.RestConstants.ERROR_MESSAGE;
 import static org.folio.rest.RestConstants.NOT_FOUND;
+import static org.folio.rest.RestConstants.OKAPI_TENANT_LOWCASE;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 import java.util.Collections;
@@ -343,9 +344,9 @@ public class RestClient {
 
   private Map<String, String> fixHeadersForRMB34(Map<String, String> requestHeaders) {
     Map<String, String> headers = new HashMap<>(requestHeaders);
-    if (headers.get("x-okapi-tenant") != null) {
-      String tenantId = headers.get("x-okapi-tenant");
-      headers.remove("x-okapi-tenant");
+    if (headers.get(OKAPI_TENANT_LOWCASE) != null) {
+      String tenantId = headers.get(OKAPI_TENANT_LOWCASE);
+      headers.remove(OKAPI_TENANT_LOWCASE);
       headers.put(OKAPI_HEADER_TENANT, tenantId);
     }
     return headers;

--- a/src/main/java/org/folio/rest/core/RestClient.java
+++ b/src/main/java/org/folio/rest/core/RestClient.java
@@ -10,6 +10,7 @@ import static org.folio.rest.RestConstants.NOT_FOUND;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -54,7 +55,7 @@ public class RestClient {
 
     HttpClientInterface client = getHttpClient(requestContext.getHeaders());
     try {
-      client.request(HttpMethod.POST, recordData.toBuffer(), endpoint, requestContext.getHeaders())
+      client.request(HttpMethod.POST, recordData.toBuffer(), endpoint, fixHeadersForRMB34(requestContext.getHeaders()))
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenAccept(body -> {
           client.closeClient();
@@ -91,7 +92,7 @@ public class RestClient {
     HttpClientInterface client = getHttpClient(requestContext.getHeaders());
     try {
       client
-        .request(HttpMethod.POST, recordData.toBuffer(), endpoint, requestContext.getHeaders())
+        .request(HttpMethod.POST, recordData.toBuffer(), endpoint, fixHeadersForRMB34(requestContext.getHeaders()))
         .thenApply(response -> {
           client.closeClient();
           if (postResponseType == PostResponseType.BODY) {
@@ -170,7 +171,7 @@ public class RestClient {
     setDefaultHeaders(client);
     try {
       client
-          .request(httpMethod, recordData.toBuffer(), endpoint, requestContext.getHeaders())
+          .request(httpMethod, recordData.toBuffer(), endpoint, fixHeadersForRMB34(requestContext.getHeaders()))
           .thenAccept(HelperUtils::verifyResponse)
           .thenAccept(avoid -> {
             client.closeClient();
@@ -201,7 +202,7 @@ public class RestClient {
     setDefaultHeaders(client);
 
     try {
-      client.request(HttpMethod.DELETE, endpoint, requestContext.getHeaders())
+      client.request(HttpMethod.DELETE, endpoint, fixHeadersForRMB34(requestContext.getHeaders()))
         .thenAccept(response -> {
           client.closeClient();
           int code = response.getCode();
@@ -242,7 +243,7 @@ public class RestClient {
 
     try {
       client
-        .request(HttpMethod.GET, endpoint, requestContext.getHeaders())
+        .request(HttpMethod.GET, endpoint, fixHeadersForRMB34(requestContext.getHeaders()))
         .thenApply(response -> {
           int code = response.getCode();
           if (code == NOT_FOUND && skipThrowNorFoundException) {
@@ -289,7 +290,7 @@ public class RestClient {
     logger.debug("Calling GET {}", endpoint);
     try {
       client
-        .request(HttpMethod.GET, endpoint, requestContext.getHeaders())
+        .request(HttpMethod.GET, endpoint, fixHeadersForRMB34(requestContext.getHeaders()))
         .thenApply(response -> {
           int code = response.getCode();
           if (code == NOT_FOUND && skipThrowNorFoundException) {
@@ -338,5 +339,15 @@ public class RestClient {
   private void setDefaultHeaders(HttpClientInterface httpClient) {
     // The RMB's HttpModuleClient2.ACCEPT is in sentence case. Using the same format to avoid duplicates
     httpClient.setDefaultHeaders(Collections.singletonMap("Accept", APPLICATION_JSON + ", " + TEXT_PLAIN));
+  }
+
+  private Map<String, String> fixHeadersForRMB34(Map<String, String> requestHeaders) {
+    Map<String, String> headers = new HashMap<>(requestHeaders);
+    if (headers.get("x-okapi-tenant") != null) {
+      String tenantId = headers.get("x-okapi-tenant");
+      headers.remove("x-okapi-tenant");
+      headers.put(OKAPI_HEADER_TENANT, tenantId);
+    }
+    return headers;
   }
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-725](https://issues.folio.org/browse/MODORDERS-725) - Temporary workaround for issue with x-okapi-tenant header

## Approach
Updated RestClient as described in the JIRA.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
