### PR TITLE
MODORDERS-1024-Error message appears when open unopened (duplicated) …

### DIFF
--- a/src/main/java/org/folio/orders/utils/validators/LocationsAndPiecesConsistencyValidator.java
+++ b/src/main/java/org/folio/orders/utils/validators/LocationsAndPiecesConsistencyValidator.java
@@ -52,7 +52,7 @@ public class LocationsAndPiecesConsistencyValidator {
         line.getReceiptStatus() != CompositePoLine.ReceiptStatus.RECEIPT_NOT_REQUIRED &&
         !line.getCheckinItems())
       .collect(toMap(CompositePoLine::getId, poLine -> Optional.of(poLine.getLocations())
-        .orElse(new ArrayList<>()).stream().collect(toMap(LocationsAndPiecesConsistencyValidator::buildLocationKey, Location::getQuantity))));
+        .orElse(new ArrayList<>()).stream().collect(toMap(LocationsAndPiecesConsistencyValidator::buildLocationKey, Location::getQuantity, Integer::sum))));
   }
 
   private static String buildLocationKey(Location location) {

--- a/src/test/java/org/folio/orders/utils/validators/LocationsAndPiecesConsistencyValidatorTest.java
+++ b/src/test/java/org/folio/orders/utils/validators/LocationsAndPiecesConsistencyValidatorTest.java
@@ -2,6 +2,8 @@ package org.folio.orders.utils.validators;
 
 import static org.folio.rest.RestConstants.VALIDATION_ERROR;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECES_TO_BE_DELETED;
+import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.P_E_MIX;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -77,5 +79,21 @@ public class LocationsAndPiecesConsistencyValidatorTest {
     Error actError = actHttpException.getError();
     assertEquals(PIECES_TO_BE_DELETED.getCode(), actError.getCode());
     assertEquals(VALIDATION_ERROR, actHttpException.getCode());
+  }
+
+  @Test
+  public void testVerifyLocationsAndPiecesConsistencyWhenTwoLocationWithPEMixedOrderingFormat() {
+    CompositePoLine poLine = new CompositePoLine().withOrderFormat(P_E_MIX);
+    String poLineId = UUID.randomUUID().toString();
+    String holdingId1 = UUID.randomUUID().toString();
+    Location location1 = new Location().withHoldingId(holdingId1).withQuantity(1).withQuantityPhysical(1);
+    Location location2 = new Location().withHoldingId(holdingId1).withQuantity(1).withQuantityElectronic(1);
+    poLine.withLocations(List.of(location1, location2));
+    poLine.withId(poLineId);
+    List<CompositePoLine> poLines = List.of(poLine);
+    Piece piece1 = new Piece().withPoLineId(poLineId).withHoldingId(holdingId1).withReceivingStatus(Piece.ReceivingStatus.EXPECTED);
+    PieceCollection pieces = new PieceCollection().withPieces(List.of(piece1)).withTotalRecords(2);
+    // Assert that no exception is thrown
+    assertDoesNotThrow(() -> LocationsAndPiecesConsistencyValidator.verifyLocationsAndPiecesConsistency(poLines, pieces));
   }
 }

--- a/src/test/java/org/folio/orders/utils/validators/LocationsAndPiecesConsistencyValidatorTest.java
+++ b/src/test/java/org/folio/orders/utils/validators/LocationsAndPiecesConsistencyValidatorTest.java
@@ -82,7 +82,7 @@ public class LocationsAndPiecesConsistencyValidatorTest {
   }
 
   @Test
-  public void testVerifyLocationsAndPiecesConsistencyWhenTwoLocationWithPEMixedOrderingFormat() {
+  public void testVerifyLocationsAndPiecesConsistencyWhenTwoSameLocationWithPEMixedOrderingFormatAndReceivingWorkflowIsSync() {
     CompositePoLine poLine = new CompositePoLine().withOrderFormat(P_E_MIX);
     String poLineId = UUID.randomUUID().toString();
     String holdingId1 = UUID.randomUUID().toString();
@@ -93,6 +93,39 @@ public class LocationsAndPiecesConsistencyValidatorTest {
     List<CompositePoLine> poLines = List.of(poLine);
     Piece piece1 = new Piece().withPoLineId(poLineId).withHoldingId(holdingId1).withReceivingStatus(Piece.ReceivingStatus.EXPECTED);
     PieceCollection pieces = new PieceCollection().withPieces(List.of(piece1)).withTotalRecords(2);
+    // Assert that no exception is thrown
+    assertDoesNotThrow(() -> LocationsAndPiecesConsistencyValidator.verifyLocationsAndPiecesConsistency(poLines, pieces));
+  }
+
+  @Test
+  public void testVerifyLocationsAndPiecesConsistencyWhenOneLocationWithPEMixedOrderingFormatReceivingWorkflowIsSync() {
+    CompositePoLine poLine = new CompositePoLine().withOrderFormat(P_E_MIX);
+    String poLineId = UUID.randomUUID().toString();
+    String holdingId1 = UUID.randomUUID().toString();
+    Location location1 = new Location().withHoldingId(holdingId1).withQuantity(2).withQuantityPhysical(1).withQuantityElectronic(1);
+    poLine.withLocations(List.of(location1));
+    poLine.withId(poLineId);
+    List<CompositePoLine> poLines = List.of(poLine);
+    Piece piece1 = new Piece().withPoLineId(poLineId).withHoldingId(holdingId1).withReceivingStatus(Piece.ReceivingStatus.EXPECTED);
+    PieceCollection pieces = new PieceCollection().withPieces(List.of(piece1)).withTotalRecords(2);
+    // Assert that no exception is thrown
+    assertDoesNotThrow(() -> LocationsAndPiecesConsistencyValidator.verifyLocationsAndPiecesConsistency(poLines, pieces));
+  }
+
+  @Test
+  public void testVerifyLocationsAndPiecesConsistencyWhenTwoLocationWithPEMixedOrderingFormatReceivingWorkflowIsIndependent() {
+    CompositePoLine poLine = new CompositePoLine().withOrderFormat(P_E_MIX);
+    String poLineId = UUID.randomUUID().toString();
+    String holdingId1 = UUID.randomUUID().toString();
+    String holdingId2 = UUID.randomUUID().toString();
+    Location location1 = new Location().withHoldingId(holdingId1).withQuantity(1).withQuantityPhysical(1);
+    Location location2 = new Location().withHoldingId(holdingId2).withQuantity(1).withQuantityElectronic(1);
+    poLine.withLocations(List.of(location1, location2));
+    poLine.withId(poLineId);
+    List<CompositePoLine> poLines = List.of(poLine);
+    Piece piece1 = new Piece().withPoLineId(poLineId).withHoldingId(holdingId1).withReceivingStatus(Piece.ReceivingStatus.EXPECTED);
+    Piece piece2 = new Piece().withPoLineId(poLineId).withHoldingId(holdingId2).withReceivingStatus(Piece.ReceivingStatus.EXPECTED);
+    PieceCollection pieces = new PieceCollection().withPieces(List.of(piece1,piece2)).withTotalRecords(2);
     // Assert that no exception is thrown
     assertDoesNotThrow(() -> LocationsAndPiecesConsistencyValidator.verifyLocationsAndPiecesConsistency(poLines, pieces));
   }


### PR DESCRIPTION
Description

Preconditions:

1.Order in “Open” status with one PO line has been created with following PO line settings:

-”Order format” - P/E mix

-”Receiving workflow” - Synchronized order and receipt quantity

-”Location” should be the same both for physical and electronic resources

2.After opening created order should be unopened.

3.Authorized user with “Orders: Can edit Orders and Order lines” permission is logged in.

Steps to reproduce:

Go to purchase order (not PO line) from Preconditions details pane.

Click “Actions” button on “Purchase order” pane and select “Open” option.

Click “Submit” button in appeared “Open - purchase order” confirmation popup.

Actual result: Error message “Order could not be saved” appears, order remains in “Pending” status

Expected result: Order workflow status is changed to “Open”

Additional information:

Also reproduces when duplicate open P/E mix order with same location both for physical and electronic resources

Error response:

{
  "errors" : [ {
    "message" : "Generic error",
    "code" : "genericError",
    "parameters" : [ ],
    "cause" : "Duplicate key L184aae84-a5bf-4c6a-85ba-4a7c73026cd5 (attempted merging values 1 and 1)"
  } ],
  "total_records" : 1
}