### PR TITLE
[MODORDERS-1030] - "Receipt status" is changed to "Fully received" wh…

### DIFF
--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -77,6 +77,8 @@ import one.util.streamex.StreamEx;
 
 public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
 
+  public static final List<ReceivingStatus> EXPECTED_STATUSES = List.of(EXPECTED, CLAIM_DELAYED, CLAIM_SENT);
+
   protected Map<String, Map<String, T>> piecesByLineId;
   private final Map<String, Map<String, Error>> processingErrors;
   private final Set<String> processedHoldingsParams;
@@ -557,9 +559,8 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
    * @return completable future holding calculated PO Line's receipt status
    */
   private Future<ReceiptStatus> calculatePoLineReceiptStatus(List<Piece> byPoLine, PoLine poLine, List<Piece> pieces) {
-    List<ReceivingStatus> receivingStatuses = List.of(EXPECTED, CLAIM_DELAYED, CLAIM_SENT);
     long expectedPiecesQuantity = byPoLine.stream()
-      .filter(piece -> receivingStatuses.contains(piece.getReceivingStatus()))
+      .filter(piece -> EXPECTED_STATUSES.contains(piece.getReceivingStatus()))
       .count();
     // Fully Received: If receiving and there is no expected piece remaining
     if (!poLine.getCheckinItems().equals(Boolean.TRUE) && expectedPiecesQuantity == 0) {

--- a/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
+++ b/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
@@ -2,7 +2,6 @@ package org.folio.orders.events.handlers;
 
 import static org.folio.orders.utils.ResourcePathResolver.PIECES_STORAGE;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
-import static org.folio.rest.acq.model.Piece.ReceivingStatus.*;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.AWAITING_RECEIPT;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.FULLY_RECEIVED;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.PARTIALLY_RECEIVED;
@@ -13,12 +12,13 @@ import java.util.Map;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.helper.BaseHelper;
+import org.folio.helper.CheckinReceivePiecesHelper;
 import org.folio.orders.utils.HelperUtils;
-import org.folio.rest.acq.model.Piece;
-import org.folio.rest.acq.model.Piece.ReceivingStatus;
-import org.folio.rest.acq.model.PieceCollection;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.Piece.ReceivingStatus;
+import org.folio.rest.jaxrs.model.PieceCollection;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLine.ReceiptStatus;
 import org.folio.service.orders.PurchaseOrderLineService;
@@ -124,7 +124,7 @@ public class ReceiptStatusConsistency extends BaseHelper implements Handler<Mess
       return poLine.getReceiptStatus();
     }
 
-    long expectedQty = getPiecesQuantityByPoLineAndStatus(List.of(EXPECTED, CLAIM_DELAYED, CLAIM_SENT), pieces);
+    long expectedQty = getPiecesQuantityByPoLineAndStatus(CheckinReceivePiecesHelper.EXPECTED_STATUSES, pieces);
     return calculatePoLineReceiptStatus(expectedQty, pieces);
   }
 

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -623,13 +623,13 @@ public class CheckinReceivingApiTest {
     String titleIdForElectronic = UUID.randomUUID().toString();
     MockServer.addMockTitleWithId(poLine, titleIdForElectronic);
 
-    Piece physicalPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+    Piece physicalPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_DELAYED)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.PHYSICAL)
       .withLocationId(locationForPhysical)
       .withId(UUID.randomUUID().toString())
       .withTitleId(titleIdForPhysical)
       .withItemId(UUID.randomUUID().toString());
-    Piece electronicPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+    Piece electronicPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_SENT)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC)
       .withId(UUID.randomUUID().toString())
       .withTitleId(titleIdForElectronic)
@@ -677,13 +677,13 @@ public class CheckinReceivingApiTest {
     String titleIdForElectronic = UUID.randomUUID().toString();
     MockServer.addMockTitleWithId(poLine, titleIdForElectronic);
 
-    Piece physicalPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+    Piece physicalPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_DELAYED)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.PHYSICAL)
       .withLocationId(locationForPhysical)
       .withId(UUID.randomUUID().toString())
       .withTitleId(titleIdForPhysical)
       .withItemId(UUID.randomUUID().toString());
-    Piece electronicPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+    Piece electronicPiece = getMinimalContentPiece(poLine.getId()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_SENT)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC)
       .withId(UUID.randomUUID().toString())
       .withTitleId(titleIdForElectronic)

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -304,7 +304,7 @@ public class CheckinReceivingApiTest {
 
     // The piece searches should be made 2 times: 1st time to get piece record,
     // 2nd time to calculate expected PO Line status
-    assertThat(pieceSearches, hasSize(3));
+    assertThat(pieceSearches, hasSize(2));
     assertThat(pieceUpdates, hasSize(1));
     assertThat(itemsSearches, hasSize(1));
     assertThat(itemUpdates, hasSize(1));
@@ -1065,8 +1065,8 @@ public class CheckinReceivingApiTest {
     assertThat(polSearches, not(nullValue()));
     assertThat(polUpdates, not(nullValue()));
 
-    // The piece searches should be made 3 times: 1st time to get all required piece records, 2nd and 3rd times to calculate expected PO Line status
-    assertThat(pieceSearches, hasSize(3));
+    // The piece searches should be made 2 times: 1st time to get all required piece records, 2nd times to calculate expected PO Line status
+    assertThat(pieceSearches, hasSize(2));
     // In total 4 pieces required update
     assertThat(pieceUpdates, hasSize(4));
     assertThat(itemsSearches, hasSize(1));
@@ -1120,8 +1120,8 @@ public class CheckinReceivingApiTest {
     assertThat(polSearches, not(nullValue()));
     assertThat(polUpdates, not(nullValue()));
 
-    // The piece searches should be made 3 times: 1st time to get piece record, 2nd and 3rd times to calculate expected PO Line status
-    assertThat(pieceSearches, hasSize(3));
+    // The piece searches should be made 2 times: 1st time to get piece record, 2nd times to calculate expected PO Line status
+    assertThat(pieceSearches, hasSize(2));
     assertThat(pieceUpdates, hasSize(1));
     assertThat(itemsSearches, hasSize(1));
     assertThat(itemUpdates, hasSize(1));


### PR DESCRIPTION
…en all piece statuses for selected title were changed to "Claim delayed" and "Claim sent"

## Purpose
https://folio-org.atlassian.net/browse/MODORDERS-1030

## Approach
Add corresponding checks to not update receipt status to "Fully received" for claim delayed/sent cases.

#### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
