### PR TITLE
[MODORDERS-879] New error returned when using multiple fiscal years

### DIFF
--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -105,7 +105,8 @@ public enum ErrorCodes {
   FORBIDDEN_DELETE_SYSTEM_VALUE("forbiddenDeleteSystemValues", "It is forbidden to delete system values"),
   FORBIDDEN_DELETE_USED_VALUE("forbiddenDeleteUsedValue", "Deleting the value used is prohibited"),
   ERROR_REMOVING_INVOICE_LINE_ENCUMBRANCES("errorRemovingInvoiceLineEncumbrances", "Error removing invoice line encumbrance links after deleting the encumbrances: %s"),
-  PO_LINE_HAS_RELATED_APPROVED_INVOICE_ERROR("poLineHasRelatedApprovedInvoice", "Composite POL related invoice lines contains lines which has status APPROVED for the current fiscal year, invoice line ids: %s");
+  PO_LINE_HAS_RELATED_APPROVED_INVOICE_ERROR("poLineHasRelatedApprovedInvoice", "Composite POL related invoice lines contains lines which has status APPROVED for the current fiscal year, invoice line ids: %s"),
+  MULTIPLE_FISCAL_YEARS("multipleFiscalYears", "Order line fund distributions have active budgets in multiple fiscal years.");
 
 
   private final String code;

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
@@ -575,7 +575,7 @@ public class PurchaseOrderLinesApiTest {
     body.setTags(new Tags().withTagList(Collections.singletonList("updated")));
     body.setCost(new Cost().withCurrency("USD").withListUnitPrice(70.0).withQuantityPhysical(1));
     body.setFundDistribution(Collections.singletonList(new FundDistribution()
-      .withCode("EUROHIST")
+      .withCode("MISCHIST")
       .withFundId("a89eccf0-57a6-495e-898d-32b9b2210f2f")
       .withDistributionType(FundDistribution.DistributionType.PERCENTAGE)
       .withValue(100D)));
@@ -619,7 +619,7 @@ public class PurchaseOrderLinesApiTest {
     body.setTags(null);
     body.setCost(new Cost().withCurrency("USD").withListUnitPrice(70.0).withQuantityPhysical(1));
     body.setFundDistribution(Collections.singletonList(new FundDistribution()
-      .withCode("EUROHIST")
+      .withCode("MISCHIST")
       .withFundId("a89eccf0-57a6-495e-898d-32b9b2210f2f")
       .withDistributionType(FundDistribution.DistributionType.PERCENTAGE)
       .withValue(100D)));

--- a/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
@@ -138,7 +138,7 @@ public class PendingToOpenEncumbranceStrategyTest {
     FundDistribution fd2 = new FundDistribution()
       .withDistributionType(FundDistribution.DistributionType.PERCENTAGE)
       .withValue(50d)
-      .withCode("EUROHIST")
+      .withCode("GENRL")
       .withFundId("1b6d3338-186e-4e35-9e75-1b886b0da53e");
     poLine.getFundDistribution().add(fd2);
 

--- a/src/test/resources/mockdata/budgets/budgets.json
+++ b/src/test/resources/mockdata/budgets/budgets.json
@@ -1,28 +1,6 @@
 {
   "budgets": [
     {
-      "id": "0bfc8ba0-b61f-4852-bc5b-1f63ec039550",
-      "name": "GRANT-SUBN-FY2019",
-      "budgetStatus": "Active",
-      "allowableEncumbrance": 100.0,
-      "allowableExpenditure": 100.0,
-      "allocated": 70000.0,
-      "awaitingPayment": 2310.0,
-      "available": 61040.0,
-      "encumbered": 2870.0,
-      "expenditures": 3780.0,
-      "unavailable": 0.0,
-      "overEncumbrance": 0.0,
-      "overExpended": 0.0,
-      "fundId": "1b6d3338-186e-4e35-9e75-1b886b0da53e",
-      "fiscalYearId": "78110b4e-2f8e-4eef-81ee-3058c0c7a9ee",
-      "acqUnitIds": [],
-      "metadata": {
-        "createdDate": "2020-01-30T01:28:17.666+0000",
-        "updatedDate": "2020-01-30T01:28:17.666+0000"
-      }
-    },
-    {
       "id": "0916fde2-7a7d-4ff0-9069-37ee1ec0c068",
       "name": "STATE-MONOSER-FY2018",
       "budgetStatus": "Active",
@@ -240,6 +218,28 @@
       "metadata": {
         "createdDate": "2020-01-30T01:28:17.795+0000",
         "updatedDate": "2020-01-30T01:28:17.795+0000"
+      }
+    },
+    {
+      "id": "0bfc8ba0-b61f-4852-bc5b-1f63ec039551",
+      "name": "GENRL-FY2020",
+      "budgetStatus": "Active",
+      "allowableEncumbrance": 100.0,
+      "allowableExpenditure": 100.0,
+      "allocated": 70000.0,
+      "awaitingPayment": 2310.0,
+      "available": 61040.0,
+      "encumbered": 2870.0,
+      "expenditures": 3780.0,
+      "unavailable": 0.0,
+      "overEncumbrance": 0.0,
+      "overExpended": 0.0,
+      "fundId": "1b6d3338-186e-4e35-9e75-1b886b0da53e",
+      "fiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
+      "acqUnitIds": [],
+      "metadata": {
+        "createdDate": "2020-01-30T01:28:17.666+0000",
+        "updatedDate": "2020-01-30T01:28:17.666+0000"
       }
     },
     {
@@ -508,5 +508,5 @@
     }
 
   ],
-  "totalRecords": 22
+  "totalRecords": 23
 }

--- a/src/test/resources/mockdata/funds/funds.json
+++ b/src/test/resources/mockdata/funds/funds.json
@@ -2,20 +2,20 @@
   "funds": [
     {
       "id": "a89eccf0-57a6-495e-898d-32b9b2210f2f",
-      "name": "European History",
-      "code": "EUROHIST",
+      "name": "History Misc",
+      "code": "MISCHIST",
       "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
     },
     {
       "id": "1b6d3338-186e-4e35-9e75-1b886b0da53e",
-      "name": "European History",
-      "code": "EUROHIST",
+      "name": "General",
+      "code": "GENRL",
       "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
     },
     {
       "id": "fb7b70f1-b898-4924-a991-0e4b6312bb5f",
-      "name": "European History",
-      "code": "EUROHIST",
+      "name": "History",
+      "code": "HIST",
       "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
     },
     {
@@ -35,7 +35,13 @@
       "name": "for encumbrance error",
       "code": "ENCUMBRANCE_ERROR",
       "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
+    },
+    {
+      "id": "e9f9bc2f-bad5-4613-9d6c-f55efa5805e7",
+      "name": "One-time Gifts",
+      "code": "GIFT-SUBN",
+      "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
     }
   ],
-  "totalRecords": 4
+  "totalRecords": 7
 }

--- a/src/test/resources/po_listed_print_serial.json
+++ b/src/test/resources/po_listed_print_serial.json
@@ -82,10 +82,10 @@
           "value": 80
         },
         {
-          "code": "GENRL",
+          "code": "GIFT-SUBN",
           "distributionType": "percentage",
           "encumbrance": "0466cb77-0344-43c6-85eb-0a64aa2934e5",
-          "fundId": "1b6d3338-186e-4e35-9e75-1b886b0da53e",
+          "fundId": "e9f9bc2f-bad5-4613-9d6c-f55efa5805e7",
           "value": 20.0
         }
       ],


### PR DESCRIPTION
## Purpose
[MODORDERS-879](https://issues.folio.org/browse/MODORDERS-879) - Prevent creating an order using 2 different fiscal years with clear error message

## Approach
- Added the check and error message in the encumbrance relations holders builder.
- New unit test + updated existing unit tests (some were using multiple fiscal years!)
- See also: "Implementation Notes" in the ticket.

#### TODOS and Open Questions
TODO: Some UI update will be needed.
Open question: we could probably support using multiple fiscal years, which might simplify implementation, but do we want to allow it ?

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
