### PR TITLE
[MODORDERS-1049] Rollback inventory if open fails to create encumbrances

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -643,9 +643,9 @@ public class ApplicationConfig {
   @Bean OpenCompositeOrderManager openCompositeOrderManager(PurchaseOrderLineService purchaseOrderLineService,
     EncumbranceWorkflowStrategyFactory encumbranceWorkflowStrategyFactory,
     TitlesService titlesService, OpenCompositeOrderInventoryService openCompositeOrderInventoryService,
-    OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator) {
+    OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator, UnOpenCompositeOrderManager unOpenCompositeOrderManager) {
     return new OpenCompositeOrderManager(purchaseOrderLineService, encumbranceWorkflowStrategyFactory,
-      titlesService, openCompositeOrderInventoryService, openCompositeOrderFlowValidator);
+      titlesService, openCompositeOrderInventoryService, openCompositeOrderFlowValidator, unOpenCompositeOrderManager);
   }
 
   @Bean OpenCompositeOrderHolderBuilder openCompositeOrderHolderBuilder(PieceStorageService pieceStorageService) {

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManager.java
@@ -162,14 +162,14 @@ public class OpenCompositeOrderManager {
       CompositePurchaseOrder poFromStorage, RequestContext requestContext) {
     EncumbranceWorkflowStrategy strategy = encumbranceWorkflowStrategyFactory.getStrategy(OrderWorkflowType.PENDING_TO_OPEN);
     return strategy.processEncumbrances(compPO, poFromStorage, requestContext)
-      .onSuccess(v -> logger.info("Finished processing encumbrances to open the order"))
+      .onSuccess(v -> logger.info("Finished processing encumbrances to open the order, order id={}", compPO.getId()))
       .recover(t -> {
-        logger.error("Error when processing encumbrances to open the order", t);
+        logger.error("Error when processing encumbrances to open the order, order id={}", compPO.getId(), t);
         // There was an error when processing the encumbrances despite the previous validations.
         // Try to rollback inventory changes
         return unOpenCompositeOrderManager.rollbackInventory(compPO, requestContext)
-          .onSuccess(v -> logger.info("Successfully rolled back inventory changes"))
-          .onFailure(t2 -> logger.error("Error when trying to rollback inventory changes", t2))
+          .onSuccess(v -> logger.info("Successfully rolled back inventory changes, order id={}", compPO.getId()))
+          .onFailure(t2 -> logger.error("Error when trying to rollback inventory changes, order id={}", compPO.getId(), t2))
           .transform(v -> Future.failedFuture(t));
       });
   }

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManager.java
@@ -26,10 +26,10 @@ import org.folio.service.finance.transaction.EncumbranceWorkflowStrategy;
 import org.folio.service.finance.transaction.EncumbranceWorkflowStrategyFactory;
 import org.folio.service.orders.OrderWorkflowType;
 import org.folio.service.orders.PurchaseOrderLineService;
+import org.folio.service.orders.flows.update.unopen.UnOpenCompositeOrderManager;
 import org.folio.service.titles.TitlesService;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
 public class OpenCompositeOrderManager {
@@ -43,15 +43,19 @@ public class OpenCompositeOrderManager {
   private final TitlesService titlesService;
   private final OpenCompositeOrderInventoryService openCompositeOrderInventoryService;
   private final OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator;
+  private final UnOpenCompositeOrderManager unOpenCompositeOrderManager;
 
-  public OpenCompositeOrderManager(PurchaseOrderLineService purchaseOrderLineService, EncumbranceWorkflowStrategyFactory encumbranceWorkflowStrategyFactory,
-                    TitlesService titlesService, OpenCompositeOrderInventoryService openCompositeOrderInventoryService,
-                    OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator) {
+  public OpenCompositeOrderManager(PurchaseOrderLineService purchaseOrderLineService,
+      EncumbranceWorkflowStrategyFactory encumbranceWorkflowStrategyFactory,
+      TitlesService titlesService, OpenCompositeOrderInventoryService openCompositeOrderInventoryService,
+      OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator,
+      UnOpenCompositeOrderManager unOpenCompositeOrderManager) {
     this.purchaseOrderLineService = purchaseOrderLineService;
     this.encumbranceWorkflowStrategyFactory = encumbranceWorkflowStrategyFactory;
     this.titlesService = titlesService;
     this.openCompositeOrderInventoryService = openCompositeOrderInventoryService;
     this.openCompositeOrderFlowValidator = openCompositeOrderFlowValidator;
+    this.unOpenCompositeOrderManager = unOpenCompositeOrderManager;
   }
 
   /**
@@ -154,20 +158,20 @@ public class OpenCompositeOrderManager {
     return compositePoLines.stream().filter(line -> !line.getIsPackage()).collect(toList());
   }
 
-  private Future<Void> finishProcessingEncumbrancesForOpenOrder(CompositePurchaseOrder compPO, CompositePurchaseOrder poFromStorage,
-                            RequestContext requestContext) {
+  private Future<Void> finishProcessingEncumbrancesForOpenOrder(CompositePurchaseOrder compPO,
+      CompositePurchaseOrder poFromStorage, RequestContext requestContext) {
     EncumbranceWorkflowStrategy strategy = encumbranceWorkflowStrategyFactory.getStrategy(OrderWorkflowType.PENDING_TO_OPEN);
-    Promise<Void> promise = Promise.promise();
-    strategy.processEncumbrances(compPO, poFromStorage, requestContext)
-      .onSuccess(result -> promise.complete())
-      .onFailure(t -> {
-        logger.error(t);
+    return strategy.processEncumbrances(compPO, poFromStorage, requestContext)
+      .onSuccess(v -> logger.info("Finished processing encumbrances to open the order"))
+      .recover(t -> {
+        logger.error("Error when processing encumbrances to open the order", t);
         // There was an error when processing the encumbrances despite the previous validations.
-        // Order lines should be saved to avoid leaving an open order with locationId instead of holdingId.
-        openOrderUpdatePoLinesSummary(compPO.getCompositePoLines(), requestContext)
-          .onComplete(asyncResult -> promise.fail(t));
+        // Try to rollback inventory changes
+        return unOpenCompositeOrderManager.rollbackInventory(compPO, requestContext)
+          .onSuccess(v -> logger.info("Successfully rolled back inventory changes"))
+          .onFailure(t2 -> logger.error("Error when trying to rollback inventory changes", t2))
+          .transform(v -> Future.failedFuture(t));
       });
-    return promise.future();
   }
 
   private void updateIncomingOrder(CompositePurchaseOrder compPO, CompositePurchaseOrder poFromStorage) {

--- a/src/main/java/org/folio/service/orders/flows/update/unopen/UnOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/unopen/UnOpenCompositeOrderManager.java
@@ -203,38 +203,38 @@ public class UnOpenCompositeOrderManager {
 
   private Future<Void> processInventoryHoldingWithItems(CompositePoLine compPOL, RequestContext requestContext) {
     return inventoryManager.getItemsByPoLineIdsAndStatus(List.of(compPOL.getId()), ItemStatus.ON_ORDER.value(), requestContext)
-                          .compose(onOrderItems -> {
-                            if (isNotEmpty(onOrderItems)) {
-                              List<String> itemIds = onOrderItems.stream().map(item -> item.getString(ID)).collect(toList());
-                              if (PoLineCommonUtil.isReceiptNotRequired(compPOL.getReceiptStatus())) {
-                                return inventoryManager.deleteItems(itemIds,  false, requestContext)
-                                              .compose(deletedItemIds -> deleteHoldingsByItems(onOrderItems, requestContext))
-                                  .map(deletedHoldingVsLocationIds -> {
-                                    updateLocations(compPOL, deletedHoldingVsLocationIds);
-                                    return null;
-                                  })
-                                  .onSuccess(v -> logger.debug("Items and holdings deleted after UnOpen order"))
-                                  .mapEmpty();
-                              }
-                              return pieceStorageService.getExpectedPiecesByLineId(compPOL.getId(), requestContext)
-                                .compose(pieceCollection -> {
-                                  if (isNotEmpty(pieceCollection.getPieces())) {
-                                    return inventoryManager.getItemRecordsByIds(itemIds, requestContext)
-                                      .map(items -> getItemsByStatus(items, ItemStatus.ON_ORDER.value()))
-                                      .compose(onOrderItemsP -> deletePiecesAndItems(onOrderItemsP, pieceCollection.getPieces(), requestContext))
-                                      .compose(deletedItems -> deleteHoldingsByItems(deletedItems, requestContext))
-                                      .map(deletedHoldingVsLocationIds -> {
-                                        updateLocations(compPOL, deletedHoldingVsLocationIds);
-                                        return null;
-                                      })
-                                      .onSuccess(v -> logger.debug("Pieces, Items, Holdings deleted after UnOpen order"))
-                                      .mapEmpty();
-                                  }
-                                  return Future.succeededFuture();
-                                });
-                            }
-                            return Future.succeededFuture();
-                          });
+      .compose(onOrderItems -> {
+        if (isNotEmpty(onOrderItems)) {
+          List<String> itemIds = onOrderItems.stream().map(item -> item.getString(ID)).collect(toList());
+          if (PoLineCommonUtil.isReceiptNotRequired(compPOL.getReceiptStatus())) {
+            return inventoryManager.deleteItems(itemIds,  false, requestContext)
+              .compose(deletedItemIds -> deleteHoldingsByItems(onOrderItems, requestContext))
+              .map(deletedHoldingVsLocationIds -> {
+                updateLocations(compPOL, deletedHoldingVsLocationIds);
+                return null;
+              })
+              .onSuccess(v -> logger.debug("Items and holdings deleted after UnOpen order"))
+              .mapEmpty();
+          }
+          return pieceStorageService.getExpectedPiecesByLineId(compPOL.getId(), requestContext)
+            .compose(pieceCollection -> {
+              if (isNotEmpty(pieceCollection.getPieces())) {
+                return inventoryManager.getItemRecordsByIds(itemIds, requestContext)
+                  .map(items -> getItemsByStatus(items, ItemStatus.ON_ORDER.value()))
+                  .compose(onOrderItemsP -> deletePiecesAndItems(onOrderItemsP, pieceCollection.getPieces(), requestContext))
+                  .compose(deletedItems -> deleteHoldingsByItems(deletedItems, requestContext))
+                  .map(deletedHoldingVsLocationIds -> {
+                    updateLocations(compPOL, deletedHoldingVsLocationIds);
+                    return null;
+                  })
+                  .onSuccess(v -> logger.debug("Pieces, Items, Holdings deleted after UnOpen order"))
+                  .mapEmpty();
+              }
+              return Future.succeededFuture();
+            });
+        }
+        return Future.succeededFuture();
+      });
   }
 
   private void updateLocations(CompositePoLine compPOL, List<Pair<String, String>> deletedHoldingVsLocationIds) {

--- a/src/main/java/org/folio/service/orders/flows/update/unopen/UnOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/unopen/UnOpenCompositeOrderManager.java
@@ -87,6 +87,10 @@ public class UnOpenCompositeOrderManager {
 
   }
 
+  public Future<Void> rollbackInventory(CompositePurchaseOrder compPO, RequestContext requestContext) {
+    return processInventory(compPO.getCompositePoLines(), true, requestContext);
+  }
+
   public Future<Void> updatePoLinesSummary(List<CompositePoLine> compositePoLines, RequestContext requestContext) {
     return GenericCompositeFuture.join(compositePoLines.stream()
       .map(HelperUtils::convertToPoLine)

--- a/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManagerTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManagerTest.java
@@ -31,6 +31,7 @@ import org.folio.service.orders.OrderInvoiceRelationService;
 import org.folio.service.orders.OrderLinesSummaryPopulateService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
+import org.folio.service.orders.flows.update.unopen.UnOpenCompositeOrderManager;
 import org.folio.service.pieces.PieceChangeReceiptStatusPublisher;
 import org.folio.service.pieces.PieceStorageService;
 import org.folio.service.titles.TitlesService;
@@ -191,9 +192,9 @@ public class OpenCompositeOrderManagerTest {
     @Bean OpenCompositeOrderManager openCompositeOrderManager(PurchaseOrderLineService purchaseOrderLineService,
       EncumbranceWorkflowStrategyFactory encumbranceWorkflowStrategyFactory,
       TitlesService titlesService, OpenCompositeOrderInventoryService openCompositeOrderInventoryService,
-      OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator){
+      OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator, UnOpenCompositeOrderManager unOpenCompositeOrderManager) {
       return new OpenCompositeOrderManager(purchaseOrderLineService, encumbranceWorkflowStrategyFactory,
-          titlesService, openCompositeOrderInventoryService, openCompositeOrderFlowValidator);
+          titlesService, openCompositeOrderInventoryService, openCompositeOrderFlowValidator, unOpenCompositeOrderManager);
     }
   }
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-1049](https://folio-org.atlassian.net/browse/MODORDERS-1049) - 500 error appears when trying to open order more than one time

## Approach
Use the unopen inventory implementation to rollback inventory changes if encumbrances fail to be created despite validation when opening an order.

[Related test PR](https://github.com/folio-org/folio-integration-tests/pull/1267).

#### TODOS
- [MODORDERS-1050](https://folio-org.atlassian.net/browse/MODORDERS-1050) - Add expenditure restriction checks when opening an order

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
