### PR TITLE
MODORDERS-858: Increase a memory to Snapshots

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1794,7 +1794,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 536870912,
+        "Memory": 1073741824,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },


### PR DESCRIPTION
## Purpose
DI fails because the mod-orders module restarts when importing a large file (500+ records).

After investigation, it has been established that the module needs more memory: 700Mb is not enough (import is not stable), after increasing memory to 1Gb import on 5k was completed.

## Approach
Increase memory in module-descriptor to deploy on Snapshots

## Learning
[MODORDERS-858](https://issues.folio.org/browse/MODORDERS-858)