### PR TITLE
[MODORDERS-989] - Rounding for the total estimated price of the order line does not work after the rollover

### DIFF
--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -376,7 +376,9 @@ public class OrderRolloverService {
   }
 
   private MonetaryAmount amountWithConversion(BigDecimal totalInitialAmountEncumbered, PoLineEncumbrancesHolder holder) {
-    return Money.of(totalInitialAmountEncumbered, holder.getPoLine().getCost().getCurrency()).with(holder.getCurrencyConversion());
+    return Money.of(totalInitialAmountEncumbered, holder.getPoLine().getCost().getCurrency())
+      .with(holder.getCurrencyConversion())
+      .with(Monetary.getDefaultRounding());
   }
 
   private List<PoLineEncumbrancesHolder> buildPoLineEncumbrancesHolders(String  systemCurrency, List<PoLine> poLines,

--- a/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
@@ -528,12 +528,9 @@ public class OrderRolloverServiceTest {
         assertThat(fundDistributionOngoing2.getEncumbrance(), equalTo(currEncumbrId2));
         assertThat(fundDistributionOngoing3.getEncumbrance(), equalTo(currEncumbrId3));
 
-        assertThat(BigDecimal.valueOf(costOneTime.getPoLineEstimatedPrice()).setScale(2, RoundingMode.HALF_EVEN),
-          equalTo(new BigDecimal("24.99").setScale(2, RoundingMode.HALF_EVEN)));
-        assertThat(BigDecimal.valueOf(costOngoing2.getPoLineEstimatedPrice()).setScale(2, RoundingMode.HALF_EVEN),
-          equalTo(new BigDecimal("24.99").setScale(2, RoundingMode.HALF_EVEN)));
-        assertThat(BigDecimal.valueOf(costOngoing3.getPoLineEstimatedPrice()).setScale(2, RoundingMode.HALF_EVEN),
-          equalTo(new BigDecimal("24.99").setScale(2, RoundingMode.HALF_EVEN)));
+        assertThat(BigDecimal.valueOf(costOneTime.getPoLineEstimatedPrice()), equalTo(new BigDecimal("24.99")));
+        assertThat(BigDecimal.valueOf(costOngoing2.getPoLineEstimatedPrice()), equalTo(new BigDecimal("24.99")));
+        assertThat(BigDecimal.valueOf(costOngoing3.getPoLineEstimatedPrice()), equalTo(new BigDecimal("24.99")));
 
         assertThat(costOneTime.getFyroAdjustmentAmount(), equalTo(0.0d));
         assertThat(costOngoing2.getFyroAdjustmentAmount(), equalTo(0.0d));


### PR DESCRIPTION
## Purpose
Conversion didn't apply rounding and led issue with not rounded poLineEstimatedPrice after rollover when primary tenant currency differs from POL currency

## Approach

- Added default rounding
- Removed setScale from tests. Tests should display real state of returning value without applying any scaling. For example before without scalling tests work as screenshot bellow:
![image](https://github.com/folio-org/mod-orders/assets/89521577/9bae1d91-d80d-4ed0-a3d1-a1120b633b83)


## Learning
[MODORDERS-991](https://issues.folio.org/browse/MODORDERS-991)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
