### PR TITLE
[MODORDERS-972] - Protect Title acq units management with permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -797,7 +797,9 @@
             "orders-storage.titles.item.put",
             "inventory.instances.item.get",
             "user-tenants.collection.get",
-            "consortia.sharing-instances.item.post"
+            "consortia.sharing-instances.item.post",
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -778,7 +778,9 @@
             "orders-storage.po-lines.item.get",
             "inventory.instances.item.get",
             "user-tenants.collection.get",
-            "consortia.sharing-instances.item.post"
+            "consortia.sharing-instances.item.post",
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
Add missed module permissions for https://issues.folio.org/browse/MODORDERS-972