### PR TITLE
MODORDERS-817: Retry mechanism for poLine creation was added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,11 @@
       <artifactId>vertx-concurrent</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-circuit-breaker</artifactId>
+      <version>4.3.8</version>
+    </dependency>
     <!--vertx-rx-java required for vertx-concurrent-1.0.0 -->
     <dependency>
       <groupId>io.vertx</groupId>

--- a/src/main/java/org/folio/dao/SequentialOrderIdStorageDaoImpl.java
+++ b/src/main/java/org/folio/dao/SequentialOrderIdStorageDaoImpl.java
@@ -1,35 +1,42 @@
 package org.folio.dao;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.dao.util.PostgresClientFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import static java.lang.String.format;
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 
 @Repository
 public class SequentialOrderIdStorageDaoImpl implements SequentialOrderIdStorageDao {
 
+  private static final Logger LOGGER = LogManager.getLogger();
+
   private static final String TABLE_NAME = "sequential_order_id";
 
-  private static final String ORDER_ID_FIELD = "order_id";
-
   private static final String SQL =
-    "WITH input_row(job_execution_id, sequential_no, order_id) AS " +
-      "(VALUES ($1, $2, $3)), " +
+    "WITH input_row(job_execution_id, sequential_no, order_id, saved_timestamp) AS " +
+      "(VALUES ($1, $2, $3, $4)), " +
       "insert_res AS ( " +
-      "  INSERT INTO %1$s (job_execution_id, sequential_no, order_id) " +
+      "  INSERT INTO %1$s (job_execution_id, sequential_no, order_id, saved_timestamp) " +
       "  SELECT * FROM input_row " +
       "  ON CONFLICT ON CONSTRAINT sequential_order_pk_constraint DO NOTHING " +
-      "  RETURNING job_execution_id, sequential_no, order_id " +
+      "  RETURNING job_execution_id, sequential_no, order_id, saved_timestamp " +
       ") " +
-      "SELECT job_execution_id, sequential_no, order_id " +
+      "SELECT order_id " +
       "FROM insert_res " +
       "UNION ALL " +
-      "SELECT t.job_execution_id, t.sequential_no, t.order_id " +
+      "SELECT t.order_id " +
       "FROM %1$s t, input_row " +
       "WHERE t.job_execution_id = input_row.job_execution_id AND t.sequential_no = input_row.sequential_no";
 
@@ -42,16 +49,20 @@ public class SequentialOrderIdStorageDaoImpl implements SequentialOrderIdStorage
 
   @Override
   public Future<String> store(String jobExecutionId, Integer sequenceNo, String orderId, String tenantId) {
-    String table = prepareFullTableName(tenantId, TABLE_NAME);
-    String sql = String.format(SQL, table);
-    Tuple params = Tuple.of(UUID.fromString(jobExecutionId), sequenceNo, UUID.fromString(orderId));
-
-    return pgClientFactory.createInstance(tenantId).execute(sql, params)
-      .map(rows -> rows.iterator().next().getValue(ORDER_ID_FIELD).toString());
+    Promise<RowSet<Row>> promise = Promise.promise();
+    try {
+      LOGGER.trace("store:: jobExecutionId: {}, sequenceNo: {}, orderId: {}", jobExecutionId, sequenceNo, tenantId);
+      String query = String.format(SQL, prepareFullTableName(tenantId, TABLE_NAME));
+      Tuple params = Tuple.of(UUID.fromString(jobExecutionId), sequenceNo, UUID.fromString(orderId), LocalDateTime.now());
+      pgClientFactory.createInstance(tenantId).execute(query, params, promise);
+    } catch (Exception e) {
+      LOGGER.error("store:: failed to store jobExecutionId: {}, sequenceNo: {}, orderId: {}", jobExecutionId, sequenceNo, tenantId, e);
+      promise.fail(e);
+    }
+    return promise.future().map(resultSet -> resultSet.iterator().next().getUUID(0).toString());
   }
 
   private String prepareFullTableName(String tenantId, String table) {
     return String.format("%s.%s", convertToPsqlStandard(tenantId), table);
   }
-
 }

--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -208,11 +208,23 @@ public class PurchaseOrderHelper {
   }
 
   /**
+   * Get purchase order by Id
+   *
+   * @param orderId purchase order id
+   * @return completable future with {@link PurchaseOrder} object
+   */
+  public Future<PurchaseOrder> getPurchaseOrderById(String orderId, RequestContext requestContext) {
+    logger.info("getPurchaseOrderById:: orderId: {}", orderId);
+    return purchaseOrderStorageService.getPurchaseOrderById(orderId, requestContext);
+  }
+
+  /**
    * Create a purchase order (PO) and a number of PO lines if provided.
    * @param compPO {@link CompositePurchaseOrder} object representing Purchase Order and optionally Purchase Order Line details.
    * @return completable future with {@link CompositePurchaseOrder} object with populated uuid on success or an exception if processing fails
    */
   public Future<CompositePurchaseOrder> createPurchaseOrder(CompositePurchaseOrder compPO, JsonObject tenantConfiguration, RequestContext requestContext) {
+    logger.info("createPurchaseOrder :: orderId: {}", compPO.getId());
     return validateNewPurchaseOrders(compPO, tenantConfiguration, requestContext)
       .compose(v -> setPoNumberIfMissing(compPO, requestContext))
       .compose(v -> processPoLineTags(compPO, requestContext))
@@ -223,6 +235,7 @@ public class PurchaseOrderHelper {
   }
 
   private Future<Void> validateNewPurchaseOrders(CompositePurchaseOrder compPO, JsonObject tenantConfiguration, RequestContext requestContext) {
+    logger.info("validateNewPurchaseOrders :: orderId: {}", compPO.getId());
     List<Future<Void>> futures = new ArrayList<>();
 
     futures.add(validateAcqUnitsOnCreate(compPO.getAcqUnitIds(), requestContext));
@@ -513,6 +526,7 @@ public class PurchaseOrderHelper {
   }
 
   private Future<Void> setPoNumberIfMissing(CompositePurchaseOrder compPO, RequestContext requestContext) {
+    logger.info("setPoNumberIfMissing :: orderId: {}", compPO.getId());
     if (null == compPO.getPoNumber()) {
       return poNumberHelper.generatePoNumber(requestContext)
         .onSuccess(compPO::setPoNumber)
@@ -557,6 +571,7 @@ public class PurchaseOrderHelper {
 
   private Future<CompositePurchaseOrder> createPOandPOLines(CompositePurchaseOrder compPO, JsonObject cachedTenantConfiguration,
                                                                       RequestContext requestContext) {
+    logger.info("createPOandPOLines :: orderId: {}", compPO.getId());
     final WorkflowStatus finalStatus = compPO.getWorkflowStatus();
 
     // we should always create PO and PO lines in PENDING status and transition to OPEN only when it's all set
@@ -813,6 +828,7 @@ public class PurchaseOrderHelper {
   }
 
   private Future<Void> setCreateInventoryDefaultValues(CompositePurchaseOrder compPO, JsonObject tenantConfiguration) {
+    logger.info("setCreateInventoryDefaultValues:: orderId: {}", compPO.getId());
     List<Future<Void>> futures = compPO.getCompositePoLines()
       .stream()
       .map(compPOL -> purchaseOrderLineHelper.setTenantDefaultCreateInventoryValues(compPOL, tenantConfiguration))
@@ -823,6 +839,7 @@ public class PurchaseOrderHelper {
   }
 
   private Future<CompositePurchaseOrder> populateOrderSummary(CompositePurchaseOrder order, RequestContext requestContext) {
+    logger.info("populateOrderSummary :: orderId: {}", order.getId());
     return orderLinesSummaryPopulateService.populate(new CompositeOrderRetrieveHolder(order), requestContext)
       .map(CompositeOrderRetrieveHolder::getOrder);
   }

--- a/src/main/resources/templates/db_scripts/create_sequential_order_id_table.sql
+++ b/src/main/resources/templates/db_scripts/create_sequential_order_id_table.sql
@@ -2,5 +2,6 @@ CREATE TABLE IF NOT EXISTS sequential_order_id (
   job_execution_id uuid NOT NULL,
   sequential_no integer NOT NULL,
   order_id uuid NOT NULL,
+  saved_timestamp timestamp,
   CONSTRAINT sequential_order_pk_constraint PRIMARY KEY(job_execution_id, sequential_no)
 );


### PR DESCRIPTION
## Purpose
Since the order is saved by REST and this is a slow operation, while new packets from Kafka come in faster, we faced a problem when the orderId was created, but the order has not been created yet. 

## Approach
The retry mechanism was added to fix this problem.

## Learning
[MODORDERS-817](https://issues.folio.org/browse/MODORDERS-817)