### PR TITLE
[MODORDERS-914] - User cannot open order when ledger has separate acquisition unit

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -83,6 +83,7 @@
           ],
           "modulePermissions": [
             "modperms.orders.item.put",
+            "finance-storage.ledgers.collection.get",
             "orders-storage.configuration.prefixes.collection.get",
             "orders-storage.configuration.suffixes.collection.get"
           ]

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -72,7 +72,7 @@ public class ResourcePathResolver {
     apis.put(ENCUMBRANCES, "/finance/encumbrances");
     apis.put(FUNDS, "/finance/funds");
     apis.put(BUDGETS, "/finance/budgets");
-    apis.put(LEDGERS, "/finance/ledgers");
+    apis.put(LEDGERS, "/finance-storage/ledgers");
     apis.put(ORDER_TRANSACTION_SUMMARIES, "/finance/order-transaction-summaries");
     apis.put(TITLES, "/orders-storage/titles");
     apis.put(REASONS_FOR_CLOSURE, "/orders-storage/configuration/reasons-for-closure");

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -48,8 +48,6 @@ public class ResourcePathResolver {
   public static final String ORDER_INVOICE_RELATIONSHIP = "order-invoice-relationship";
   public static final String EXPORT_HISTORY = "export-history";
   public static final String TAGS = "tags";
-  public static final String PREFIX = "poNumberPrefix";
-  public static final String SUFFIX = "poNumberSuffix";
 
   private static final Map<String, String> SUB_OBJECT_ITEM_APIS;
   private static final Map<String, String> SUB_OBJECT_COLLECTION_APIS;

--- a/src/main/java/org/folio/service/finance/LedgerService.java
+++ b/src/main/java/org/folio/service/finance/LedgerService.java
@@ -23,7 +23,7 @@ import io.vertx.core.Future;
 
 public class LedgerService {
 
-  private static final String ENDPOINT = "/finance/ledgers";
+  private static final String ENDPOINT = "/finance-storage/ledgers";
 
   private final RestClient restClient;
 


### PR DESCRIPTION
## Purpose
The purpose of this pull request is to address the issue where the order fails to open, citing "Ledger not found for transaction," when a fund is assigned in a fund distribution on a POL (Purchase Order Line) while using an acquisition unit that restricts view in a library. The problem occurs when the acquisition unit is applied to the ledger only but not the fund. The pull request aims to modify the behavior so that the order can be opened successfully, even if the acquisition unit is not assigned to the user.

## Approach

- Retrieve ledger from storage around bussines module
- Added module permission

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
[MODORDERS-914](https://issues.folio.org/browse/MODORDERS-914)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [x] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [x] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
