### PR TITLE
[MODORDERS-859] Release encumbrance when orderStatus is set to CLOSED

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -236,7 +236,7 @@ public class PurchaseOrderHelper {
       .compose(v -> processPoLineTags(compPO, requestContext))
       .compose(v -> createPOandPOLines(compPO, tenantConfiguration, requestContext))
       .compose(aCompPO -> populateOrderSummary(aCompPO, requestContext))
-      .compose(compOrder -> encumbranceService.updateEncumbrancesOrderStatus(compOrder, requestContext)
+      .compose(compOrder -> encumbranceService.updateEncumbrancesOrderStatusAndReleaseIfClosed(compOrder, requestContext)
         .map(v -> compOrder));
   }
 
@@ -323,7 +323,7 @@ public class PurchaseOrderHelper {
             }
           })
           .compose(ok -> handleFinalOrderStatus(compPO, poFromStorage.getWorkflowStatus().value(), requestContext))
-          .compose(v -> encumbranceService.updateEncumbrancesOrderStatus(compPO, requestContext));
+          .compose(v -> encumbranceService.updateEncumbrancesOrderStatusAndReleaseIfClosed(compPO, requestContext));
       });
   }
 

--- a/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
+++ b/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
@@ -93,7 +93,8 @@ public abstract class AbstractOrderStatusHandler extends BaseHelper implements H
         if (Boolean.TRUE.equals(isStatusChanged)) {
           return purchaseOrderHelper.handleFinalOrderItemsStatus(purchaseOrder, poLines, initialStatus.value(), requestContext)
             .compose(aVoid -> purchaseOrderStorageService.saveOrder(purchaseOrder, requestContext))
-            .compose(purchaseOrderParam -> encumbranceService.updateEncumbrancesOrderStatus(convert(purchaseOrder), requestContext));
+            .compose(purchaseOrderParam -> encumbranceService.updateEncumbrancesOrderStatusAndReleaseIfClosed(
+              convert(purchaseOrder), requestContext));
         }
         return Future.succeededFuture();
       });


### PR DESCRIPTION
## Purpose
[MODORDERS-859](https://issues.folio.org/browse/MODORDERS-859) - Encumbrances are not always released when an order is closed

## Approach
Whenever an encumbrance orderStatus is changed to CLOSED, also make sure the encumbrance status is Released.

[Integration tests](https://github.com/folio-org/folio-integration-tests/pull/894)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
