### PR TITLE
[MODORDERS-1005] - Check acq units from Title when receiving/unreceicing pieces

### DIFF
--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -77,8 +77,7 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
   }
 
   public Future<ReceivingResults> checkinPieces(CheckinCollection checkinCollection, RequestContext requestContext) {
-    return getPoLines(new ArrayList<>(checkinPieces.keySet()), requestContext)
-      .compose(poLines -> removeForbiddenEntities(poLines, checkinPieces, requestContext))
+    return removeForbiddenEntities(checkinPieces, requestContext)
       .compose(vVoid -> processCheckInPieces(checkinCollection, requestContext));
   }
 

--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.orders.events.handlers.MessageAddress;
 import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.rest.core.models.RequestContext;
@@ -51,25 +49,20 @@ import io.vertx.core.json.JsonObject;
 import one.util.streamex.StreamEx;
 
 public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
-  private static final Logger logger = LogManager.getLogger(CheckinHelper.class);
+
   public static final String IS_ITEM_ORDER_CLOSED_PRESENT = "isItemOrderClosedPresent";
-  /**
-   * Map with PO line id as a key and value is map with piece id as a key and
-   * {@link CheckInPiece} as a value
-   */
-  private final Map<String, Map<String, CheckInPiece>> checkinPieces;
 
   public CheckinHelper(CheckinCollection checkinCollection, Map<String, String> okapiHeaders,
                 Context ctx) {
     super(okapiHeaders, ctx);
     // Convert request to map representation
     CheckinCollection checkinCollectionClone = JsonObject.mapFrom(checkinCollection).mapTo(CheckinCollection.class);
-    checkinPieces = groupCheckinPiecesByPoLineId(checkinCollectionClone);
+    piecesByLineId = groupCheckinPiecesByPoLineId(checkinCollectionClone);
     updateCheckInPiecesStatus();
     // Logging quantity of the piece records to be checked in
     if (logger.isDebugEnabled()) {
-      int poLinesQty = checkinPieces.size();
-      int piecesQty = StreamEx.ofValues(checkinPieces)
+      int poLinesQty = piecesByLineId.size();
+      int piecesQty = StreamEx.ofValues(piecesByLineId)
         .mapToInt(Map::size)
         .sum();
       logger.debug("{} piece record(s) are going to be checkedIn for {} PO line(s)", piecesQty, poLinesQty);
@@ -77,7 +70,7 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
   }
 
   public Future<ReceivingResults> checkinPieces(CheckinCollection checkinCollection, RequestContext requestContext) {
-    return removeForbiddenEntities(checkinPieces, requestContext)
+    return removeForbiddenEntities(requestContext)
       .compose(vVoid -> processCheckInPieces(checkinCollection, requestContext));
   }
 
@@ -103,7 +96,7 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
   private Future<Map<String, List<Piece>>> createItemsWithPieceUpdate(CheckinCollection checkinCollection, RequestContext requestContext) {
     Map<String, List<CheckInPiece>> poLineIdVsCheckInPiece = getItemCreateNeededCheckinPieces(checkinCollection);
     List<Future<Pair<String, Piece>>> futures = new ArrayList<>();
-    return retrievePieceRecords(checkinPieces, requestContext)
+    return retrievePieceRecords(requestContext)
       .map(piecesGroupedByPoLine -> { piecesGroupedByPoLine.forEach((poLineId, pieces) -> poLineIdVsCheckInPiece.get(poLineId)
         .forEach(checkInPiece -> pieces.forEach(piece -> {
           if (checkInPiece.getId().equals(piece.getId()) && Boolean.TRUE.equals(checkInPiece.getCreateItem())) {
@@ -272,7 +265,7 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
   }
 
   private void updateCheckInPiecesStatus() {
-    checkinPieces.values()
+    piecesByLineId.values()
       .stream()
       .map(Map::values)
       .flatMap(Collection::stream)
@@ -365,11 +358,11 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
 
   @Override
   protected String getLocationId(Piece piece) {
-    return checkinPieces.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
+    return piecesByLineId.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
   }
 
   @Override
   protected String getHoldingId(Piece piece) {
-    return checkinPieces.get(piece.getPoLineId()).get(piece.getId()).getHoldingId();
+    return piecesByLineId.get(piece.getPoLineId()).get(piece.getId()).getHoldingId();
   }
 }

--- a/src/main/java/org/folio/helper/ExpectHelper.java
+++ b/src/main/java/org/folio/helper/ExpectHelper.java
@@ -14,7 +14,6 @@ import org.folio.rest.jaxrs.model.ReceivingResult;
 import org.folio.rest.jaxrs.model.ReceivingResults;
 import org.folio.rest.jaxrs.model.ToBeExpected;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -48,8 +47,7 @@ public class ExpectHelper extends CheckinReceivePiecesHelper<ExpectPiece> {
   }
 
   public Future<ReceivingResults> expectPieces(ExpectCollection expectCollection, RequestContext requestContext) {
-    return getPoLines(new ArrayList<>(expectPieces.keySet()), requestContext)
-      .compose(poLines -> removeForbiddenEntities(poLines, expectPieces, requestContext))
+    return removeForbiddenEntities(expectPieces, requestContext)
       .compose(vVoid -> processExpectPieces(expectCollection, requestContext));
   }
 

--- a/src/main/java/org/folio/helper/ReceivingHelper.java
+++ b/src/main/java/org/folio/helper/ReceivingHelper.java
@@ -16,7 +16,6 @@ import static org.folio.service.inventory.InventoryManager.ITEM_LEVEL_CALL_NUMBE
 import static org.folio.service.inventory.InventoryManager.ITEM_STATUS;
 import static org.folio.service.inventory.InventoryManager.ITEM_STATUS_NAME;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -81,8 +80,7 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
   }
 
   public Future<ReceivingResults>   receiveItems(ReceivingCollection receivingCollection, RequestContext requestContext) {
-    return getPoLines(new ArrayList<>(receivingItems.keySet()), requestContext)
-      .compose(poLines -> removeForbiddenEntities(poLines, receivingItems, requestContext))
+    return removeForbiddenEntities(receivingItems, requestContext)
       .compose(vVoid -> processReceiveItems(receivingCollection, requestContext));
   }
 

--- a/src/main/java/org/folio/helper/ReceivingHelper.java
+++ b/src/main/java/org/folio/helper/ReceivingHelper.java
@@ -24,8 +24,6 @@ import java.util.Map;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.orders.events.handlers.MessageAddress;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
@@ -50,24 +48,21 @@ import io.vertx.core.json.JsonObject;
 import one.util.streamex.StreamEx;
 
 public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
-  private static final Logger logger = LogManager.getLogger(ReceivingHelper.class);
+
   private static final String GET_RECEIVING_HISTORY_BY_QUERY = resourcesPath(RECEIVING_HISTORY);
-  /**
-   * Map with PO line id as a key and value is map with piece id as a key and {@link ReceivedItem} as a value
-   */
-  private final Map<String, Map<String, ReceivedItem>> receivingItems;
+
   @Autowired
   private AcquisitionsUnitsService acquisitionsUnitsService;
 
   public ReceivingHelper(ReceivingCollection receivingCollection, Map<String, String> okapiHeaders, Context ctx) {
     super(okapiHeaders, ctx);
     // Convert request to map representation
-    receivingItems = groupReceivedItemsByPoLineId(receivingCollection);
+    piecesByLineId = groupReceivedItemsByPoLineId(receivingCollection);
 
     // Logging quantity of the piece records to be received
     if (logger.isDebugEnabled()) {
-      int poLinesQty = receivingItems.size();
-      int piecesQty = StreamEx.ofValues(receivingItems)
+      int poLinesQty = piecesByLineId.size();
+      int piecesQty = StreamEx.ofValues(piecesByLineId)
                                .mapToInt(Map::size)
                                .sum();
       logger.debug("{} piece record(s) are going to be received for {} PO line(s)", piecesQty, poLinesQty);
@@ -76,18 +71,18 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
 
   public ReceivingHelper(Map<String, String> okapiHeaders, Context ctx) {
     super(okapiHeaders, ctx);
-    receivingItems = null;
+    piecesByLineId = null;
   }
 
   public Future<ReceivingResults>   receiveItems(ReceivingCollection receivingCollection, RequestContext requestContext) {
-    return removeForbiddenEntities(receivingItems, requestContext)
+    return removeForbiddenEntities(requestContext)
       .compose(vVoid -> processReceiveItems(receivingCollection, requestContext));
   }
 
   private Future<ReceivingResults> processReceiveItems(ReceivingCollection receivingCollection, RequestContext requestContext) {
     Map<String, Map<String, Location>> pieceLocationsGroupedByPoLine = groupLocationsByPoLineIdOnReceiving(receivingCollection);
     // 1. Get piece records from storage
-    return this.retrievePieceRecords(receivingItems, requestContext)
+    return this.retrievePieceRecords(requestContext)
       // 2. Filter locationId
       .compose(piecesByPoLineIds -> filterMissingLocations(piecesByPoLineIds, requestContext))
       // 3. Update items in the Inventory if required
@@ -311,11 +306,11 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
 
   @Override
   protected String getLocationId(Piece piece) {
-    return receivingItems.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
+    return piecesByLineId.get(piece.getPoLineId()).get(piece.getId()).getLocationId();
   }
 
   @Override
   protected String getHoldingId(Piece piece) {
-    return receivingItems.get(piece.getPoLineId()).get(piece.getId()).getHoldingId();
+    return piecesByLineId.get(piece.getPoLineId()).get(piece.getId()).getHoldingId();
   }
 }

--- a/src/main/java/org/folio/service/pieces/PieceStorageService.java
+++ b/src/main/java/org/folio/service/pieces/PieceStorageService.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
@@ -112,17 +113,17 @@ public class PieceStorageService {
   }
 
   public Future<List<Piece>> getPiecesByIds(List<String> pieceIds, RequestContext requestContext) {
-    logger.debug("getPiecesByIds start");
-    String query = convertIdsToCqlQuery(pieceIds);
+    logger.debug("getPiecesByIds:: start to retrieving pieces by ids: {}", pieceIds);
     var futures = ofSubLists(new ArrayList<>(pieceIds), MAX_IDS_FOR_GET_RQ_15)
-      .map(ids -> getPieces(Integer.MAX_VALUE, 0, query, requestContext))
+      .map(HelperUtils::convertIdsToCqlQuery)
+      .map(query -> getPieces(Integer.MAX_VALUE, 0, query, requestContext))
       .toList();
     return collectResultsOnSuccess(futures)
       .map(lists -> lists.stream()
         .map(PieceCollection::getPieces)
         .flatMap(Collection::stream)
         .toList())
-      .onSuccess(v -> logger.info("getPiecesByIds end"));
+      .onSuccess(v -> logger.info("getPiecesByIds:: pieces by ids successfully retrieve: {}", pieceIds));
   }
 
   public Future<List<Piece>> getPiecesByLineIdsByChunks(List<String> lineIds, RequestContext requestContext) {

--- a/src/test/java/org/folio/helper/CheckinHelperTest.java
+++ b/src/test/java/org/folio/helper/CheckinHelperTest.java
@@ -32,6 +32,7 @@ import org.folio.service.ProtectionService;
 import org.folio.service.configuration.ConfigurationEntriesService;
 import org.folio.service.inventory.InventoryManager;
 import org.folio.service.orders.PurchaseOrderLineService;
+import org.folio.service.pieces.PieceStorageService;
 import org.folio.service.pieces.flows.create.PieceCreateFlowInventoryManager;
 import org.folio.service.titles.TitlesService;
 import org.junit.jupiter.api.AfterAll;
@@ -153,6 +154,10 @@ public class CheckinHelperTest {
     @Bean
     TitlesService titlesService() {
       return mock(TitlesService.class);
+    }
+    @Bean
+    PieceStorageService pieceStorageService() {
+      return mock(PieceStorageService.class);
     }
     @Bean
     InventoryManager inventoryManager() {

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -989,7 +989,7 @@ public class CheckinReceivingApiTest {
     assertThat(getPieceUpdates(), is(nullValue()));
     assertThat(getItemsSearches(), is(nullValue()));
     assertThat(getItemUpdates(), is(nullValue()));
-    assertThat(getPoLineSearches(), hasSize(1));
+    assertThat(getPoLineSearches(), is(nullValue()));
     assertThat(getPoLineUpdates(), is(nullValue()));
 
     // Verify messages sent via event bus

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -1571,15 +1571,21 @@ public class MockServer {
     } else if (queryParam.contains(ID_FOR_INTERNAL_SERVER_ERROR) || queryParam.contains(PO_ID_GET_LINES_INTERNAL_SERVER_ERROR)) {
       serverResponse(ctx, 500, APPLICATION_JSON, Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
     } else {
-      String poId = EMPTY;
+      String poId;
       String tenant = ctx.request().getHeader(OKAPI_HEADER_TENANT);
-      List<String> polIds = Collections.emptyList();
+      List<String> polIds;
 
       if (queryParam.contains(PURCHASE_ORDER_ID)) {
+        polIds = Collections.emptyList();
         Matcher matcher = Pattern.compile(".*" + PURCHASE_ORDER_ID + "==(\\S[^)]+).*").matcher(queryParam);
         poId = matcher.find() ? matcher.group(1) : EMPTY;
-      } else if (queryParam.startsWith("id==")) {
-        polIds = extractIdsFromQuery(queryParam);
+      } else {
+        poId = EMPTY;
+        if (queryParam.startsWith("id==")) {
+          polIds = extractIdsFromQuery(queryParam);
+        } else {
+          polIds = Collections.emptyList();
+        }
       }
 
       List<JsonObject> postedPoLines = getRqRsEntries(HttpMethod.SEARCH, type);
@@ -1615,6 +1621,7 @@ public class MockServer {
           poLineCollection.getPoLines().addAll(postedPoLines.stream()
             .map(jsonObj -> jsonObj.mapTo(PoLine.class))
             .collect(Collectors.toList()));
+          poLineCollection.getPoLines().removeIf(poLine -> polIds.isEmpty() ? !poId.equals(poLine.getPurchaseOrderId()) : !polIds.contains(poLine.getId()));
         }
 
         poLineCollection.setTotalRecords(poLineCollection.getPoLines().size());

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -1581,11 +1581,7 @@ public class MockServer {
         poId = matcher.find() ? matcher.group(1) : EMPTY;
       } else {
         poId = EMPTY;
-        if (queryParam.startsWith("id==")) {
-          polIds = extractIdsFromQuery(queryParam);
-        } else {
-          polIds = Collections.emptyList();
-        }
+        polIds = queryParam.startsWith("id==") ? extractIdsFromQuery(queryParam) : Collections.emptyList();
       }
 
       List<JsonObject> postedPoLines = getRqRsEntries(HttpMethod.SEARCH, type);

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -1621,7 +1621,7 @@ public class MockServer {
           poLineCollection.getPoLines().addAll(postedPoLines.stream()
             .map(jsonObj -> jsonObj.mapTo(PoLine.class))
             .collect(Collectors.toList()));
-          poLineCollection.getPoLines().removeIf(poLine -> polIds.isEmpty() ? !poId.equals(poLine.getPurchaseOrderId()) : !polIds.contains(poLine.getId()));
+          poLineCollection.getPoLines().removeIf(poLine -> !polIds.isEmpty() && !polIds.contains(poLine.getId()));
         }
 
         poLineCollection.setTotalRecords(poLineCollection.getPoLines().size());

--- a/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
+++ b/src/test/resources/mockdata/pieces/pieceRecordsCollection.json
@@ -426,6 +426,15 @@
       "receivingStatus": "Expected"
     },
     {
+      "id": "f3316376-2ed8-4285-9ec3-6a1169083b8f",
+      "itemId": "",
+      "titleId": "bc763ccc-6f2f-4868-9349-2e8066bebe46",
+      "locationId": "2a00b0be-1447-42a1-a112-124450991899",
+      "poLineId": "84fedaa4-ae4d-4d9b-9a93-7cf9058c67e5",
+      "receiptDate": "2018-10-09T00:00:00.000Z",
+      "receivingStatus": "Expected"
+    },
+    {
       "id": "71d9322b-5cdd-45d8-ad45-c7f3044802e7",
       "itemId": "",
       "titleId": "9a665b22-9fe5-4c95-b4ee-837a5433c95d",


### PR DESCRIPTION
## Purpose
The receiving app objects inherit an acquisition unit from the related POL. Meaning the unit can not be different from ordering to receiving. Some libraries will require these permissions to be separated.

## Approach

- Retrieve titles and check their acq-units when receiving, checking-in and expecting

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
[MODORDERS-1005](https://issues.folio.org/browse/MODORDERS-1005)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
