### PR TITLE
Add limit for retrieving organizations

### DIFF
--- a/src/main/java/org/folio/service/caches/MappingParametersCache.java
+++ b/src/main/java/org/folio/service/caches/MappingParametersCache.java
@@ -28,9 +28,11 @@ import java.util.concurrent.TimeUnit;
 public class MappingParametersCache {
   private static final Logger LOGGER = LogManager.getLogger();
   public static final String ORGANIZATIONS = "/organizations/organizations?limit=%s";
-  public static final int ORGANIZATIONS_LIMIT = 1000;
 
-  @Value("${orders.cache.organization.expiration.seconds:3600}")
+  @Value("${orders.cache.mapping.parameters.settings.limit:1000}")
+  public int settingsLimit;
+
+  @Value("${orders.cache.mapping.parameters.expiration.seconds:3600}")
   private long cacheExpirationTime;
 
   private AsyncCache<String, MappingParameters> cache;
@@ -67,7 +69,7 @@ public class MappingParametersCache {
     LOGGER.debug("loadMappingParameters:: Trying to load organizations '{}' for cache, okapi url: {}, tenantId: {}",
       tenantId, params.getOkapiUrl(), params.getTenantId());
 
-    return RestUtil.doRequest(params, String.format(ORGANIZATIONS, ORGANIZATIONS_LIMIT), HttpMethod.GET, null)
+    return RestUtil.doRequest(params, String.format(ORGANIZATIONS, settingsLimit), HttpMethod.GET, null)
       .toCompletionStage()
       .toCompletableFuture()
       .thenCompose(httpResponse -> {

--- a/src/main/java/org/folio/service/caches/MappingParametersCache.java
+++ b/src/main/java/org/folio/service/caches/MappingParametersCache.java
@@ -27,7 +27,8 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class MappingParametersCache {
   private static final Logger LOGGER = LogManager.getLogger();
-  public static final String ORGANIZATIONS = "/organizations/organizations";
+  public static final String ORGANIZATIONS = "/organizations/organizations?limit=%s";
+  public static final int ORGANIZATIONS_LIMIT = 1000;
 
   @Value("${orders.cache.organization.expiration.seconds:3600}")
   private long cacheExpirationTime;
@@ -66,7 +67,7 @@ public class MappingParametersCache {
     LOGGER.debug("loadMappingParameters:: Trying to load organizations '{}' for cache, okapi url: {}, tenantId: {}",
       tenantId, params.getOkapiUrl(), params.getTenantId());
 
-    return RestUtil.doRequest(params, ORGANIZATIONS, HttpMethod.GET, null)
+    return RestUtil.doRequest(params, String.format(ORGANIZATIONS, ORGANIZATIONS_LIMIT), HttpMethod.GET, null)
       .toCompletionStage()
       .toCompletableFuture()
       .thenCompose(httpResponse -> {

--- a/src/test/java/org/folio/di/CacheTest.java
+++ b/src/test/java/org/folio/di/CacheTest.java
@@ -96,7 +96,7 @@ public class CacheTest {
     organization.setId(organizationId);
 
     WireMock.stubFor(
-      get("/organizations/organizations")
+      get("/organizations/organizations?limit=0")
         .willReturn(okJson(new JsonObject()
           .put("organizations", JsonArray.of(organization))
           .put("totalRecords", 1)
@@ -119,7 +119,7 @@ public class CacheTest {
     Async async = context.async();
 
     WireMock.stubFor(
-      get("/organizations/organizations")
+      get("/organizations/organizations?limit=0")
         .willReturn(serverError()));
 
     mappingParametersCache


### PR DESCRIPTION
## Purpose
Prevent returning of 10 first organizations by default if the limit is not defined in the request params

## Approach
Set limit to 1000 for getting organization for MappingParametersCache

