### PR TITLE
[MODORDERS-1039] Update encumbrance expense class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.vertx/
 .gradle
 /.resourceCache/
+/src/main/resources/postgres-conf.json

--- a/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
@@ -42,9 +42,12 @@ public class EncumbrancesProcessingHolderBuilder {
       .getEncumbrance().getInitialAmountEncumbered();
     double updatedInitialAmount = holder.getNewEncumbrance()
       .getEncumbrance().getInitialAmountEncumbered();
+    String newExpenseClassId = holder.getNewEncumbrance().getExpenseClassId();
+    String oldExpenseClassId = holder.getOldEncumbrance().getExpenseClassId();
 
     return Double.compare(amountBeforeUpdate, updatedAmount) != 0
-      || (Double.compare(initialAmountBeforeUpdate, updatedInitialAmount) != 0);
+      || (Double.compare(initialAmountBeforeUpdate, updatedInitialAmount) != 0)
+      || !Objects.equals(oldExpenseClassId, newExpenseClassId);
   }
 
   private List<EncumbranceRelationsHolder> getToBeCreatedHolders(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {

--- a/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
@@ -46,7 +46,7 @@ public class EncumbrancesProcessingHolderBuilder {
     String oldExpenseClassId = holder.getOldEncumbrance().getExpenseClassId();
 
     return Double.compare(amountBeforeUpdate, updatedAmount) != 0
-      || (Double.compare(initialAmountBeforeUpdate, updatedInitialAmount) != 0)
+      || Double.compare(initialAmountBeforeUpdate, updatedInitialAmount) != 0
       || !Objects.equals(oldExpenseClassId, newExpenseClassId);
   }
 

--- a/src/main/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategy.java
@@ -1,6 +1,5 @@
 package org.folio.service.finance.transaction;
 
-import static java.util.stream.Collectors.toList;
 import static org.folio.orders.utils.FundDistributionUtils.validateFundDistributionTotal;
 
 import java.util.List;
@@ -44,8 +43,10 @@ public class PendingToPendingEncumbranceStrategy implements EncumbranceWorkflowS
 
   private EncumbrancesProcessingHolder distributeHoldersByOperation(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {
     EncumbrancesProcessingHolder holder = new EncumbrancesProcessingHolder();
+    List<EncumbranceRelationsHolder> toUpdate = getTransactionsToUpdate(encumbranceRelationsHolders);
     List<EncumbranceRelationsHolder> toDelete = getTransactionsToDelete(encumbranceRelationsHolders);
-    List<Transaction> toRelease = toDelete.stream().map(EncumbranceRelationsHolder::getOldEncumbrance).collect(toList());
+    List<Transaction> toRelease = toDelete.stream().map(EncumbranceRelationsHolder::getOldEncumbrance).toList();
+    holder.withEncumbrancesForUpdate(toUpdate);
     holder.withEncumbrancesForRelease(toRelease);
     holder.withEncumbrancesForDelete(toDelete);
     return holder;
@@ -54,7 +55,26 @@ public class PendingToPendingEncumbranceStrategy implements EncumbranceWorkflowS
   private List<EncumbranceRelationsHolder> getTransactionsToDelete(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {
     return encumbranceRelationsHolders.stream()
       .filter(holder -> Objects.isNull(holder.getNewEncumbrance()))
-      .collect(toList());
+      .toList();
+  }
+
+  private List<EncumbranceRelationsHolder> getTransactionsToUpdate(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {
+    // Return a list of holders with transactions that need to have an expense class update.
+    // We want to avoid loading all financial data like in pending->open, so we copy some fields
+    // from the old encumbrance (amount is 0 with pending orders).
+    List<EncumbranceRelationsHolder> toUpdate = encumbranceRelationsHolders.stream()
+      .filter(holder -> holder.getNewEncumbrance() != null && holder.getOldEncumbrance() != null &&
+        !Objects.equals(holder.getNewEncumbrance().getExpenseClassId(), holder.getOldEncumbrance().getExpenseClassId()))
+      .toList();
+    toUpdate.forEach(holder -> {
+      Transaction oldEncumbrance = holder.getOldEncumbrance();
+      Transaction newEncumbrance = holder.getNewEncumbrance();
+      newEncumbrance.withFiscalYearId(oldEncumbrance.getFiscalYearId())
+        .withCurrency(oldEncumbrance.getCurrency())
+        .withAmount(oldEncumbrance.getAmount())
+        .getEncumbrance().withInitialAmountEncumbered(oldEncumbrance.getEncumbrance().getInitialAmountEncumbered());
+    });
+    return toUpdate;
   }
 
 }

--- a/src/main/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategy.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import org.folio.models.EncumbranceRelationsHolder;
 import org.folio.models.EncumbrancesProcessingHolder;
+import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
@@ -72,7 +73,12 @@ public class PendingToPendingEncumbranceStrategy implements EncumbranceWorkflowS
       newEncumbrance.withFiscalYearId(oldEncumbrance.getFiscalYearId())
         .withCurrency(oldEncumbrance.getCurrency())
         .withAmount(oldEncumbrance.getAmount())
-        .getEncumbrance().withInitialAmountEncumbered(oldEncumbrance.getEncumbrance().getInitialAmountEncumbered());
+        .getEncumbrance()
+          .withInitialAmountEncumbered(oldEncumbrance.getEncumbrance().getInitialAmountEncumbered())
+          .withOrderStatus(Encumbrance.OrderStatus.PENDING)
+          .withStatus(oldEncumbrance.getEncumbrance().getStatus())
+          .withSubscription(oldEncumbrance.getEncumbrance().getSubscription())
+          .withReEncumber(oldEncumbrance.getEncumbrance().getReEncumber());
     });
     return toUpdate;
   }

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -58,6 +58,7 @@ import org.folio.service.finance.transaction.EncumbranceServiceTest;
 import org.folio.service.finance.transaction.OpenToClosedEncumbranceStrategyTest;
 import org.folio.service.finance.transaction.OpenToPendingEncumbranceStrategyTest;
 import org.folio.service.finance.transaction.PendingToOpenEncumbranceStrategyTest;
+import org.folio.service.finance.transaction.PendingToPendingEncumbranceStrategyTest;
 import org.folio.service.finance.transaction.TransactionServiceTest;
 import org.folio.service.inventory.HoldingsSummaryServiceTest;
 import org.folio.service.inventory.InventoryManagerTest;
@@ -264,6 +265,10 @@ public class ApiTestSuite {
 
   @Nested
   class PendingToOpenEncumbranceStrategyTestNested extends PendingToOpenEncumbranceStrategyTest {
+  }
+
+  @Nested
+  class PendingToPendingEncumbranceStrategyTestNested extends PendingToPendingEncumbranceStrategyTest {
   }
 
   @Nested

--- a/src/test/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/PendingToPendingEncumbranceStrategyTest.java
@@ -1,0 +1,151 @@
+package org.folio.service.finance.transaction;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.TestConstants.COMP_ORDER_MOCK_DATA_PATH;
+import static org.folio.TestUtils.getMockAsJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.models.EncumbranceRelationsHolder;
+import org.folio.models.EncumbrancesProcessingHolder;
+import org.folio.rest.acq.model.finance.Encumbrance;
+import org.folio.rest.acq.model.finance.Metadata;
+import org.folio.rest.acq.model.finance.Transaction;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePoLine;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.FundDistribution;
+import org.folio.service.exchange.ExchangeRateProviderResolver;
+import org.folio.service.finance.FiscalYearService;
+import org.folio.service.finance.FundService;
+import org.folio.service.finance.LedgerService;
+import org.folio.service.finance.budget.BudgetService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(VertxExtension.class)
+public class PendingToPendingEncumbranceStrategyTest {
+  public static final String PENDING_ORDER_ID = "22f0d3dd-267d-405c-9917-29395b8507d8";
+  public static final String ORDER_PATH = COMP_ORDER_MOCK_DATA_PATH + PENDING_ORDER_ID + ".json";
+
+  private PendingToPendingEncumbranceStrategy pendingToPendingEncumbranceStrategy;
+
+  @Mock
+  private EncumbranceService encumbranceService;
+  @Mock
+  private FundService fundService;
+  @Mock
+  private FiscalYearService fiscalYearService;
+  @Mock
+  private ExchangeRateProviderResolver exchangeRateProviderResolver;
+  @Mock
+  private BudgetService budgetService;
+  @Mock
+  private LedgerService ledgerService;
+  @Mock
+  private RequestContext requestContext;
+  @Captor
+  ArgumentCaptor<EncumbrancesProcessingHolder> holderCaptor;
+
+  @BeforeEach
+  void init() {
+    EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder = new EncumbranceRelationsHoldersBuilder(
+      encumbranceService, fundService, fiscalYearService, exchangeRateProviderResolver, budgetService, ledgerService);
+
+    pendingToPendingEncumbranceStrategy = new PendingToPendingEncumbranceStrategy(encumbranceService,
+      encumbranceRelationsHoldersBuilder);
+  }
+
+  @Test
+  void testChangingExpenseClass(VertxTestContext vertxTestContext) {
+    // Given
+    String newExpenseClassId = "d9328814-eba1-4083-98ca-026eb269a4a8";
+    CompositePurchaseOrder order = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
+    CompositePurchaseOrder orderFromStorage = JsonObject.mapFrom(order).mapTo(CompositePurchaseOrder.class);
+    CompositePoLine poLine = order.getCompositePoLines().get(0);
+    FundDistribution fd1 = poLine.getFundDistribution().get(0);
+    FundDistribution fd2 = poLine.getFundDistribution().get(1);
+
+    String oldExpenseClassId = fd1.getExpenseClassId();
+    fd1.setExpenseClassId(newExpenseClassId);
+
+    Transaction encumbrance1 = new Transaction()
+      .withTransactionType(Transaction.TransactionType.ENCUMBRANCE)
+      .withAmount(0d)
+      .withId(fd1.getEncumbrance())
+      .withFromFundId(fd1.getFundId())
+      .withExpenseClassId(oldExpenseClassId)
+      .withSource(Transaction.Source.PO_LINE)
+      .withEncumbrance(new Encumbrance()
+        .withSourcePurchaseOrderId(order.getId())
+        .withSourcePoLineId(poLine.getId())
+        .withOrderType(Encumbrance.OrderType.fromValue(order.getOrderType().value()))
+        .withInitialAmountEncumbered(2d)
+        .withOrderStatus(Encumbrance.OrderStatus.PENDING)
+        .withStatus(Encumbrance.Status.PENDING))
+      .withMetadata(new Metadata());
+    Transaction encumbrance2 = new Transaction()
+      .withTransactionType(Transaction.TransactionType.ENCUMBRANCE)
+      .withAmount(0d)
+      .withId(fd2.getEncumbrance())
+      .withFromFundId(fd2.getFundId())
+      .withExpenseClassId(fd2.getExpenseClassId())
+      .withSource(Transaction.Source.PO_LINE)
+      .withEncumbrance(new Encumbrance()
+        .withSourcePurchaseOrderId(order.getId())
+        .withSourcePoLineId(poLine.getId())
+        .withOrderType(Encumbrance.OrderType.fromValue(order.getOrderType().value()))
+        .withInitialAmountEncumbered(2d)
+        .withOrderStatus(Encumbrance.OrderStatus.PENDING)
+        .withStatus(Encumbrance.Status.PENDING))
+      .withMetadata(new Metadata());
+    List<Transaction> encumbrances = List.of(encumbrance1, encumbrance2);
+
+    doReturn(succeededFuture(encumbrances))
+      .when(encumbranceService).getEncumbrancesByIds(anyList(), eq(requestContext));
+    doReturn(succeededFuture())
+      .when(encumbranceService).createOrUpdateEncumbrances(any(EncumbrancesProcessingHolder.class), eq(requestContext));
+
+    // When
+    Future<Void> future = pendingToPendingEncumbranceStrategy.processEncumbrances(order, orderFromStorage, requestContext);
+
+    // Then
+    vertxTestContext.assertComplete(future)
+      .onSuccess(result -> vertxTestContext.verify(() -> {
+        verify(encumbranceService, times(1))
+          .createOrUpdateEncumbrances(holderCaptor.capture(), eq(requestContext));
+        List<EncumbrancesProcessingHolder> holders = holderCaptor.getAllValues();
+        assertEquals(1, holders.size());
+        EncumbrancesProcessingHolder holder = holders.get(0);
+        assertEquals(0, holder.getEncumbrancesForCreate().size());
+        assertEquals(1, holder.getEncumbrancesForUpdate().size());
+        assertEquals(0, holder.getEncumbrancesForDelete().size());
+        assertEquals(0, holder.getEncumbrancesForRelease().size());
+        assertEquals(0, holder.getEncumbrancesForUnrelease().size());
+        EncumbranceRelationsHolder updateHolder = holder.getEncumbrancesForUpdate().get(0);
+        Transaction updatedTransaction = updateHolder.getNewEncumbrance();
+        assertEquals(newExpenseClassId, updatedTransaction.getExpenseClassId());
+        assertEquals(encumbrance1, updatedTransaction.withExpenseClassId(oldExpenseClassId));
+        vertxTestContext.completeNow();
+      }))
+      .onFailure(vertxTestContext::failNow);
+  }
+}

--- a/src/test/resources/mockdata/compositeOrders/22f0d3dd-267d-405c-9917-29395b8507d8.json
+++ b/src/test/resources/mockdata/compositeOrders/22f0d3dd-267d-405c-9917-29395b8507d8.json
@@ -1,0 +1,84 @@
+{
+  "id": "22f0d3dd-267d-405c-9917-29395b8507d8",
+  "approved": true,
+  "assignedTo": "",
+  "manualPo": false,
+  "poNumber": "1",
+  "orderType": "One-Time",
+  "reEncumber": false,
+  "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflowStatus": "Pending",
+  "metadata": {
+    "createdDate": "2018-06-29T00:00:00.000",
+    "createdByUserId": "28d0f99c-d137-11e8-a8d5-f2801f1b9fd1"
+  },
+  "compositePoLines": [
+    {
+      "id": "bb8b9683-70d6-4eff-94c8-175ac297d2f8",
+      "checkinItems": false,
+      "acquisitionMethod": "796596c4-62b5-4b64-a2ce-524c747afaa2",
+      "contributors": [],
+      "cost": {
+        "listUnitPrice": 1.0,
+        "currency": "USD",
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 1.0
+      },
+      "details": {
+        "productIds": [],
+        "subscriptionInterval": 0
+      },
+      "eresource": {
+        "activated": false,
+        "createInventory": "None",
+        "trial": false,
+        "accessProvider": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1"
+      },
+      "fundDistribution": [
+        {
+          "code": "AFRICAHIST",
+          "encumbrance": "9e609d2b-de47-4f60-bb56-8a778289e6e0",
+          "fundId": "e9285a1c-1dfc-4380-868c-e74073003f43",
+          "expenseClassId": "61e68a14-8091-42fc-8c23-e1b0064aa811",
+          "distributionType": "percentage",
+          "value": 50.0
+        },
+        {
+          "code": "AFRICAHIST",
+          "encumbrance": "82ed2077-1ae4-4c7e-a850-c1497fce7e09",
+          "fundId": "e9285a1c-1dfc-4380-868c-e74073003f43",
+          "expenseClassId": "75a9ecf4-1d1d-4cc1-bb7c-a4f14714a17b",
+          "distributionType": "percentage",
+          "value": 50.0
+        }
+      ],
+      "isPackage": false,
+      "locations": [
+        {
+          "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
+          "quantity": 2,
+          "quantityPhysical": 2
+        }
+      ],
+      "orderFormat": "Physical Resource",
+      "paymentStatus": "Pending",
+      "physical": {
+        "createInventory": "Instance, Holding, Item",
+        "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "materialSupplier": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",
+        "volumes": []
+      },
+      "poLineNumber": "10001-1",
+      "purchaseOrderId": "22f0d3dd-267d-405c-9917-29395b8507d8",
+      "receiptStatus": "Pending",
+      "reportingCodes": [],
+      "source": "User",
+      "titleOrPackage": "test",
+      "vendorDetail": {
+        "instructions": "",
+        "vendorAccount": "1324"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-1039](https://folio-org.atlassian.net/browse/MODORDERS-1039) - Encumbrance expense class not updated after a change to the fund distribution

## Approach
- For pending orders, update encumbrances with an expense class change (using the old encumbrance for some fields like the fiscal year id)
- For open orders, match fund distribution lines to old transactions by checking the fund and expense class first, and the encumbrance id next if there is no match; this is to avoid a conflict with the unique encumbrance database restriction when updating or recreating encumbrances.
- Also added `postgres-conf.json` to `.gitignore`.

**See also**: "Implementation Notes" in [MODORDERS-1039](https://folio-org.atlassian.net/browse/MODORDERS-1039).

[Related integration test](https://github.com/folio-org/folio-integration-tests/pull/1271)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
