### PR TITLE
[MODORDERS-730] Item not appearing under holdings after instance connection change

### DIFF
--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.folio.models.orders.lines.update.OrderLineUpdateInstanceHolder;
 import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.rest.acq.model.StoragePatchOrderLineRequest;
@@ -85,7 +86,7 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
               .thenCompose(newHoldingId -> {
                 holder.addHoldingRefsToStoragePatchOrderLineRequest(holdingId, newHoldingId);
                 CompositePoLine compositePoLine = PoLineCommonUtil.convertToCompositePoLine(holder.getStoragePoLine());
-                if (PoLineCommonUtil.isItemsUpdateRequired(compositePoLine)) {
+                if (ObjectUtils.notEqual(holdingId, newHoldingId)) {
                   return updateItemsHolding(holdingId, newHoldingId, compositePoLine.getId(), requestContext);
                 } else {
                   return CompletableFuture.completedFuture(null);

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -111,11 +111,7 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
             .thenCompose(newHoldingId -> {
                 holder.addHoldingRefsToStoragePatchOrderLineRequest(holdingId, newHoldingId);
                 CompositePoLine compositePoLine = PoLineCommonUtil.convertToCompositePoLine(holder.getStoragePoLine());
-                if (PoLineCommonUtil.isItemsUpdateRequired(compositePoLine)) {
-                  return updateItemsHolding(holdingId, newHoldingId, compositePoLine.getId(), requestContext);
-                } else {
-                  return CompletableFuture.completedFuture(null);
-                }
+                return updateItemsHolding(holdingId, newHoldingId, compositePoLine.getId(), requestContext);
             })
         );
       }

--- a/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
+++ b/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
@@ -12,6 +12,8 @@ import static org.folio.service.inventory.InventoryManager.ITEM_STATUS;
 import static org.folio.service.inventory.InventoryManager.ITEM_STATUS_NAME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -200,16 +202,28 @@ public class WithHoldingOrderLineUpdateInstanceStrategyTest {
         .withStoragePoLine(poLine)
         .withPathOrderLineRequest(patchOrderLineRequest);
 
+    List<JsonObject> items = holdingIds.stream().map(holdingId -> {
+      JsonObject item = new JsonObject().put(TestConstants.ID, UUID.randomUUID().toString());
+      item.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ItemStatus.ON_ORDER.value()));
+      item.put(ITEM_HOLDINGS_RECORD_ID, holdingId);
+      return item;
+    }).collect(toList());
+
 
     doReturn(completedFuture(UUID.randomUUID().toString())).when(inventoryManager)
         .getOrCreateHoldingRecordByInstanceAndLocation(eq(instanceId), eq(locations.get(0)), eq(requestContext));
     doReturn(completedFuture(UUID.randomUUID().toString())).when(inventoryManager)
         .getOrCreateHoldingRecordByInstanceAndLocation(eq(instanceId), eq(locations.get(1)), eq(requestContext));
+    doReturn(completedFuture(List.of(items.get(0)))).when(inventoryManager).getItemsByHoldingIdAndOrderLineId(eq(holdingIds.get(0)), eq(orderLineId), eq(requestContext));
+    doReturn(completedFuture(List.of(items.get(1)))).when(inventoryManager).getItemsByHoldingIdAndOrderLineId(eq(holdingIds.get(1)), eq(orderLineId), eq(requestContext));
+    doReturn(completedFuture(null)).when(inventoryManager).updateItem(any(JsonObject.class), eq(requestContext));
 
     withHoldingOrderLineUpdateInstanceStrategy.updateInstance(orderLineUpdateInstanceHolder, requestContext).join();
 
     verify(inventoryManager, times(1)).getOrCreateHoldingRecordByInstanceAndLocation(instanceId, locations.get(0), requestContext);
     verify(inventoryManager, times(1)).getOrCreateHoldingRecordByInstanceAndLocation(instanceId, locations.get(1), requestContext);
+    verify(inventoryManager, times(2)).getItemsByHoldingIdAndOrderLineId(anyString(), anyString(), any(RequestContext.class));
+    verify(inventoryManager, times(2)).updateItem(any(JsonObject.class), any(RequestContext.class));
   }
 
   @Test
@@ -304,6 +318,13 @@ public class WithHoldingOrderLineUpdateInstanceStrategyTest {
         .withStoragePoLine(poLine)
         .withPathOrderLineRequest(patchOrderLineRequest);
 
+    List<JsonObject> items = holdingIds.stream().map(holdingId -> {
+      JsonObject item = new JsonObject().put(TestConstants.ID, UUID.randomUUID().toString());
+      item.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ItemStatus.ON_ORDER.value()));
+      item.put(ITEM_HOLDINGS_RECORD_ID, holdingId);
+      return item;
+    }).collect(toList());
+
 
     doReturn(completedFuture(UUID.randomUUID().toString())).when(inventoryManager)
         .getOrCreateHoldingRecordByInstanceAndLocation(eq(instanceId), eq(locations.get(0)), eq(requestContext));
@@ -313,6 +334,9 @@ public class WithHoldingOrderLineUpdateInstanceStrategyTest {
     doReturn(completedFuture(new ArrayList())).when(inventoryManager).getItemsByHoldingId(eq(holdingIds.get(1)), eq(requestContext));
     doReturn(completedFuture(null)).when(inventoryManager).deleteHoldingById(eq(holdingIds.get(0)), eq(true), eq(requestContext));
     doReturn(completedFuture(null)).when(inventoryManager).deleteHoldingById(eq(holdingIds.get(0)), eq(true), eq(requestContext));
+    doReturn(completedFuture(List.of(items.get(0)))).when(inventoryManager).getItemsByHoldingIdAndOrderLineId(eq(holdingIds.get(0)), eq(orderLineId), eq(requestContext));
+    doReturn(completedFuture(List.of(items.get(1)))).when(inventoryManager).getItemsByHoldingIdAndOrderLineId(eq(holdingIds.get(1)), eq(orderLineId), eq(requestContext));
+    doReturn(completedFuture(null)).when(inventoryManager).updateItem(any(JsonObject.class), eq(requestContext));
 
     withHoldingOrderLineUpdateInstanceStrategy.updateInstance(orderLineUpdateInstanceHolder, requestContext).join();
 
@@ -320,6 +344,8 @@ public class WithHoldingOrderLineUpdateInstanceStrategyTest {
     verify(inventoryManager, times(1)).getOrCreateHoldingRecordByInstanceAndLocation(instanceId, locations.get(1), requestContext);
     verify(inventoryManager, times(1)).deleteHoldingById(eq(holdingIds.get(0)), eq(true), eq(requestContext));
     verify(inventoryManager, times(1)).deleteHoldingById(eq(holdingIds.get(1)), eq(true), eq(requestContext));
+    verify(inventoryManager, times(2)).getItemsByHoldingIdAndOrderLineId(anyString(), anyString(), any(RequestContext.class));
+    verify(inventoryManager, times(2)).updateItem(any(JsonObject.class), any(RequestContext.class));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
When in  PoLine receiving workflow set as Independent items is not updated.

## Approach

- Replacing logic of checking need to update item when using patch method with holdingsOperation - find or replace. We should just compare current and new holdings.

## Learning
[MODORDERS-730](https://issues.folio.org/browse/MODORDERS-730)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
