### PR TITLE
UIREC-285 Update itemRecord with accessionNumber during checkin

### DIFF
--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.rest.core.exceptions.ErrorCodes.ITEM_UPDATE_FAILED;
+import static org.folio.service.inventory.InventoryManager.ITEM_ACCESSION_NUMBER;
 import static org.folio.service.inventory.InventoryManager.ITEM_BARCODE;
 import static org.folio.service.inventory.InventoryManager.ITEM_CHRONOLOGY;
 import static org.folio.service.inventory.InventoryManager.ITEM_DISCOVERY_SUPPRESS;
@@ -357,6 +358,9 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
     itemRecord.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, checkinPiece.getItemStatus().value()));
     if (StringUtils.isNotEmpty(checkinPiece.getBarcode())) {
       itemRecord.put(ITEM_BARCODE, checkinPiece.getBarcode());
+    }
+    if (StringUtils.isNotEmpty(checkinPiece.getAccessionNumber())) {
+      itemRecord.put(ITEM_ACCESSION_NUMBER, checkinPiece.getAccessionNumber());
     }
     if (StringUtils.isNotEmpty(checkinPiece.getCallNumber())) {
       itemRecord.put(ITEM_LEVEL_CALL_NUMBER, checkinPiece.getCallNumber());

--- a/src/main/java/org/folio/service/inventory/InventoryManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryManager.java
@@ -101,6 +101,7 @@ public class InventoryManager {
   public static final String HOLDING_SOURCE = "sourceId";
   public static final String ITEM_HOLDINGS_RECORD_ID = "holdingsRecordId";
   public static final String ITEM_BARCODE = "barcode";
+  public static final String ITEM_ACCESSION_NUMBER = "accessionNumber";
   public static final String ITEM_LEVEL_CALL_NUMBER = "itemLevelCallNumber";
   public static final String ITEM_STATUS = "status";
   public static final String ITEM_STATUS_NAME = "name";


### PR DESCRIPTION
## Purpose
In [ui-receiving](https://github.com/folio-org/ui-receiving) the accession number field needs to be included in the “receive all view” table. Changes made to the accession number during receive need to be persisted in the item record.

See https://issues.folio.org/browse/UIREC-285 for more details.
See also [PR#462 in ui-receiving](https://github.com/folio-org/ui-receiving/pull/462).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
