### PR TITLE
[MODORDERS-514] Fixed closing a composite order

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -344,7 +344,8 @@ public class PurchaseOrderHelper {
       Future.succeededFuture()
         .map(v -> {
           List<PoLine> poLines = HelperUtils.convertToPoLines(compPO.getCompositePoLines());
-          changeOrderStatus(purchaseOrder, poLines);
+          if (initialOrdersStatus.equals(compPO.getWorkflowStatus().value()))
+            changeOrderStatus(purchaseOrder, poLines);
           promise.complete(poLines);
           return null;
         })

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -1893,9 +1893,7 @@ public class PurchaseOrdersApiTest {
     PurchaseOrder storageUpdatedOrder = orderUpdates.get(0).mapTo(PurchaseOrder.class);
     assertNotNull(storageUpdatedOrder.getWorkflowStatus());
 
-    //MODORDERS-234 Status automatically changes to Open
-    assertEquals(PurchaseOrder.WorkflowStatus.OPEN, storageUpdatedOrder.getWorkflowStatus());
-
+    assertEquals(PurchaseOrder.WorkflowStatus.CLOSED, storageUpdatedOrder.getWorkflowStatus());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[MODORDERS-514](https://issues.folio.org/browse/MODORDERS-514) - Closing a composite order can fail silently when lines are included

## Approach
- As suggested in the ticket's description, simply checking if the order status has changed before trying to change it based on the lines. If the status has changed, do not call `changeOrderStatus()`.
- Fixed a unit test.

[Integration test](https://github.com/folio-org/folio-integration-tests/pull/915)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
