### PR TITLE
MODORDERS-989. Remove unused module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -447,10 +447,6 @@
           "modulePermissions": [
             "orders-storage.pieces.collection.get",
             "orders-storage.pieces.item.put",
-            "orders-storage.po-lines.collection.get",
-            "orders-storage.po-lines.item.put",
-            "orders-storage.purchase-orders.item.get",
-            "orders-storage.purchase-orders.item.put",
             "orders-storage.titles.collection.get",
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get"


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDERS-1005

Calls to retrieve PO lines and orders were deleted in scope of https://github.com/folio-org/mod-orders/pull/832 , so these permissions are not needed any more