### PR TITLE
MODOERDERS-1028-Add specific error code of barcode uniqueness error e…

### DIFF
--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -5,8 +5,6 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
-import static org.folio.rest.core.exceptions.ErrorCodes.ITEM_UPDATE_FAILED;
-import static org.folio.rest.core.exceptions.ErrorCodes.BARCODE_IS_NOT_UNIQUE;
 import static org.folio.service.inventory.InventoryManager.ITEM_ACCESSION_NUMBER;
 import static org.folio.service.inventory.InventoryManager.ITEM_BARCODE;
 import static org.folio.service.inventory.InventoryManager.ITEM_CHRONOLOGY;

--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -216,7 +216,7 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
       })
       // Add processing error if item failed to be updated
       .onFailure(e -> {
-        addErrorForUpdatingItem(piece, e.toString());
+        addErrorForUpdatingItem(piece, e);
         promise.complete(false);
       });
     return promise.future();

--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -218,21 +218,10 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
       })
       // Add processing error if item failed to be updated
       .onFailure(e -> {
-        produceErrorMessage(piece, e.toString());
+        addErrorForUpdatingItem(piece, e.toString());
         promise.complete(false);
       });
     return promise.future();
-  }
-
-  // This function produces error message based on the error it receives from the checkinItem()
-  protected void produceErrorMessage(Piece piece, String error) {
-    if (error.contains("Barcode must be unique")) {
-      logger.error("The barcode associate with item '{}' is not unique, it cannot be updated", piece.getId());
-      addError(piece.getPoLineId(), piece.getId(), BARCODE_IS_NOT_UNIQUE.toError());
-    } else {
-      logger.error("Item associated with piece '{}' cannot be updated", piece.getId());
-      addError(piece.getPoLineId(), piece.getId(), ITEM_UPDATE_FAILED.toError());
-    }
   }
 
   private void updatePieceWithCheckinInfo(Piece piece) {

--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -224,12 +224,12 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
     return promise.future();
   }
 
-  // This function produces error message based the error it receives from the checkinItem()
+  // This function produces error message based on the error it receives from the checkinItem()
   protected void produceErrorMessage(Piece piece, String error) {
     if (error.contains("Barcode must be unique")) {
       logger.error("The barcode associate with item '{}' is not unique, it cannot be updated", piece.getId());
       addError(piece.getPoLineId(), piece.getId(), BARCODE_IS_NOT_UNIQUE.toError());
-    } else if (error != null) {
+    } else {
       logger.error("Item associated with piece '{}' cannot be updated", piece.getId());
       addError(piece.getPoLineId(), piece.getId(), ITEM_UPDATE_FAILED.toError());
     }

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -811,7 +811,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
     if (error.contains(BARCODE_NOT_UNIQUE_MESSAGE)) {
       logger.error("The barcode associate with item '{}' is not unique, it cannot be updated", piece.getId());
       addError(piece.getPoLineId(), piece.getId(), BARCODE_IS_NOT_UNIQUE.toError());
-    } else if (error != null) {
+    } else {
       logger.error("Item associated with piece '{}' cannot be updated", piece.getId());
       addError(piece.getPoLineId(), piece.getId(), ITEM_UPDATE_FAILED.toError());
     }

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -52,6 +52,7 @@ import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Eresource;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Location;
+import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.Piece.ReceivingStatus;
@@ -80,12 +81,11 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
 
   public static final List<ReceivingStatus> RECEIVED_STATUSES = List.of(RECEIVED, UNRECEIVABLE);
   public static final List<ReceivingStatus> EXPECTED_STATUSES = List.of(EXPECTED, CLAIM_DELAYED, CLAIM_SENT, LATE);
-
+  private static final String BARCODE_NOT_UNIQUE_MESSAGE = "Barcode must be unique";
   protected Map<String, Map<String, T>> piecesByLineId;
   private final Map<String, Map<String, Error>> processingErrors;
   private final Set<String> processedHoldingsParams;
   private final Map<String, String> processedHoldings;
-  private static final String BARCODE_NOT_UNIQUE_MESSAGE = "Barcode must be unique";
   @Autowired
   private  ProtectionService protectionService;
   @Autowired
@@ -601,7 +601,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
    * @param pieceId piece id
    * @return error object if presents or null
    */
-  private Error getError(String polId, String pieceId) {
+  protected Error getError(String polId, String pieceId) {
     return Optional.ofNullable(processingErrors.get(polId))
      .map(errors -> errors.get(pieceId))
      .orElse(null);
@@ -808,13 +808,14 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
     Map<String, Title> titleById;
   }
 
-  protected void addErrorForUpdatingItem(Piece piece, String error) {
-    if (error.contains(BARCODE_NOT_UNIQUE_MESSAGE)) {
+  protected void addErrorForUpdatingItem(Piece piece, Throwable e) {
+    if (StringUtils.isNotBlank(e.getMessage()) && e.getMessage().contains(BARCODE_NOT_UNIQUE_MESSAGE)) {
       logger.error("The barcode associate with item '{}' is not unique, it cannot be updated", piece.getId());
       addError(piece.getPoLineId(), piece.getId(), BARCODE_IS_NOT_UNIQUE.toError());
     } else {
-      logger.error("Item associated with piece '{}' cannot be updated", piece.getId());
-      addError(piece.getPoLineId(), piece.getId(), ITEM_UPDATE_FAILED.toError());
+      logger.error("Item associated with piece '{}' cannot be updated", piece.getId(), e);
+      var causeParam = new Parameter().withKey("cause").withValue(e.getMessage());
+      addError(piece.getPoLineId(), piece.getId(), ITEM_UPDATE_FAILED.toError().withParameters(List.of(causeParam)));
     }
   }
 }

--- a/src/main/java/org/folio/helper/ReceivingHelper.java
+++ b/src/main/java/org/folio/helper/ReceivingHelper.java
@@ -218,7 +218,7 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
       })
       // Add processing error if item failed to be updated
       .otherwise(e -> {
-        addErrorForUpdatingItem(piece, e.toString());
+        addErrorForUpdatingItem(piece, e);
         return false;
       });
   }

--- a/src/main/java/org/folio/helper/ReceivingHelper.java
+++ b/src/main/java/org/folio/helper/ReceivingHelper.java
@@ -206,7 +206,6 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
           .isOnOrderItemStatus(piecesByLineId.get(piece.getPoLineId()).get(piece.getId()));
   }
 
-
   @Override
   protected Future<Boolean> receiveInventoryItemAndUpdatePiece(JsonObject item, Piece piece, RequestContext requestContext) {
     ReceivedItem receivedItem = piecesByLineId.get(piece.getPoLineId())
@@ -219,9 +218,8 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
         return true;
       })
       // Add processing error if item failed to be updated
-       .otherwise(e -> {
-        logger.error("Item associated with piece '{}' cannot be updated", piece.getId());
-        addError(piece.getPoLineId(), piece.getId(), ITEM_UPDATE_FAILED.toError());
+      .otherwise(e -> {
+        addErrorForUpdatingItem(piece, e.toString());
         return false;
       });
   }

--- a/src/main/java/org/folio/helper/ReceivingHelper.java
+++ b/src/main/java/org/folio/helper/ReceivingHelper.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.folio.orders.utils.ResourcePathResolver.RECEIVING_HISTORY;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
-import static org.folio.rest.core.exceptions.ErrorCodes.ITEM_UPDATE_FAILED;
 import static org.folio.service.inventory.InventoryManager.COPY_NUMBER;
 import static org.folio.service.inventory.InventoryManager.ITEM_BARCODE;
 import static org.folio.service.inventory.InventoryManager.ITEM_CHRONOLOGY;

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -115,7 +115,7 @@ public enum ErrorCodes {
   ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND("encumbrancesForReEncumberNotFound", "The encumbrances were correctly created during the rollover or have already been updated."),
   CLAIMING_CONFIG_INVALID("claimingConfigInvalid", "Claiming interval should be set and greater than 0 if claiming is active"),
   TEMPLATE_NAME_ALREADY_EXISTS("templateNameNotUnique", "Template name already exists"),
-  BARCODE_IS_NOT_UNIQUE("barcodeIsNotUnique", "Barcode must be unique");
+  BARCODE_IS_NOT_UNIQUE("barcodeIsNotUnique", "Barcode must be unique, this barcode already exists");
 
 
   private final String code;

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -117,7 +117,6 @@ public enum ErrorCodes {
   TEMPLATE_NAME_ALREADY_EXISTS("templateNameNotUnique", "Template name already exists"),
   BARCODE_IS_NOT_UNIQUE("barcodeIsNotUnique", "Barcode must be unique, this barcode already exists");
 
-
   private final String code;
   private final String description;
 

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -115,7 +115,7 @@ public enum ErrorCodes {
   ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND("encumbrancesForReEncumberNotFound", "The encumbrances were correctly created during the rollover or have already been updated."),
   CLAIMING_CONFIG_INVALID("claimingConfigInvalid", "Claiming interval should be set and greater than 0 if claiming is active"),
   TEMPLATE_NAME_ALREADY_EXISTS("templateNameNotUnique", "Template name already exists"),
-  BARCODE_IS_NOT_UNIQUE("barcodeIsNotUnique", "Barcode must be unique, this barcode already exists");
+  BARCODE_IS_NOT_UNIQUE("barcodeIsNotUnique", "The barcode already exists. The barcode must be unique");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -114,7 +114,8 @@ public enum ErrorCodes {
   FUND_LOCATION_RESTRICTION_VIOLATION("fundLocationRestrictionViolation", "One of the locations is restricted to be used by all funds."),
   ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND("encumbrancesForReEncumberNotFound", "The encumbrances were correctly created during the rollover or have already been updated."),
   CLAIMING_CONFIG_INVALID("claimingConfigInvalid", "Claiming interval should be set and greater than 0 if claiming is active"),
-  TEMPLATE_NAME_ALREADY_EXISTS("templateNameNotUnique", "Template name already exists");
+  TEMPLATE_NAME_ALREADY_EXISTS("templateNameNotUnique", "Template name already exists"),
+  BARCODE_IS_NOT_UNIQUE("barcodeIsNotUnique", "Barcode must be unique");
 
 
   private final String code;


### PR DESCRIPTION
**Purpose:**

During receiving pieces on the Full Receiving Screen View when populating barcodes the validation of related item barcode uniqueness occurs. In cases when the barcode is not unique, we need to provide a clear message about the reason to users.

**Actual result:**

Currently this error message is shown:

{
  "receivingResults" : [ {
    "poLineId" : "8c9da779-0cf2-4da1-9749-9c1954f368ef",
    "processedSuccessfully" : 0,
    "processedWithError" : 1,
    "receivingItemResults" : [ {
      "pieceId" : "44f2fdaa-b65c-4349-867c-56563761699a",
      "processingStatus" : {
        "type" : "failure",
        "error" : {
          "message" : "The item record failed to be updated",
          "code" : "itemUpdateFailed",
          "parameters" : [ ]
        }
      }
    } ]
  } ],
  "totalRecords" : 1
}
**Expected result:**

Error block is updated to cleary say that item barcode is not unique.