### PR TITLE
[MODORDERS-892] Update only encumbrances to release

### DIFF
--- a/src/main/java/org/folio/service/finance/transaction/TransactionService.java
+++ b/src/main/java/org/folio/service/finance/transaction/TransactionService.java
@@ -137,6 +137,8 @@ public class TransactionService {
   }
 
   public Future<Void> batchReleaseAndDelete(List<Transaction> transactions, RequestContext requestContext) {
+    // Transactions are not automatically released in mod-finance-storage before they are deleted.
+    // They need to be released for the budgets to be updated correctly.
     // NOTE: we will have to use transactionPatches when it is available (see MODORDERS-1008)
     List<String> allIds = transactions.stream().map(Transaction::getId).toList();
     List<Transaction> transactionsToRelease = transactions.stream()

--- a/src/main/java/org/folio/service/finance/transaction/TransactionService.java
+++ b/src/main/java/org/folio/service/finance/transaction/TransactionService.java
@@ -138,9 +138,12 @@ public class TransactionService {
 
   public Future<Void> batchReleaseAndDelete(List<Transaction> transactions, RequestContext requestContext) {
     // NOTE: we will have to use transactionPatches when it is available (see MODORDERS-1008)
-    transactions.forEach(tr -> tr.getEncumbrance().setStatus(Encumbrance.Status.RELEASED));
-    List<String> ids = transactions.stream().map(Transaction::getId).toList();
-    return batchAllOrNothing(null, transactions, ids, null, requestContext);
+    List<String> allIds = transactions.stream().map(Transaction::getId).toList();
+    List<Transaction> transactionsToRelease = transactions.stream()
+      .filter(tr -> tr.getEncumbrance().getStatus() != Encumbrance.Status.RELEASED)
+      .toList();
+    transactionsToRelease.forEach(tr -> tr.getEncumbrance().setStatus(Encumbrance.Status.RELEASED));
+    return batchAllOrNothing(null, transactionsToRelease, allIds, null, requestContext);
   }
 
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-892](https://folio-org.atlassian.net/browse/MODORDERS-892) - Accumulate all transactions in holder to make only single call to mod-finance

## Approach
In the previous [PR](https://github.com/folio-org/mod-orders/pull/833) I forgot to filter encumbrances to release before deleting encumbrances related to a po line or po. It doesn't have much of an impact, but it is better to avoid updating transactions for nothing. This is just a fix for that.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
