### PR TITLE
[MODINVOICE-516] Added a permission to bypass acqunit checks

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -155,6 +155,9 @@
           "permissionsRequired": [
             "orders.po-lines.collection.get"
           ],
+          "permissionsDesired": [
+            "orders.bypass-acquisitions-units"
+          ],
           "modulePermissions": [
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get",
@@ -195,6 +198,9 @@
           "permissionsRequired": [
             "orders.po-lines.item.get"
           ],
+          "permissionsDesired": [
+            "orders.bypass-acquisitions-units"
+          ],
           "modulePermissions": [
             "orders-storage.po-lines.item.get",
             "orders-storage.alerts.item.get",
@@ -213,6 +219,9 @@
           "pathPattern": "/orders/order-lines/{id}",
           "permissionsRequired": [
             "orders.po-lines.item.put"
+          ],
+          "permissionsDesired": [
+            "orders.bypass-acquisitions-units"
           ],
           "modulePermissions": [
             "orders-storage.alerts.item.post",
@@ -1449,6 +1458,11 @@
         "acquisitions-units.units.item.put",
         "acquisitions-units.units.item.delete"
       ]
+    },
+    {
+      "permissionName": "orders.bypass-acquisitions-units",
+      "displayName": "Bypass acquisition units checks",
+      "description": "Backend internal permission to bypass acquisition units checks"
     },
     {
       "permissionName": "orders.acquisitions-units-assignments.assign",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -156,7 +156,7 @@
             "orders.po-lines.collection.get"
           ],
           "permissionsDesired": [
-            "orders.bypass-acquisitions-units"
+            "orders.bypass-acquisition-units"
           ],
           "modulePermissions": [
             "acquisitions-units-storage.units.collection.get",
@@ -199,7 +199,7 @@
             "orders.po-lines.item.get"
           ],
           "permissionsDesired": [
-            "orders.bypass-acquisitions-units"
+            "orders.bypass-acquisition-units"
           ],
           "modulePermissions": [
             "orders-storage.po-lines.item.get",
@@ -221,7 +221,7 @@
             "orders.po-lines.item.put"
           ],
           "permissionsDesired": [
-            "orders.bypass-acquisitions-units"
+            "orders.bypass-acquisition-units"
           ],
           "modulePermissions": [
             "orders-storage.alerts.item.post",
@@ -1460,7 +1460,7 @@
       ]
     },
     {
-      "permissionName": "orders.bypass-acquisitions-units",
+      "permissionName": "orders.bypass-acquisition-units",
       "displayName": "Bypass acquisition units checks",
       "description": "Backend internal permission to bypass acquisition units checks"
     },

--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -614,7 +614,7 @@ public class PurchaseOrderHelper {
         boolean isApprovalRequired = isApprovalRequiredConfiguration(tenantConfig);
         if (isApprovalRequired && compPO.getApproved()
           .equals(Boolean.TRUE)) {
-          if (isUserNotHaveApprovePermission(requestContext)) {
+          if (userDoesNotHaveApprovePermission(requestContext)) {
             throw new HttpException(HttpStatus.HTTP_FORBIDDEN.toInt(), USER_HAS_NO_APPROVAL_PERMISSIONS);
           }
           compPO.setApprovalDate(new Date());
@@ -626,13 +626,13 @@ public class PurchaseOrderHelper {
   }
 
   private void checkOrderUnopenPermissions(RequestContext requestContext) {
-    if (isUserNotHaveUnopenPermission(requestContext)) {
+    if (userDoesNotHaveUnopenPermission(requestContext)) {
       throw new HttpException(HttpStatus.HTTP_FORBIDDEN.toInt(), USER_HAS_NO_UNOPEN_PERMISSIONS);
     }
   }
 
   private void checkOrderReopenPermissions(RequestContext requestContext) {
-    if (isUserNotHaveReopenPermission(requestContext)) {
+    if (userDoesNotHaveReopenPermission(requestContext)) {
       throw new HttpException(HttpStatus.HTTP_FORBIDDEN.toInt(), USER_HAS_NO_REOPEN_PERMISSIONS);
     }
   }

--- a/src/main/java/org/folio/orders/utils/AcqDesiredPermissions.java
+++ b/src/main/java/org/folio/orders/utils/AcqDesiredPermissions.java
@@ -7,7 +7,8 @@ public enum AcqDesiredPermissions {
   ASSIGN("orders.acquisitions-units-assignments.assign"),
   MANAGE("orders.acquisitions-units-assignments.manage"),
   TITLES_ASSIGN("titles.acquisitions-units-assignments.assign"),
-  TITLES_MANAGE("titles.acquisitions-units-assignments.manage");
+  TITLES_MANAGE("titles.acquisitions-units-assignments.manage"),
+  BYPASS_ACQ_UNITS("orders.bypass-acquisitions-units");
 
   private final String permission;
   private static final List<String> values;

--- a/src/main/java/org/folio/orders/utils/AcqDesiredPermissions.java
+++ b/src/main/java/org/folio/orders/utils/AcqDesiredPermissions.java
@@ -26,7 +26,7 @@ public enum AcqDesiredPermissions {
     return permission;
   }
 
-  public static List<String> getValues() {
-    return values;
+  public static List<String> getValuesExceptBypass() {
+    return values.stream().filter(v -> !BYPASS_ACQ_UNITS.getPermission().equals(v)).toList();
   }
 }

--- a/src/main/java/org/folio/orders/utils/AcqDesiredPermissions.java
+++ b/src/main/java/org/folio/orders/utils/AcqDesiredPermissions.java
@@ -8,7 +8,7 @@ public enum AcqDesiredPermissions {
   MANAGE("orders.acquisitions-units-assignments.manage"),
   TITLES_ASSIGN("titles.acquisitions-units-assignments.assign"),
   TITLES_MANAGE("titles.acquisitions-units-assignments.manage"),
-  BYPASS_ACQ_UNITS("orders.bypass-acquisitions-units");
+  BYPASS_ACQ_UNITS("orders.bypass-acquisition-units");
 
   private final String permission;
   private static final List<String> values;

--- a/src/main/java/org/folio/orders/utils/PermissionsUtil.java
+++ b/src/main/java/org/folio/orders/utils/PermissionsUtil.java
@@ -18,7 +18,11 @@ public class PermissionsUtil {
 
   private PermissionsUtil() {}
 
-  public static boolean isUserDoesNotHaveDesiredPermission(AcqDesiredPermissions acqPerm, RequestContext requestContext) {
+  public static boolean userHasDesiredPermission(AcqDesiredPermissions acqPerm, RequestContext requestContext) {
+    return getProvidedPermissions(requestContext).contains(acqPerm.getPermission());
+  }
+
+  public static boolean userDoesNotHaveDesiredPermission(AcqDesiredPermissions acqPerm, RequestContext requestContext) {
     return !getProvidedPermissions(requestContext).contains(acqPerm.getPermission());
   }
 
@@ -32,15 +36,15 @@ public class PermissionsUtil {
       .toList();
   }
 
-  public static boolean isUserNotHaveApprovePermission(RequestContext requestContext) {
+  public static boolean userDoesNotHaveApprovePermission(RequestContext requestContext) {
     return !getProvidedPermissions(requestContext).contains(PERMISSION_ORDER_APPROVE);
   }
 
-  public static boolean isUserNotHaveUnopenPermission(RequestContext requestContext) {
+  public static boolean userDoesNotHaveUnopenPermission(RequestContext requestContext) {
     return !getProvidedPermissions(requestContext).contains(PERMISSION_ORDER_UNOPEN);
   }
 
-  public static boolean isUserNotHaveReopenPermission(RequestContext requestContext) {
+  public static boolean userDoesNotHaveReopenPermission(RequestContext requestContext) {
     return !getProvidedPermissions(requestContext).contains(PERMISSION_ORDER_REOPEN);
   }
 }

--- a/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
@@ -19,7 +19,7 @@ import static org.folio.helper.PurchaseOrderHelper.isApprovalRequiredConfigurati
 import static org.folio.orders.utils.HelperUtils.DEFAULT_POLINE_LIMIT;
 import static org.folio.orders.utils.HelperUtils.ORDER_CONFIG_MODULE_NAME;
 import static org.folio.orders.utils.HelperUtils.PO_LINES_LIMIT_PROPERTY;
-import static org.folio.orders.utils.PermissionsUtil.isUserNotHaveApprovePermission;
+import static org.folio.orders.utils.PermissionsUtil.userDoesNotHaveApprovePermission;
 import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE;
 import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.OTHER;
 import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.PHYSICAL_RESOURCE;
@@ -279,7 +279,7 @@ public class CreateOrderEventHandler implements EventHandler {
     CompositePurchaseOrder order = Json.decodeValue(dataImportEventPayload.getContext().get(ORDER.value()), CompositePurchaseOrder.class);
     Boolean isApproved = order.getApproved();
     boolean isApprovalRequired = isApprovalRequiredConfiguration(tenantConfig);
-    boolean isUserNotHaveApprovalPermission = isUserNotHaveApprovePermission(requestContext);
+    boolean isUserNotHaveApprovalPermission = userDoesNotHaveApprovePermission(requestContext);
 
     if (isApprovalRequired && Boolean.TRUE.equals(isApproved) && isUserNotHaveApprovalPermission) {
       order.setApproved(false);
@@ -302,7 +302,7 @@ public class CreateOrderEventHandler implements EventHandler {
     }
 
     boolean isApprovalRequired = isApprovalRequiredConfiguration(tenantConfig);
-    boolean isUserNotHaveApprovalPermission = isUserNotHaveApprovePermission(requestContext);
+    boolean isUserNotHaveApprovalPermission = userDoesNotHaveApprovePermission(requestContext);
 
     if (workflowStatus.equals(WorkflowStatus.OPEN)) {
       if (isApprovalRequired && isUserNotHaveApprovalPermission) {

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -278,7 +278,7 @@ public class PurchaseOrdersApiTest {
   public static final String ORDER_DELETE_ERROR_TENANT = "order_delete_error";
   static final Header ERROR_ORDER_DELETE_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, ORDER_DELETE_ERROR_TENANT);
 
-  public static final Header ALL_DESIRED_PERMISSIONS_HEADER = new Header(OKAPI_HEADER_PERMISSIONS, new JsonArray(AcqDesiredPermissions.getValues()).encode());
+  public static final Header ALL_DESIRED_PERMISSIONS_HEADER = new Header(OKAPI_HEADER_PERMISSIONS, new JsonArray(AcqDesiredPermissions.getValuesExceptBypass()).encode());
   public static final Header APPROVAL_PERMISSIONS_HEADER = new Header(OKAPI_HEADER_PERMISSIONS, new JsonArray(Collections.singletonList("orders.item.approve")).encode());
   public static final Header UNOPEN_PERMISSIONS_HEADER = new Header(OKAPI_HEADER_PERMISSIONS, new JsonArray(Collections.singletonList("orders.item.unopen")).encode());
   public static final Header REOPEN_PERMISSIONS_HEADER = new Header(OKAPI_HEADER_PERMISSIONS, new JsonArray(Collections.singletonList("orders.item.reopen")).encode());

--- a/src/test/java/org/folio/rest/impl/TitlesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/TitlesApiTest.java
@@ -72,7 +72,7 @@ public class TitlesApiTest {
   public static final String SAMPLE_TITLE_ID = "9a665b22-9fe5-4c95-b4ee-837a5433c95d";
   private final JsonObject titleJsonReqData = getMockAsJson(TITLES_MOCK_DATA_PATH + "title.json");
   private final JsonObject packageTitleJsonReqData = getMockAsJson(TITLES_MOCK_DATA_PATH + "package_title.json");
-  public static final Header ALL_DESIRED_PERMISSIONS_HEADER = new Header(OKAPI_HEADER_PERMISSIONS, new JsonArray(AcqDesiredPermissions.getValues()).encode());
+  public static final Header ALL_DESIRED_PERMISSIONS_HEADER = new Header(OKAPI_HEADER_PERMISSIONS, new JsonArray(AcqDesiredPermissions.getValuesExceptBypass()).encode());
 
   private static boolean runningOnOwn;
 


### PR DESCRIPTION
## Purpose
[MODINVOICE-516](https://folio-org.atlassian.net/browse/MODINVOICE-516) - Invoice transactions should not be changed when acquisition check was failed

## Approach
- Added a permission to bypass acqunit checks. It will be used in mod-invoice when updating an invoice
- Fixed English for some method names
- Updated unit tests

[Related mod-invoice PR](https://github.com/folio-org/mod-invoice/pull/479)
[Related integration test](https://github.com/folio-org/folio-integration-tests/pull/1299)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
