### PR TITLE
MODORDERS-863 - Error after importing open orders for the second time

### DIFF
--- a/src/main/java/org/folio/dao/PoLinesImportProgressDao.java
+++ b/src/main/java/org/folio/dao/PoLinesImportProgressDao.java
@@ -18,11 +18,12 @@ public interface PoLinesImportProgressDao {
    */
   Future<Void> savePoLinesAmountPerOrder(String orderId, int totalPoLines, String tenantId);
   /**
-   * Increases by one a number of po lines which have been processed by specified {@code orderId}.
+   * Increases by one a number of po lines which have been processed by specified {@code orderId}
+   * and checks whether all po lines have been processed for order with specified orderId.
    *
    * @param orderId  - order id
    * @param tenantId - tenant id
-   * @return Future of void
+   * @return Future with {@code true} if all po lines for have been processed, otherwise Future with {@code false}
    */
   Future<Boolean> trackProcessedPoLine(String orderId, String tenantId);
 

--- a/src/main/java/org/folio/dao/PoLinesImportProgressDao.java
+++ b/src/main/java/org/folio/dao/PoLinesImportProgressDao.java
@@ -24,7 +24,7 @@ public interface PoLinesImportProgressDao {
    * @param tenantId - tenant id
    * @return Future of void
    */
-  Future<Void> trackProcessedPoLine(String orderId, String tenantId);
+  Future<Boolean> trackProcessedPoLine(String orderId, String tenantId);
 
   /**
    * Checks whether all po line for particular order with specified {@code orderId} have been processed.

--- a/src/main/java/org/folio/service/dataimport/PoLineImportProgressService.java
+++ b/src/main/java/org/folio/service/dataimport/PoLineImportProgressService.java
@@ -19,11 +19,12 @@ public interface PoLineImportProgressService {
   Future<Void> savePoLinesAmountPerOrder(String orderId, int totalPoLines, String tenantId);
 
   /**
-   * Increases by one a number of po lines which have been processed/imported by specified {@code orderId}.
+   * Increases by one a number of po lines which have been processed by specified {@code orderId}
+   * and checks whether all po lines have been processed for order with specified orderId.
    *
    * @param orderId  - order id
    * @param tenantId - tenant id
-   * @return Future of void
+   * @return Future with {@code true} if all po lines for have been processed, otherwise Future with {@code false}
    */
   Future<Boolean> trackProcessedPoLine(String orderId, String tenantId);
 

--- a/src/main/java/org/folio/service/dataimport/PoLineImportProgressService.java
+++ b/src/main/java/org/folio/service/dataimport/PoLineImportProgressService.java
@@ -25,7 +25,7 @@ public interface PoLineImportProgressService {
    * @param tenantId - tenant id
    * @return Future of void
    */
-  Future<Void> trackProcessedPoLine(String orderId, String tenantId);
+  Future<Boolean> trackProcessedPoLine(String orderId, String tenantId);
 
   /**
    * Checks whether all po line for particular order with specified {@code orderId} have been processed.

--- a/src/main/java/org/folio/service/dataimport/PoLineImportProgressServiceImpl.java
+++ b/src/main/java/org/folio/service/dataimport/PoLineImportProgressServiceImpl.java
@@ -21,7 +21,7 @@ public class PoLineImportProgressServiceImpl implements PoLineImportProgressServ
   }
 
   @Override
-  public Future<Void> trackProcessedPoLine(String orderId, String tenantId) {
+  public Future<Boolean> trackProcessedPoLine(String orderId, String tenantId) {
     return poLinesImportProgressDao.trackProcessedPoLine(orderId, tenantId);
   }
 

--- a/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
@@ -421,7 +421,7 @@ public class CreateOrderEventHandler implements EventHandler {
 
   private Future<Void> savePoLinesAmountPerOrder(String orderId, DataImportEventPayload eventPayload, JsonObject tenantConfig) {
     Map<String, String> headers = DataImportUtils.extractOkapiHeaders(eventPayload);
-    OkapiConnectionParams params = new OkapiConnectionParams(headers, Vertx.vertx());
+    OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
     return jobExecutionTotalRecordsCache.get(eventPayload.getJobExecutionId(), params)
       .map(totalRecords -> determinePoLinesAmountPerOrder(eventPayload, totalRecords, tenantConfig))
@@ -453,7 +453,9 @@ public class CreateOrderEventHandler implements EventHandler {
     }
 
     return poLineHelper.createPoLine(poLine, tenantConfig, requestContext)
-      .eventually(createPoLine -> poLineImportProgressService.trackProcessedPoLine(orderId, dataImportEventPayload.getTenant()))
+      .recover(e -> poLineImportProgressService.trackProcessedPoLine(orderId, dataImportEventPayload.getTenant())
+        .onFailure(trackingError -> LOGGER.warn("saveOrderLines:: Failed to track processed PO line by orderId: {}, jobExecutionId: {}", orderId, dataImportEventPayload.getJobExecutionId(), trackingError))
+        .compose(v -> Future.failedFuture(e)))
       .onComplete(ar -> dataImportEventPayload.getContext().put(PO_LINE_KEY, Json.encode(poLine)));
   }
 
@@ -520,7 +522,7 @@ public class CreateOrderEventHandler implements EventHandler {
   private Future<Void> overrideCreateInventoryField(JsonObject poLineJson, DataImportEventPayload dataImportEventPayload) {
     String profileSnapshotId = dataImportEventPayload.getContext().get(JOB_PROFILE_SNAPSHOT_ID_KEY);
     Map<String, String> headers = DataImportUtils.extractOkapiHeaders(dataImportEventPayload);
-    OkapiConnectionParams okapiParams = new OkapiConnectionParams(headers, Vertx.vertx());
+    OkapiConnectionParams okapiParams = new OkapiConnectionParams(headers, vertx);
 
     return jobProfileSnapshotCache.get(profileSnapshotId, okapiParams)
       .compose(snapshotOptional -> snapshotOptional

--- a/src/main/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandler.java
@@ -78,8 +78,9 @@ public class OrderPostProcessingEventHandler implements EventHandler {
     RequestContext requestContext = new RequestContext(vertxContext, okapiHeaders);
     CompositePoLine poLine = Json.decodeValue(payloadContext.get(PO_LINE_KEY), CompositePoLine.class);
 
+    LOGGER.info("handle:: jobExecutionId {}, poLineId {}, orderId {}", dataImportEventPayload.getJobExecutionId(), poLine.getId(), poLine.getPurchaseOrderId());
     ensurePoLineWithInstanceId(poLine, dataImportEventPayload, requestContext)
-      .compose(v -> poLineImportProgressService.poLinesProcessed(poLine.getPurchaseOrderId(), dataImportEventPayload.getTenant()))
+      .compose(v -> poLineImportProgressService.trackProcessedPoLine(poLine.getPurchaseOrderId(), dataImportEventPayload.getTenant()))
       .compose(poLinesImported -> Boolean.TRUE.equals(poLinesImported)
         ? openOrder(poLine, requestContext, dataImportEventPayload.getJobExecutionId())
         : Future.succeededFuture())

--- a/src/test/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandlerTest.java
+++ b/src/test/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandlerTest.java
@@ -180,7 +180,6 @@ public class OrderPostProcessingEventHandlerTest extends DiAbstractRestTest {
     PoLineImportProgressService polProgressService = getBeanFromSpringContext(vertx, PoLineImportProgressService.class);
     polProgressService.savePoLinesAmountPerOrder(order.getId(), 2, TENANT_ID)
       .compose(v -> polProgressService.trackProcessedPoLine(order.getId(), TENANT_ID))
-      .compose(v -> polProgressService.trackProcessedPoLine(order.getId(), TENANT_ID))
       .onComplete(context.asyncAssertSuccess(v -> future.complete(null)));
 
     SendKeyValues<String, String> request = prepareKafkaRequest(dataImportEventPayload);
@@ -240,7 +239,7 @@ public class OrderPostProcessingEventHandlerTest extends DiAbstractRestTest {
 
     CompletableFuture<Void> future = new CompletableFuture<>();
     PoLineImportProgressService polProgressService = getBeanFromSpringContext(vertx, PoLineImportProgressService.class);
-    polProgressService.savePoLinesAmountPerOrder(order.getId(), 2, TENANT_ID)
+    polProgressService.savePoLinesAmountPerOrder(order.getId(), 3, TENANT_ID)
       .compose(v -> polProgressService.trackProcessedPoLine(order.getId(), TENANT_ID))
       .onComplete(context.asyncAssertSuccess(v -> future.complete(null)));
 


### PR DESCRIPTION
## Purpose
to prevent attempts to open an order more than one time during import open order with multiple po lines which in turn causes  validation error in the mod-finance-storage

> "message" : "All expected transactions already processed",

## Approach
* atomically increase po lines processing progress and check completion of all po lines processing before making decision for corresponding order opening
* update and add tests


## Learning
[MODSOURCE-301](https://issues.folio.org/browse/MODSOURCE-301)