### PR TITLE
MODORDERS-761: Support inventory 12.0 in ModuleDescriptor "requires"

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -971,7 +971,7 @@
     },
     {
       "id": "inventory",
-      "version": "10.5 11.0"
+      "version": "10.5 11.0 12.0"
     },
     {
       "id": "instance-types",


### PR DESCRIPTION
Add version 12.0 to the list of supported inventory interface versions in ModuleDescriptor "requires" section.

DELETE /inventory/instances and DELETE /inventory/items have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

mod-orders doesn't need any code change for this because it doesn't use these two DELETE APIs.