### PR TITLE
[MODORDERS-865] - Rewrite the orders rollover interaction in an asynchronous way

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -38,8 +38,9 @@ import org.folio.service.finance.budget.BudgetService;
 import org.folio.service.finance.expenceclass.BudgetExpenseClassService;
 import org.folio.service.finance.expenceclass.ExpenseClassService;
 import org.folio.service.finance.expenceclass.ExpenseClassValidationService;
-import org.folio.service.finance.rollover.RolloverErrorService;
-import org.folio.service.finance.rollover.RolloverRetrieveService;
+import org.folio.service.finance.rollover.LedgerRolloverErrorService;
+import org.folio.service.finance.rollover.LedgerRolloverProgressService;
+import org.folio.service.finance.rollover.LedgerRolloverService;
 import org.folio.service.finance.transaction.ClosedToOpenEncumbranceStrategy;
 import org.folio.service.finance.transaction.EncumbranceRelationsHoldersBuilder;
 import org.folio.service.finance.transaction.EncumbranceService;
@@ -195,9 +196,11 @@ public class ApplicationConfig {
 
   @Bean
   OrderRolloverService rolloverOrderService(FundService fundService, PurchaseOrderLineService purchaseOrderLineService, TransactionService transactionService,
-                                            ConfigurationEntriesCache configurationEntriesCache, ExchangeRateProviderResolver exchangeRateProviderResolver) {
+                                            ConfigurationEntriesCache configurationEntriesCache, ExchangeRateProviderResolver exchangeRateProviderResolver,
+                                            LedgerRolloverProgressService ledgerRolloverProgressService, LedgerRolloverErrorService ledgerRolloverErrorService) {
     return new OrderRolloverService(fundService, purchaseOrderLineService, transactionService,
-                                    configurationEntriesCache, exchangeRateProviderResolver);
+                                    configurationEntriesCache, exchangeRateProviderResolver,
+                                    ledgerRolloverProgressService, ledgerRolloverErrorService);
   }
 
   @Bean
@@ -345,7 +348,7 @@ public class ApplicationConfig {
                                                           FundService fundService,
                                                           ExchangeRateProviderResolver exchangeRateProviderResolver,
                                                           FiscalYearService fiscalYearService,
-                                                          RolloverRetrieveService rolloverRetrieveService,
+                                                          LedgerRolloverService ledgerRolloverService,
                                                           TransactionService transactionService,
                                                           FundsDistributionService fundsDistributionService) {
     return new ReEncumbranceHoldersBuilder(budgetService,
@@ -353,32 +356,37 @@ public class ApplicationConfig {
                                            fundService,
                                            exchangeRateProviderResolver,
                                            fiscalYearService,
-                                           rolloverRetrieveService,
+                                           ledgerRolloverService,
                                            transactionService, fundsDistributionService);
   }
 
   @Bean
   OrderReEncumberService orderReEncumberService(PurchaseOrderStorageService purchaseOrderStorageService,
                                                 ReEncumbranceHoldersBuilder reEncumbranceHoldersBuilder,
-                                                RolloverErrorService rolloverErrorService,
-                                                RolloverRetrieveService rolloverRetrieveService,
+                                                LedgerRolloverErrorService ledgerRolloverErrorService,
+                                                LedgerRolloverProgressService ledgerRolloverProgressService,
                                                 PurchaseOrderLineService purchaseOrderLineService,
                                                 TransactionService transactionService,
                                                 OrderTransactionSummariesService orderTransactionSummariesService,
                                                 BudgetRestrictionService budgetRestrictionService) {
-    return new OrderReEncumberService(purchaseOrderStorageService, reEncumbranceHoldersBuilder, rolloverErrorService,
-                                      rolloverRetrieveService, purchaseOrderLineService, transactionService,
+    return new OrderReEncumberService(purchaseOrderStorageService, reEncumbranceHoldersBuilder, ledgerRolloverErrorService,
+      ledgerRolloverProgressService, purchaseOrderLineService, transactionService,
                                       orderTransactionSummariesService, budgetRestrictionService);
   }
 
   @Bean
-  RolloverErrorService rolloverErrorService(RestClient restClient) {
-    return new RolloverErrorService(restClient);
+  LedgerRolloverErrorService ledgerRolloverErrorService(RestClient restClient) {
+    return new LedgerRolloverErrorService(restClient);
   }
 
   @Bean
-  RolloverRetrieveService rolloverRetrieveService(RestClient restClient) {
-    return new RolloverRetrieveService(restClient);
+  LedgerRolloverService ledgerRolloverService(RestClient restClient) {
+    return new LedgerRolloverService(restClient);
+  }
+
+  @Bean
+  LedgerRolloverProgressService ledgerRolloverProgressService(RestClient restClient) {
+    return new LedgerRolloverProgressService(restClient);
   }
 
   @Bean

--- a/src/main/java/org/folio/service/finance/rollover/LedgerRolloverProgressService.java
+++ b/src/main/java/org/folio/service/finance/rollover/LedgerRolloverProgressService.java
@@ -1,0 +1,43 @@
+package org.folio.service.finance.rollover;
+
+import io.vertx.core.Future;
+import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgress;
+import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgressCollection;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.exceptions.HttpException;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+
+import java.util.List;
+
+public class LedgerRolloverProgressService {
+
+  private static final String ENDPOINT = "/finance/ledger-rollovers-progress";
+
+  private static final String ENDPOINT_BY_ID = ENDPOINT + "/{id}";
+
+  private final RestClient restClient;
+
+  public LedgerRolloverProgressService(RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  public Future<List<LedgerFiscalYearRolloverProgress>> getRolloversProgress(String rolloverId, RequestContext requestContext) {
+    String query = "ledgerRolloverId==" + rolloverId;
+    RequestEntry requestEntry = new RequestEntry(ENDPOINT).withQuery(query).withOffset(0).withLimit(1);
+    return restClient.get(requestEntry, LedgerFiscalYearRolloverProgressCollection.class, requestContext)
+      .map(LedgerFiscalYearRolloverProgressCollection::getLedgerFiscalYearRolloverProgresses);
+  }
+
+  public Future<LedgerFiscalYearRolloverProgress> getRolloversProgressByRolloverId(String rolloverId, RequestContext requestContext) {
+    return getRolloversProgress(rolloverId, requestContext)
+      .map(progresses -> progresses.stream().findFirst()
+        .orElseThrow(() -> new HttpException(404, "Can't retrieve rollover progress by rolloverId")));
+  }
+
+  public Future<Void> updateRolloverProgress(LedgerFiscalYearRolloverProgress ledgerFiscalYearRolloverProgress, RequestContext requestContext) {
+    RequestEntry requestEntry = new RequestEntry(ENDPOINT_BY_ID).withId(ledgerFiscalYearRolloverProgress.getId());
+    return restClient.put(requestEntry, ledgerFiscalYearRolloverProgress, requestContext);
+  }
+
+}

--- a/src/main/java/org/folio/service/finance/rollover/LedgerRolloverService.java
+++ b/src/main/java/org/folio/service/finance/rollover/LedgerRolloverService.java
@@ -5,8 +5,6 @@ import static org.folio.service.finance.transaction.EncumbranceService.AND;
 
 import java.util.List;
 
-import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgress;
-import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgressCollection;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
@@ -15,14 +13,13 @@ import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverCollection;
 
 import io.vertx.core.Future;
 
-public class RolloverRetrieveService {
+public class LedgerRolloverService {
 
     private static final String LEDGER_ROLLOVERS_ENDPOINT = "/finance/ledger-rollovers";
-    private static final String LEDGER_ROLLOVERS_PROGRESS_ENDPOINT = "/finance/ledger-rollovers-progress";
 
     private final RestClient restClient;
 
-    public RolloverRetrieveService(RestClient restClient) {
+    public LedgerRolloverService(RestClient restClient) {
         this.restClient = restClient;
     }
 
@@ -41,16 +38,5 @@ public class RolloverRetrieveService {
         return restClient.get(requestEntry, LedgerFiscalYearRolloverCollection.class, requestContext)
                 .map(LedgerFiscalYearRolloverCollection::getLedgerFiscalYearRollovers);
     }
-
-    public Future<List<LedgerFiscalYearRolloverProgress>> getRolloversProgress(String rolloverId, RequestContext requestContext) {
-        String query = "ledgerRolloverId==" + rolloverId;
-        RequestEntry requestEntry = new RequestEntry(LEDGER_ROLLOVERS_PROGRESS_ENDPOINT)
-                .withQuery(query)
-                .withOffset(0)
-                .withLimit(1);
-        return restClient.get(requestEntry, LedgerFiscalYearRolloverProgressCollection.class, requestContext)
-                .map(LedgerFiscalYearRolloverProgressCollection::getLedgerFiscalYearRolloverProgresses);
-    }
-
 
 }

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -4,9 +4,12 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.folio.orders.utils.HelperUtils.calculateCostUnitsTotal;
+import static org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ_15;
 import static org.folio.rest.jaxrs.model.PurchaseOrder.WorkflowStatus.CLOSED;
 import static org.folio.rest.jaxrs.model.PurchaseOrder.WorkflowStatus.OPEN;
+import static org.folio.rest.jaxrs.model.RolloverStatus.ERROR;
+import static org.folio.rest.jaxrs.model.RolloverStatus.SUCCESS;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -30,6 +33,7 @@ import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Fund;
+import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgress;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Cost;
@@ -40,9 +44,12 @@ import org.folio.rest.jaxrs.model.LedgerFiscalYearRollover;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLineCollection;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
+import org.folio.rest.jaxrs.model.RolloverStatus;
 import org.folio.service.caches.ConfigurationEntriesCache;
 import org.folio.service.exchange.ExchangeRateProviderResolver;
 import org.folio.service.finance.FundService;
+import org.folio.service.finance.rollover.LedgerRolloverErrorService;
+import org.folio.service.finance.rollover.LedgerRolloverProgressService;
 import org.folio.service.finance.transaction.TransactionService;
 import org.javamoney.moneta.Money;
 
@@ -67,17 +74,35 @@ public class OrderRolloverService {
   private final TransactionService transactionService;
   private final ConfigurationEntriesCache configurationEntriesCache;
   private final ExchangeRateProviderResolver exchangeRateProviderResolver;
+  private final LedgerRolloverProgressService ledgerRolloverProgressService;
+  private final LedgerRolloverErrorService ledgerRolloverErrorService;
 
   public OrderRolloverService(FundService fundService, PurchaseOrderLineService purchaseOrderLineService, TransactionService transactionService,
-    ConfigurationEntriesCache configurationEntriesCache, ExchangeRateProviderResolver exchangeRateProviderResolver) {
+    ConfigurationEntriesCache configurationEntriesCache, ExchangeRateProviderResolver exchangeRateProviderResolver,
+    LedgerRolloverProgressService ledgerRolloverProgressService, LedgerRolloverErrorService ledgerRolloverErrorService) {
     this.fundService = fundService;
     this.purchaseOrderLineService = purchaseOrderLineService;
     this.transactionService = transactionService;
     this.configurationEntriesCache = configurationEntriesCache;
     this.exchangeRateProviderResolver = exchangeRateProviderResolver;
+    this.ledgerRolloverProgressService = ledgerRolloverProgressService;
+    this.ledgerRolloverErrorService = ledgerRolloverErrorService;
   }
 
   public Future<Void> rollover(LedgerFiscalYearRollover ledgerFYRollover, RequestContext requestContext) {
+    return prepareRollover(ledgerFYRollover, requestContext)
+      .onSuccess(v -> ledgerRolloverProgressService.getRolloversProgressByRolloverId(ledgerFYRollover.getId(), requestContext)
+        .compose(progress -> startRollover(ledgerFYRollover, progress, requestContext)));
+  }
+
+
+  public Future<Void> prepareRollover(LedgerFiscalYearRollover ledgerFYRollover, RequestContext requestContext) {
+    return ledgerRolloverProgressService.getRolloversProgressByRolloverId(ledgerFYRollover.getId(), requestContext)
+      .map(progress -> progress.withOrdersRolloverStatus(RolloverStatus.IN_PROGRESS))
+      .compose(progressToUpdate -> ledgerRolloverProgressService.updateRolloverProgress(progressToUpdate, requestContext));
+  }
+
+  public Future<Void> startRollover(LedgerFiscalYearRollover ledgerFYRollover, LedgerFiscalYearRolloverProgress progress, RequestContext requestContext) {
     var fundIdsFuture = fundService.getFundsByLedgerId(ledgerFYRollover.getLedgerId(), requestContext)
       .map(ledgerFunds -> ledgerFunds.stream()
         .map(Fund::getId)
@@ -86,8 +111,17 @@ public class OrderRolloverService {
     return fundIdsFuture
       .compose(ledgerFundIds -> configurationEntriesCache.getSystemCurrency(requestContext)
         .compose(systemCurrency -> rolloverOrdersByFundIds(ledgerFundIds, ledgerFYRollover, systemCurrency, requestContext)))
+      .recover(t -> handleOrderRolloverError(t, ledgerFYRollover, progress, requestContext))
+      .compose(aVoid -> calculateAndUpdateOverallProgressStatus(progress.withOrdersRolloverStatus(SUCCESS), requestContext))
       .onSuccess(v -> logger.info("Order Rollover success : All orders processed"))
       .onFailure(t -> logger.error("Order Rollover failed", t));
+  }
+
+  private Future<Void> handleOrderRolloverError(Throwable t, LedgerFiscalYearRollover rollover, LedgerFiscalYearRolloverProgress progress, RequestContext requestContext) {
+    logger.error("Orders rollover failed for ledger {}", rollover.getLedgerId(), t);
+    return ledgerRolloverErrorService.saveRolloverError(rollover.getId(), t, ORDER_ROLLOVER, "Overall order rollover", requestContext)
+      .compose(v -> ledgerRolloverProgressService.updateRolloverProgress(progress.withOrdersRolloverStatus(ERROR).withOverallRolloverStatus(ERROR), requestContext))
+      .compose(v -> Future.failedFuture(t));
   }
 
   private Future<Void> rolloverOrdersByFundIds(List<String> ledgerFundIds, LedgerFiscalYearRollover ledgerFYRollover, String systemCurrency, RequestContext requestContext) {
@@ -189,6 +223,18 @@ public class OrderRolloverService {
         }
       })
       .map(v -> removeEncumbranceLinks(poLines));
+  }
+
+  public Future<Void> calculateAndUpdateOverallProgressStatus(LedgerFiscalYearRolloverProgress progress, RequestContext requestContext) {
+    return ledgerRolloverErrorService.getRolloverErrorsByRolloverId(progress.getLedgerRolloverId(), requestContext)
+      .compose(rolloverErrors -> {
+        if (rolloverErrors.getTotalRecords() == 0) {
+          progress.setOverallRolloverStatus(RolloverStatus.SUCCESS);
+        } else {
+          progress.setOverallRolloverStatus(RolloverStatus.ERROR);
+        }
+        return ledgerRolloverProgressService.updateRolloverProgress(progress, requestContext);
+      });
   }
 
   private List<PoLine> applyPoLinesRolloverChanges(List<PoLineEncumbrancesHolder> poLineEncumbrancesHolders) {

--- a/src/main/java/org/folio/service/orders/ReEncumbranceHoldersBuilder.java
+++ b/src/main/java/org/folio/service/orders/ReEncumbranceHoldersBuilder.java
@@ -36,7 +36,7 @@ import org.folio.service.finance.FiscalYearService;
 import org.folio.service.finance.FundService;
 import org.folio.service.finance.LedgerService;
 import org.folio.service.finance.budget.BudgetService;
-import org.folio.service.finance.rollover.RolloverRetrieveService;
+import org.folio.service.finance.rollover.LedgerRolloverService;
 import org.folio.service.finance.transaction.TransactionService;
 import org.javamoney.moneta.Money;
 
@@ -52,20 +52,20 @@ public class ReEncumbranceHoldersBuilder {
   private final FundService fundService;
   private final ExchangeRateProviderResolver exchangeRateProviderResolver;
   private final FiscalYearService fiscalYearService;
-  private final RolloverRetrieveService rolloverRetrieveService;
+  private final LedgerRolloverService ledgerRolloverService;
   private final TransactionService transactionService;
   private final FundsDistributionService fundsDistributionService;
 
   public ReEncumbranceHoldersBuilder(BudgetService budgetService, LedgerService ledgerService, FundService fundService,
                                      ExchangeRateProviderResolver exchangeRateProviderResolver, FiscalYearService fiscalYearService,
-                                     RolloverRetrieveService rolloverRetrieveService, TransactionService transactionService,
+                                     LedgerRolloverService ledgerRolloverService, TransactionService transactionService,
                                      FundsDistributionService fundsDistributionService) {
     this.budgetService = budgetService;
     this.ledgerService = ledgerService;
     this.fundService = fundService;
     this.exchangeRateProviderResolver = exchangeRateProviderResolver;
     this.fiscalYearService = fiscalYearService;
-    this.rolloverRetrieveService = rolloverRetrieveService;
+    this.ledgerRolloverService = ledgerRolloverService;
     this.transactionService = transactionService;
     this.fundsDistributionService = fundsDistributionService;
   }
@@ -166,7 +166,7 @@ public class ReEncumbranceHoldersBuilder {
     if (ledgerIds.isEmpty() || fiscalYearId.isEmpty()) {
       return Future.succeededFuture(holders);
     }
-    return rolloverRetrieveService.getLedgerFyRollovers(fiscalYearId.get(), ledgerIds, requestContext)
+    return ledgerRolloverService.getLedgerFyRollovers(fiscalYearId.get(), ledgerIds, requestContext)
       .map(rollovers -> withRollovers(rollovers, holders));
   }
 

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -46,6 +46,7 @@ import org.folio.service.exchange.ManualExchangeRateProviderTest;
 import org.folio.service.expenceclass.ExpenseClassValidationServiceTest;
 import org.folio.service.finance.FundServiceTest;
 import org.folio.service.finance.budget.BudgetRestrictionServiceTest;
+import org.folio.service.finance.rollover.LedgerRolloverErrorServiceTest;
 import org.folio.service.finance.transaction.EncumbranceRelationsHoldersBuilderTest;
 import org.folio.service.finance.transaction.EncumbranceServiceTest;
 import org.folio.service.finance.transaction.OpenToClosedEncumbranceStrategyTest;
@@ -443,4 +444,9 @@ public class ApiTestSuite {
   @Nested
   class ExportHistoryImplTestNested extends ExportHistoryImplTest {
   }
+
+  @Nested
+  class LedgerRolloverErrorServiceTestNested extends LedgerRolloverErrorServiceTest {
+  }
+
 }

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -47,6 +47,8 @@ import org.folio.service.expenceclass.ExpenseClassValidationServiceTest;
 import org.folio.service.finance.FundServiceTest;
 import org.folio.service.finance.budget.BudgetRestrictionServiceTest;
 import org.folio.service.finance.rollover.LedgerRolloverErrorServiceTest;
+import org.folio.service.finance.rollover.LedgerRolloverProgressServiceTest;
+import org.folio.service.finance.rollover.LedgerRolloverServiceTest;
 import org.folio.service.finance.transaction.EncumbranceRelationsHoldersBuilderTest;
 import org.folio.service.finance.transaction.EncumbranceServiceTest;
 import org.folio.service.finance.transaction.OpenToClosedEncumbranceStrategyTest;
@@ -446,7 +448,15 @@ public class ApiTestSuite {
   }
 
   @Nested
+  class LedgerRolloverServiceTestNested extends LedgerRolloverServiceTest {
+  }
+
+  @Nested
   class LedgerRolloverErrorServiceTestNested extends LedgerRolloverErrorServiceTest {
+  }
+
+  @Nested
+  class LedgerRolloverProgressServiceTestNested extends LedgerRolloverProgressServiceTest {
   }
 
 }

--- a/src/test/java/org/folio/service/finance/rollover/LedgerRolloverErrorServiceTest.java
+++ b/src/test/java/org/folio/service/finance/rollover/LedgerRolloverErrorServiceTest.java
@@ -1,0 +1,167 @@
+package org.folio.service.finance.rollover;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverError;
+import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverErrorCollection;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockitoAnnotations;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.TestConfig.mockPort;
+import static org.folio.TestConstants.X_OKAPI_TOKEN;
+import static org.folio.TestConstants.X_OKAPI_USER_ID;
+import static org.folio.rest.RestConstants.OKAPI_URL;
+import static org.folio.rest.core.RestClientTest.X_OKAPI_TENANT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(VertxExtension.class)
+public class LedgerRolloverErrorServiceTest {
+
+  @InjectMocks
+  private LedgerRolloverErrorService ledgerRolloverErrorService;
+  @Mock
+  private RestClient restClient;
+  private RequestContext requestContext;
+
+  @BeforeEach
+  public void initMocks() {
+    Map<String, String> okapiHeadersMock = new HashMap<>();
+    okapiHeadersMock.put(OKAPI_URL, "http://localhost:" + mockPort);
+    okapiHeadersMock.put(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue());
+    okapiHeadersMock.put(X_OKAPI_TENANT.getName(), X_OKAPI_TENANT.getValue());
+    okapiHeadersMock.put(X_OKAPI_USER_ID.getName(), X_OKAPI_USER_ID.getValue());
+    requestContext = new RequestContext(Vertx.vertx().getOrCreateContext(), okapiHeadersMock);
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void testShouldRetrieveRolloverErrorsByRolloverId(VertxTestContext vertxTestContext) {
+    //Given
+    String rolloverId = UUID.randomUUID().toString();
+    String rolloverErrorId = UUID.randomUUID().toString();
+
+    var rolloverError = new LedgerFiscalYearRolloverError().withId(rolloverErrorId).withLedgerRolloverId(rolloverId)
+      .withErrorType(LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER).withFailedAction("Overall order rollover")
+      .withErrorMessage("Error when retrieving exchange rate provider");
+    var errorCollection = new LedgerFiscalYearRolloverErrorCollection()
+      .withLedgerFiscalYearRolloverErrors(List.of(rolloverError)).withTotalRecords(0);
+
+    doReturn(succeededFuture(errorCollection)).when(restClient).get(any(RequestEntry.class),
+      eq(LedgerFiscalYearRolloverErrorCollection.class), eq(requestContext));
+
+    //When
+    var future = ledgerRolloverErrorService.getRolloverErrorsByRolloverId(rolloverId, requestContext);
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        //Then
+        assertEquals(result.result(), errorCollection);
+
+        ArgumentCaptor<RequestEntry> argumentCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+        verify(restClient).get(argumentCaptor.capture(), eq(LedgerFiscalYearRolloverErrorCollection.class), eq(requestContext));
+
+        RequestEntry requestEntry = argumentCaptor.getValue();
+        assertEquals("/finance/ledger-rollovers-errors", requestEntry.getBaseEndpoint());
+        assertThat(URLDecoder.decode(requestEntry.buildEndpoint(), StandardCharsets.UTF_8), containsString("ledgerRolloverId==" + rolloverId));
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void testShouldSaveRolloverError(VertxTestContext vertxTestContext) {
+    //Given
+    String rolloverId = UUID.randomUUID().toString();
+    String rolloverErrorId = UUID.randomUUID().toString();
+
+    var rolloverError = new LedgerFiscalYearRolloverError().withId(rolloverErrorId).withLedgerRolloverId(rolloverId)
+      .withErrorType(LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER).withFailedAction("Overall order rollover")
+      .withErrorMessage("Error when retrieving exchange rate provider");
+
+    Throwable throwable = new RuntimeException("Error when retrieving exchange rate provider");
+
+    doReturn(succeededFuture(rolloverError)).when(restClient).post(any(RequestEntry.class),
+      any(LedgerFiscalYearRolloverError.class), eq(LedgerFiscalYearRolloverError.class), eq(requestContext));
+
+    //When
+    var future = ledgerRolloverErrorService.saveRolloverError(rolloverId, throwable,
+      LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER, "Overall order rollover", requestContext);
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        //Then
+        assertEquals(result.result(), rolloverError);
+
+        ArgumentCaptor<RequestEntry> errorCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+        ArgumentCaptor<LedgerFiscalYearRolloverError> rolloverErrorCaptor =
+          ArgumentCaptor.forClass(LedgerFiscalYearRolloverError.class);
+        verify(restClient).post(errorCaptor.capture(), rolloverErrorCaptor.capture(),
+          eq(LedgerFiscalYearRolloverError.class), eq(requestContext));
+
+        RequestEntry requestEntry = errorCaptor.getValue();
+        LedgerFiscalYearRolloverError rolloverErrorAfterCapture = rolloverErrorCaptor.getValue();
+
+        assertNull(rolloverErrorAfterCapture.getId());
+        assertNotEquals(rolloverError, rolloverErrorAfterCapture);
+        assertEquals("/finance/ledger-rollovers-errors", requestEntry.getBaseEndpoint());
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void testShouldDeleteRolloverErrors(VertxTestContext vertxTestContext) {
+    //Given
+    String rolloverId = UUID.randomUUID().toString();
+    String rolloverErrorId = UUID.randomUUID().toString();
+
+    var rolloverError = new LedgerFiscalYearRolloverError().withId(rolloverErrorId).withLedgerRolloverId(rolloverId)
+      .withErrorType(LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER).withFailedAction("Overall order rollover")
+      .withErrorMessage("Error when retrieving exchange rate provider");
+
+    LedgerRolloverErrorService spy = Mockito.spy(ledgerRolloverErrorService);
+    doReturn(succeededFuture()).when(restClient).delete(any(RequestEntry.class), eq(requestContext));
+
+    //When
+    var future = spy.deleteRolloverErrors(List.of(rolloverError), requestContext);
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        //Then
+        ArgumentCaptor<RequestEntry> errorCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+
+        verify(restClient).delete(errorCaptor.capture(), eq(requestContext));
+        verify(restClient, times(1)).delete(any(RequestEntry.class), eq(requestContext));
+        verify(spy, times(1)).deleteRolloverError(rolloverErrorId, requestContext);
+
+        RequestEntry requestEntry = errorCaptor.getValue();
+
+        assertEquals("/finance-storage/ledger-rollovers-errors/" + rolloverErrorId, requestEntry.buildEndpoint());
+        vertxTestContext.completeNow();
+      });
+  }
+
+}

--- a/src/test/java/org/folio/service/finance/rollover/LedgerRolloverErrorServiceTest.java
+++ b/src/test/java/org/folio/service/finance/rollover/LedgerRolloverErrorServiceTest.java
@@ -72,7 +72,7 @@ public class LedgerRolloverErrorServiceTest {
       .withErrorType(LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER).withFailedAction("Overall order rollover")
       .withErrorMessage("Error when retrieving exchange rate provider");
     var errorCollection = new LedgerFiscalYearRolloverErrorCollection()
-      .withLedgerFiscalYearRolloverErrors(List.of(rolloverError)).withTotalRecords(0);
+      .withLedgerFiscalYearRolloverErrors(List.of(rolloverError)).withTotalRecords(1);
 
     doReturn(succeededFuture(errorCollection)).when(restClient).get(any(RequestEntry.class),
       eq(LedgerFiscalYearRolloverErrorCollection.class), eq(requestContext));

--- a/src/test/java/org/folio/service/finance/rollover/LedgerRolloverProgressServiceTest.java
+++ b/src/test/java/org/folio/service/finance/rollover/LedgerRolloverProgressServiceTest.java
@@ -1,0 +1,121 @@
+package org.folio.service.finance.rollover;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgress;
+import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgressCollection;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.RolloverStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.TestConfig.mockPort;
+import static org.folio.TestConstants.X_OKAPI_TOKEN;
+import static org.folio.TestConstants.X_OKAPI_USER_ID;
+import static org.folio.rest.RestConstants.OKAPI_URL;
+import static org.folio.rest.core.RestClientTest.X_OKAPI_TENANT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(VertxExtension.class)
+public class LedgerRolloverProgressServiceTest {
+
+  @InjectMocks
+  private LedgerRolloverProgressService ledgerRolloverProgressService;
+  @Mock
+  private RestClient restClient;
+  private RequestContext requestContext;
+
+  @BeforeEach
+  public void initMocks() {
+    Map<String, String> okapiHeadersMock = new HashMap<>();
+    okapiHeadersMock.put(OKAPI_URL, "http://localhost:" + mockPort);
+    okapiHeadersMock.put(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue());
+    okapiHeadersMock.put(X_OKAPI_TENANT.getName(), X_OKAPI_TENANT.getValue());
+    okapiHeadersMock.put(X_OKAPI_USER_ID.getName(), X_OKAPI_USER_ID.getValue());
+    requestContext = new RequestContext(Vertx.vertx().getOrCreateContext(), okapiHeadersMock);
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void testShouldRetrieveRolloverProgressByRolloverId(VertxTestContext vertxTestContext) {
+    //Given
+    String rolloverId = UUID.randomUUID().toString();
+    String progressId = UUID.randomUUID().toString();
+
+    var rolloverProgress = new LedgerFiscalYearRolloverProgress().withId(progressId).withLedgerRolloverId(rolloverId)
+      .withOverallRolloverStatus(RolloverStatus.IN_PROGRESS).withOrdersRolloverStatus(RolloverStatus.NOT_STARTED)
+      .withFinancialRolloverStatus(RolloverStatus.SUCCESS).withBudgetsClosingRolloverStatus(RolloverStatus.SUCCESS);
+    var progressCollection = new LedgerFiscalYearRolloverProgressCollection()
+      .withLedgerFiscalYearRolloverProgresses(List.of(rolloverProgress)).withTotalRecords(1);
+
+    doReturn(succeededFuture(progressCollection)).when(restClient).get(any(RequestEntry.class),
+      eq(LedgerFiscalYearRolloverProgressCollection.class), eq(requestContext));
+
+    //When
+    var future = ledgerRolloverProgressService.getRolloversProgressByRolloverId(rolloverId, requestContext);
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        //Then
+        assertEquals(result.result(), rolloverProgress);
+
+        ArgumentCaptor<RequestEntry> argumentCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+        verify(restClient).get(argumentCaptor.capture(), eq(LedgerFiscalYearRolloverProgressCollection.class), eq(requestContext));
+
+        RequestEntry requestEntry = argumentCaptor.getValue();
+        assertEquals("/finance/ledger-rollovers-progress", requestEntry.getBaseEndpoint());
+        assertThat(URLDecoder.decode(requestEntry.buildEndpoint(), StandardCharsets.UTF_8), containsString("ledgerRolloverId==" + rolloverId));
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void testShouldUpdateRolloverProgress(VertxTestContext vertxTestContext) {
+    //Given
+    String rolloverId = UUID.randomUUID().toString();
+    String progressId = UUID.randomUUID().toString();
+
+    var rolloverProgress = new LedgerFiscalYearRolloverProgress().withId(progressId).withLedgerRolloverId(rolloverId)
+      .withOverallRolloverStatus(RolloverStatus.IN_PROGRESS).withOrdersRolloverStatus(RolloverStatus.NOT_STARTED)
+      .withFinancialRolloverStatus(RolloverStatus.SUCCESS).withBudgetsClosingRolloverStatus(RolloverStatus.SUCCESS);
+
+    doReturn(succeededFuture()).when(restClient).put(any(RequestEntry.class),
+      any(LedgerFiscalYearRolloverProgress.class), eq(requestContext));
+
+    //When
+    var future = ledgerRolloverProgressService.updateRolloverProgress(rolloverProgress,  requestContext);
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        //Then
+
+        ArgumentCaptor<RequestEntry> captor = ArgumentCaptor.forClass(RequestEntry.class);
+        verify(restClient).put(captor.capture(), any(LedgerFiscalYearRolloverProgress.class), eq(requestContext));
+        RequestEntry requestEntry = captor.getValue();
+
+        assertEquals("/finance/ledger-rollovers-progress/" + progressId, requestEntry.buildEndpoint());
+        vertxTestContext.completeNow();
+      });
+  }
+
+}

--- a/src/test/java/org/folio/service/finance/rollover/LedgerRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/finance/rollover/LedgerRolloverServiceTest.java
@@ -1,0 +1,93 @@
+package org.folio.service.finance.rollover;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.LedgerFiscalYearRollover;
+import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverCollection;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.TestConfig.mockPort;
+import static org.folio.TestConstants.X_OKAPI_TOKEN;
+import static org.folio.TestConstants.X_OKAPI_USER_ID;
+import static org.folio.rest.RestConstants.OKAPI_URL;
+import static org.folio.rest.core.RestClientTest.X_OKAPI_TENANT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(VertxExtension.class)
+public class LedgerRolloverServiceTest {
+
+  @InjectMocks
+  private LedgerRolloverService ledgerRolloverService;
+  @Mock
+  private RestClient restClient;
+  private RequestContext requestContext;
+
+  @BeforeEach
+  public void initMocks() {
+    Map<String, String> okapiHeadersMock = new HashMap<>();
+    okapiHeadersMock.put(OKAPI_URL, "http://localhost:" + mockPort);
+    okapiHeadersMock.put(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue());
+    okapiHeadersMock.put(X_OKAPI_TENANT.getName(), X_OKAPI_TENANT.getValue());
+    okapiHeadersMock.put(X_OKAPI_USER_ID.getName(), X_OKAPI_USER_ID.getValue());
+    requestContext = new RequestContext(Vertx.vertx().getOrCreateContext(), okapiHeadersMock);
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void testShouldRetrieveRolloverByFiscalYearIdAndLedgerId(VertxTestContext vertxTestContext) {
+    //Given
+    String ledgerId = UUID.randomUUID().toString();
+    String rolloverId = UUID.randomUUID().toString();
+    String fiscalYearId = UUID.randomUUID().toString();
+
+    var rollover = new LedgerFiscalYearRollover().withId(rolloverId).withLedgerId(ledgerId).withToFiscalYearId(fiscalYearId);
+    var rolloverCollection = new LedgerFiscalYearRolloverCollection()
+      .withLedgerFiscalYearRollovers(List.of(rollover)).withTotalRecords(1);
+
+    doReturn(succeededFuture(rolloverCollection)).when(restClient).get(any(RequestEntry.class),
+      eq(LedgerFiscalYearRolloverCollection.class), eq(requestContext));
+
+    //When
+    var future = ledgerRolloverService.getLedgerFyRollovers(fiscalYearId, ledgerId, requestContext);
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        //Then
+        assertEquals(result.result(), rolloverCollection);
+
+        ArgumentCaptor<RequestEntry> argumentCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+        verify(restClient).get(argumentCaptor.capture(), eq(LedgerFiscalYearRolloverCollection.class), eq(requestContext));
+
+        RequestEntry requestEntry = argumentCaptor.getValue();
+        assertEquals("/finance/ledger-rollovers", requestEntry.getBaseEndpoint());
+        assertThat(URLDecoder.decode(requestEntry.buildEndpoint(), StandardCharsets.UTF_8), CoreMatchers.allOf(
+          containsString("toFiscalYearId==" + fiscalYearId), containsString("ledgerId==" + ledgerId)));
+        vertxTestContext.completeNow();
+      });
+  }
+
+}

--- a/src/test/java/org/folio/service/orders/ReEncumbranceHoldersBuilderTest.java
+++ b/src/test/java/org/folio/service/orders/ReEncumbranceHoldersBuilderTest.java
@@ -58,7 +58,7 @@ import org.folio.service.finance.FiscalYearService;
 import org.folio.service.finance.FundService;
 import org.folio.service.finance.LedgerService;
 import org.folio.service.finance.budget.BudgetService;
-import org.folio.service.finance.rollover.RolloverRetrieveService;
+import org.folio.service.finance.rollover.LedgerRolloverService;
 import org.folio.service.finance.transaction.TransactionService;
 import org.javamoney.moneta.Money;
 import org.javamoney.moneta.spi.DefaultNumberValue;
@@ -91,7 +91,7 @@ public class ReEncumbranceHoldersBuilderTest {
   @Mock
   private BudgetService budgetService;
   @Mock
-  private RolloverRetrieveService rolloverRetrieveService;
+  private LedgerRolloverService ledgerRolloverService;
   @Mock
   private ExchangeRateProviderResolver exchangeRateProviderResolver;
   @Mock
@@ -364,7 +364,7 @@ public class ReEncumbranceHoldersBuilderTest {
     LedgerFiscalYearRollover rollover2 = new LedgerFiscalYearRollover().withLedgerId(ledgerId2);
 
 
-    when(rolloverRetrieveService.getLedgerFyRollovers(anyString(), anyList(), any())).thenReturn(Future.succeededFuture(Arrays.asList(rollover1, rollover2)));
+    when(ledgerRolloverService.getLedgerFyRollovers(anyString(), anyList(), any())).thenReturn(Future.succeededFuture(Arrays.asList(rollover1, rollover2)));
 
     List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withRollovers(holders, requestContext).result();
 
@@ -399,7 +399,7 @@ public class ReEncumbranceHoldersBuilderTest {
     assertThat(resultHolders, hasItem(allOf(hasProperty("rollover", nullValue()), hasProperty("ledgerId", is(fund3.getLedgerId())))));
     assertThat(resultHolders, hasItem(allOf(hasProperty("rollover", nullValue()), hasProperty("ledgerId", is(fund4.getLedgerId())))));
 
-    verify(rolloverRetrieveService, never()).getLedgerFyRollovers(anyString(), anyList(), any());
+    verify(ledgerRolloverService, never()).getLedgerFyRollovers(anyString(), anyList(), any());
   }
 
   @Test
@@ -416,7 +416,7 @@ public class ReEncumbranceHoldersBuilderTest {
     assertThat(resultHolders, hasItem(allOf(hasProperty("rollover", nullValue()), hasProperty("ledgerId"))));
 
 
-    verify(rolloverRetrieveService, never()).getLedgerFyRollovers(anyString(), anyList(), any());
+    verify(ledgerRolloverService, never()).getLedgerFyRollovers(anyString(), anyList(), any());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Need to rewrite orders rollover in an asynchronous way to avoid issues with socket conection timeout while processing rollover.

## Approach

- Splitted rollover related services
- Added preparation to orders rollover
- Immediately response after rollover preparation and start orders rollover
- Added calculation overall rollover progress

## Learning
[MODORDERS-865](https://issues.folio.org/browse/MODORDERS-865)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
