### PR TITLE
[MODORDERS-881] Populate locations and material type for POLs when multiple Holdings/Items were created

### DIFF
--- a/src/main/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandler.java
@@ -85,10 +85,7 @@ public class OrderPostProcessingEventHandler implements EventHandler {
     orderFormatToAdjustingCostDetails.put(PHYSICAL_RESOURCE, ((poLine, locations) -> poLine.getCost().setQuantityPhysical(getLocationsPhysicalQuantitySum(locations))));
     orderFormatToAdjustingCostDetails.put(ELECTRONIC_RESOURCE, ((poLine, locations) -> poLine.getCost().setQuantityElectronic(getLocationsElectronicQuantitySum(locations))));
     orderFormatToAdjustingCostDetails.put(OTHER, ((poLine, locations) -> poLine.getCost().setQuantityPhysical(getLocationsPhysicalQuantitySum(locations))));
-    orderFormatToAdjustingCostDetails.put(P_E_MIX, ((poLine, locations) ->
-      poLine.getCost()
-        .withQuantityPhysical(getLocationsPhysicalQuantitySum(locations))
-        .withQuantityElectronic(null)));
+    orderFormatToAdjustingCostDetails.put(P_E_MIX, ((poLine, locations) -> poLine.getCost().setQuantityPhysical(getLocationsPhysicalQuantitySum(locations))));
 
     orderFormatToLocation.put(PHYSICAL_RESOURCE, quantity -> new Location().withQuantityPhysical(quantity));
     orderFormatToLocation.put(ELECTRONIC_RESOURCE, quantity -> new Location().withQuantityElectronic(quantity));

--- a/src/test/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandlerTest.java
+++ b/src/test/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandlerTest.java
@@ -317,7 +317,7 @@ public class OrderPostProcessingEventHandlerTest extends DiAbstractRestTest {
       .withOrderFormat(CompositePoLine.OrderFormat.P_E_MIX)
       .withPhysical(new Physical())
       .withEresource(new Eresource())
-      .withCost(new Cost().withCurrency("USD"));
+      .withCost(new Cost().withCurrency("USD").withQuantityElectronic(2));
 
     JsonObject itemJson = new JsonObject()
       .put(ID, ITEM_ID)
@@ -342,7 +342,7 @@ public class OrderPostProcessingEventHandlerTest extends DiAbstractRestTest {
     assertEquals(1, location.getQuantityPhysical());
     assertNull(location.getQuantityElectronic());
     assertEquals(1, updatedPoLine.getCost().getQuantityPhysical());
-    assertNull(updatedPoLine.getCost().getQuantityElectronic());
+    assertEquals(2, updatedPoLine.getCost().getQuantityElectronic());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Populate locations and material type for POLs when multiple Holdings/Items were created

## Approach
Populate multiple locations based on holdings locations and poLine location template with quantities, populate material type with the value from the first item 

## Learning
Jira: https://issues.folio.org/browse/MODORDERS-881

