### PR TITLE
[MODORDERS-894] - Adding fund distribution line in the POL breaks the order record. Can no longer open.

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -713,7 +713,7 @@ public class PurchaseOrderLineHelper {
     compositePoLine.getFundDistribution().stream()
       .filter(fundDistribution -> storageFundIds.contains(fundDistribution.getFundId()) && fundDistribution.getEncumbrance() == null)
       .forEach(fundDistribution -> storagePoLine.getFundDistribution().stream()
-          .filter(storageFundDistribution -> storageFundDistribution.getFundId().equals(fundDistribution.getFundId()))
+          .filter(storageFundDistribution -> storageFundDistribution.getFundId().equals(fundDistribution.getFundId()) && storageFundDistribution.getExpenseClassId().equals(fundDistribution.getExpenseClassId()))
           .findFirst()
           .ifPresent(storageFundDistribution -> fundDistribution.setEncumbrance(storageFundDistribution.getEncumbrance())));
 

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -713,7 +714,8 @@ public class PurchaseOrderLineHelper {
     compositePoLine.getFundDistribution().stream()
       .filter(fundDistribution -> storageFundIds.contains(fundDistribution.getFundId()) && fundDistribution.getEncumbrance() == null)
       .forEach(fundDistribution -> storagePoLine.getFundDistribution().stream()
-          .filter(storageFundDistribution -> storageFundDistribution.getFundId().equals(fundDistribution.getFundId()) && storageFundDistribution.getExpenseClassId().equals(fundDistribution.getExpenseClassId()))
+          .filter(storageFundDistribution -> storageFundDistribution.getFundId().equals(fundDistribution.getFundId())
+            && Objects.equals(storageFundDistribution.getExpenseClassId(), fundDistribution.getExpenseClassId()))
           .findFirst()
           .ifPresent(storageFundDistribution -> fundDistribution.setEncumbrance(storageFundDistribution.getEncumbrance())));
 

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -714,8 +714,8 @@ public class PurchaseOrderLineHelper {
     compositePoLine.getFundDistribution().stream()
       .filter(fundDistribution -> storageFundIds.contains(fundDistribution.getFundId()) && fundDistribution.getEncumbrance() == null)
       .forEach(fundDistribution -> storagePoLine.getFundDistribution().stream()
-          .filter(storageFundDistribution -> storageFundDistribution.getFundId().equals(fundDistribution.getFundId())
-            && Objects.equals(storageFundDistribution.getExpenseClassId(), fundDistribution.getExpenseClassId()))
+          .filter(storageFundDistribution -> storageFundDistribution.getFundId().equals(fundDistribution.getFundId()))
+          .filter(storageFundDistribution -> Objects.equals(storageFundDistribution.getExpenseClassId(), fundDistribution.getExpenseClassId()))
           .findFirst()
           .ifPresent(storageFundDistribution -> fundDistribution.setEncumbrance(storageFundDistribution.getEncumbrance())));
 


### PR DESCRIPTION
## Purpose
When saving same fund distribution with differente expense class id it was a cause of duplicating encumbrance id in fund distribution

## Approach

- Updated check for comparing fund distribution from storage and request

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
[MODORDERS-894](https://issues.folio.org/browse/MODORDERS-894)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
