### PR TITLE
MODORDERS-778 - Temporary disable data-import verticle deployment

### DIFF
--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -46,15 +46,18 @@ public class InitAPIs implements InitAPI {
         DatabindCodec.mapper().setConfig(deserializationConfig);
         DatabindCodec.prettyMapper().setConfig(deserializationConfig);
         SpringContextUtil.init(vertx, context, ApplicationConfig.class);
-        SpringContextUtil.autowireDependencies(this, context);
-        deployConsumersVerticles(vertx).onSuccess(hdr -> {
-            handler.handle(Future.succeededFuture());
-            LOGGER.info("Consumer Verticles were successfully started");
-          })
-          .onFailure(th -> {
-            handler.handle(Future.failedFuture(th));
-            LOGGER.error("Consumer Verticles were not started", th);
-          });
+        handler.complete();
+
+//        TODO: will be uncommented in scope of the https://issues.folio.org/browse/MODORDERS-773
+//        SpringContextUtil.autowireDependencies(this, context);
+//        deployConsumersVerticles(vertx).onSuccess(hdr -> {
+//            handler.handle(Future.succeededFuture());
+//            LOGGER.info("Consumer Verticles were successfully started");
+//          })
+//          .onFailure(th -> {
+//            handler.handle(Future.failedFuture(th));
+//            LOGGER.error("Consumer Verticles were not started", th);
+//          });
       },
       result -> {
         if (result.succeeded()) {

--- a/src/test/java/org/folio/di/DataImportTest.java
+++ b/src/test/java/org/folio/di/DataImportTest.java
@@ -10,6 +10,7 @@ import org.folio.rest.jaxrs.model.Event;
 import org.folio.verticle.consumers.DataImportKafkaHandler;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -21,6 +22,8 @@ import static org.folio.DataImportEventTypes.DI_COMPLETED;
 import static org.folio.DataImportEventTypes.DI_ERROR;
 import static org.junit.Assert.assertTrue;
 
+// TODO: tests will be enabled in scope of the https://issues.folio.org/browse/MODORDERS-773
+@Ignore()
 @RunWith(VertxUnitRunner.class)
 public class DataImportTest extends DiAbstractRestTest {
 


### PR DESCRIPTION
## Purpose
it is necessary to prevent the mod-orders module from subscription to Kafka events to avoid unused interaction with Kafka, since in the Nolana the module is not involved in the data-import process and data-import events handling.


## Learning
[MODORDERS-778](https://issues.folio.org/browse/MODORDERS-778)
