### PR TITLE
[MODORDERS-714] - Fix issue with Receipt and Payment statuses when order is transited from Cancel to Open(ReOpen)

### DIFF
--- a/src/test/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManagerTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManagerTest.java
@@ -109,8 +109,8 @@ public class ReOpenCompositeOrderManagerTest {
 
   @ParameterizedTest
   @CsvSource(value = {"Open:Expected:Awaiting Receipt:Awaiting Payment",
-                      "Approved:Received:Partially Received:Partially Paid",
-                      "Paid:Received:Partially Received:Partially Paid"}, delimiter = ':')
+                      "Approved:Received:Partially Received:Fully Paid",
+                      "Paid:Received:Partially Received:Fully Paid"}, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveSameStatuses(
         String invoiceStatus, String pieceStatus, String expReceiptStatus, String expPaymentStatus)
                       throws ExecutionException, InterruptedException {
@@ -172,12 +172,16 @@ public class ReOpenCompositeOrderManagerTest {
   }
 
   @ParameterizedTest
-  @CsvSource(value = {"Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Partially Paid",
-                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Partially Paid:Awaiting Payment",
-                      "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Partially Paid:Awaiting Payment"}, delimiter = ':')
+  @CsvSource(value = {"Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Partially Paid:true:false",
+                      "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Fully Paid:true:true",
+                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment:true:true",
+                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment:true:false",
+                      "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Fully Paid:Awaiting Payment:true:true",
+                      "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Partially Paid:Awaiting Payment:false:true"}, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveDifferentStatuses(
                   String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
-                  String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2)
+                  String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2,
+                  boolean releaseEncumbrances1, boolean releaseEncumbrances2)
     throws ExecutionException, InterruptedException {
     CompositePurchaseOrder oldOrder = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     CompositePoLine poLine1 = oldOrder.getCompositePoLines().get(0);
@@ -203,12 +207,14 @@ public class ReOpenCompositeOrderManagerTest {
       .withId(UUID.randomUUID().toString())
       .withInvoiceId(invoice1.getId())
       .withPoLineId(poLineId1)
+      .withReleaseEncumbrance(releaseEncumbrances1)
       .withFundDistributions(List.of(new org.folio.rest.acq.model.invoice.FundDistribution()
         .withEncumbrance(encumbrance1Id)));
     InvoiceLine invoiceLine2 = new InvoiceLine()
       .withId(UUID.randomUUID().toString())
       .withInvoiceId(invoice2.getId())
       .withPoLineId(poLineId2)
+      .withReleaseEncumbrance(releaseEncumbrances2)
       .withFundDistributions(List.of(new org.folio.rest.acq.model.invoice.FundDistribution()
         .withEncumbrance(encumbrance2Id)));
     List<InvoiceLine> invoiceLines = List.of(invoiceLine1, invoiceLine2);
@@ -238,9 +244,9 @@ public class ReOpenCompositeOrderManagerTest {
 
   @ParameterizedTest
   @CsvSource(value = {
-    "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Partially Paid",
-    "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Partially Paid:Awaiting Payment",
-    "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Partially Paid:Awaiting Payment"
+    "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Fully Paid",
+    "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment",
+    "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Fully Paid:Awaiting Payment"
   }, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveDifferentStatusesAndPolCoveredMoreThenOneInvoice(
     String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Needs to rollback Receipt and Payment statuses after transition order from Cancel to Open (Reopen Flow)

## Approach
There is a logic in the mod-invoice which a responsible for updating POL statuses when invoice Approve or Paid.
Rollback statuses logic now implemented based on mod-invoice logic 

#### TODOS and Open Questions
Still have tests which randomly fail and will be fixed in scope of https://issues.folio.org/browse/MODORDERS-728
Test failing is not related to ReOPen logic and related to Protected field validation 

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
