### PR TITLE
[MODORDERS-915] - NPE in OrderReEncumberService.java:245

### DIFF
--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -110,7 +110,8 @@ public enum ErrorCodes {
   ERROR_REMOVING_INVOICE_LINE_ENCUMBRANCES("errorRemovingInvoiceLineEncumbrances", "Error removing invoice line encumbrance links after deleting the encumbrances: %s"),
   PO_LINE_HAS_RELATED_APPROVED_INVOICE_ERROR("poLineHasRelatedApprovedInvoice", "Composite POL related invoice lines contains lines which has status APPROVED for the current fiscal year, invoice line ids: %s"),
   MULTIPLE_FISCAL_YEARS("multipleFiscalYears", "Order line fund distributions have active budgets in multiple fiscal years."),
-  INSTANCE_INVALID_PRODUCT_ID_ERROR("instanceInvalidProductIdError", "Instance connection could not be changed, the chosen instance contains an invalid Product ID.");
+  INSTANCE_INVALID_PRODUCT_ID_ERROR("instanceInvalidProductIdError", "Instance connection could not be changed, the chosen instance contains an invalid Product ID."),
+  ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND("encumbrancesForReEncumberNotFound", "The encumbrances were correctly created during the rollover or have already been updated.");
 
 
   private final String code;

--- a/src/main/java/org/folio/service/orders/OrderReEncumberService.java
+++ b/src/main/java/org/folio/service/orders/OrderReEncumberService.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
@@ -21,6 +20,7 @@ import javax.money.MonetaryOperator;
 import javax.money.convert.CurrencyConversion;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -207,7 +207,7 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
 
   private List<ReEncumbranceHolder> ensureReEncumbranceHoldersExist(List<ReEncumbranceHolder> holders) {
     return Optional.of(holders)
-      .filter(Predicate.not(List::isEmpty))
+      .filter(CollectionUtils::isNotEmpty)
       .orElseThrow(() -> new HttpException(HttpResponseStatus.CONFLICT.code(), ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND.toError()));
   }
 

--- a/src/main/java/org/folio/service/orders/OrderReEncumberService.java
+++ b/src/main/java/org/folio/service/orders/OrderReEncumberService.java
@@ -6,18 +6,22 @@ import static org.folio.orders.utils.ResourcePathResolver.ALERTS;
 import static org.folio.orders.utils.ResourcePathResolver.REPORTING_CODES;
 import static org.folio.rest.core.exceptions.ErrorCodes.FUNDS_NOT_FOUND;
 import static org.folio.rest.core.exceptions.ErrorCodes.ROLLOVER_NOT_COMPLETED;
+import static org.folio.rest.core.exceptions.ErrorCodes.ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
 import javax.money.MonetaryOperator;
 import javax.money.convert.CurrencyConversion;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -121,8 +125,9 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
       .compose(holders -> checkRolloverHappensForAllLedgers(holders, requestContext))
       .compose(holders -> reEncumbranceHoldersBuilder.withBudgets(holders, requestContext))
       .compose(holders -> reEncumbranceHoldersBuilder.withConversions(holders, requestContext))
-      .map(this::filterNeedReEncumbranceHolders)
       .compose(holders -> reEncumbranceHoldersBuilder.withPreviousFyEncumbrances(holders, requestContext))
+      .map(this::filterNeedReEncumbranceHolders)
+      .map(this::ensureReEncumbranceHoldersExist)
       .map(this::adjustPoLinesCost)
       .compose(holders -> reEncumbranceHoldersBuilder.withToEncumbrances(holders, requestContext))
       .compose(holders -> validateAndCreateEncumbrances(holders, requestContext))
@@ -136,7 +141,7 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
             .filter(holder -> Objects.isNull(holder.getLedgerId()))
             .map(ReEncumbranceHolder::getFundId)
             .map(id -> new Parameter().withValue(id).withKey("fund"))
-            .collect(toList());
+            .toList();
     if (parameters.isEmpty()) {
       return holders;
     }
@@ -179,7 +184,7 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
                         ledgerIds.add(rollover.getLedgerId());
                       }
                     }))
-            .collect(toList()))
+            .toList())
             .map(aVoid -> ledgerIds);
   }
 
@@ -192,11 +197,18 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
   private List<ReEncumbranceHolder> filterNeedReEncumbranceHolders(List<ReEncumbranceHolder> reEncumbranceHolders) {
     return reEncumbranceHolders.stream()
             .filter(this::isRolloverRequired)
-            .collect(toList());
+            .toList();
   }
 
   private boolean isRolloverRequired(ReEncumbranceHolder reEncumbranceHolder) {
-    return Objects.nonNull(reEncumbranceHolder.getEncumbranceRollover());
+    return ObjectUtils.allNotNull(reEncumbranceHolder.getEncumbranceRollover(),
+      reEncumbranceHolder.getFyToPoLineConversion(), reEncumbranceHolder.getPreviousFyEncumbrance());
+  }
+
+  private List<ReEncumbranceHolder> ensureReEncumbranceHoldersExist(List<ReEncumbranceHolder> holders) {
+    return Optional.of(holders)
+      .filter(Predicate.not(List::isEmpty))
+      .orElseThrow(() -> new HttpException(HttpResponseStatus.CONFLICT.code(), ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND.toError()));
   }
 
   private Future<Void> deleteRolloverErrors(String orderId, RequestContext requestContext) {
@@ -207,13 +219,13 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
 
   private Future<Void> updatePoLines(List<ReEncumbranceHolder> holders, RequestContext requestContext) {
     List<PoLine> lines = holders.stream().map(ReEncumbranceHolder::getPoLine).map(poLine -> {
-      List<String> alertIds = poLine.getAlerts().stream().map(Alert::getId).collect(toList());
-      List<String> codeIds = poLine.getReportingCodes().stream().map(ReportingCode::getId).collect(toList());
+      List<String> alertIds = poLine.getAlerts().stream().map(Alert::getId).toList();
+      List<String> codeIds = poLine.getReportingCodes().stream().map(ReportingCode::getId).toList();
       JsonObject jsonPoLine = JsonObject.mapFrom(poLine);
       jsonPoLine.remove(ALERTS);
       jsonPoLine.remove(REPORTING_CODES);
       return jsonPoLine.mapTo(PoLine.class).withAlerts(alertIds).withReportingCodes(codeIds);
-    }).collect(toList());
+    }).toList();
     return purchaseOrderLineService.saveOrderLines(lines, requestContext);
   }
 
@@ -269,7 +281,7 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
                                                                                      RequestContext requestContext) {
     List<ReEncumbranceHolder> holderForCreateEncumbrances = holders.stream()
       .filter(holder -> StringUtils.isEmpty(holder.getNewEncumbrance().getId()))
-      .collect(toList());
+      .toList();
 
     budgetRestrictionService.checkEncumbranceRestrictions(holderForCreateEncumbrances);
     return holders.stream()
@@ -282,7 +294,7 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
           .compose(aVoid -> GenericCompositeFuture.join(holderForCreateEncumbrances.stream()
             .map(holder -> transactionService.createTransaction(holder.getNewEncumbrance(), requestContext)
               .onSuccess(holder::withNewEncumbrance))
-            .collect(toList())))
+            .toList()))
           .map(aVoid -> holders);
       })
       .orElseGet(() ->  Future.succeededFuture(holders));


### PR DESCRIPTION
## Purpose
We are trying to operate with encumbrance which doesn't exists in [the current line](https://github.com/folio-org/mod-orders/blob/358e9124124226df08b0b2cf060bca0b44ae9c46/src/main/java/org/folio/service/orders/OrderReEncumberService.java#L238). It leads us to NPE.

## Approach

- Added filter to remove from collection holders which has no previous fy encumbrances
- Throwing exception when re encumber holders collection is empty

## Learning
[MODORDERS-915](https://issues.folio.org/browse/MODORDERS-915)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
