### PR TITLE
[MODORDERS-1071] Approved invoices should not affect paymentStatus when reopening

### DIFF
--- a/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
@@ -106,7 +106,7 @@ public class ReOpenCompositeOrderManager {
     var poLineInvoiceLinesMap = holder.getOrderLineInvoiceLines().stream().collect(groupingBy(InvoiceLine::getPoLineId));
 
     List<Invoice> poLineInvoices = poLineInvoicesMap.get(poLine.getId());
-    if (CollectionUtils.isNotEmpty(poLineInvoices) && isAnyInvoicesApprovedOrPaid(poLineInvoices)) {
+    if (CollectionUtils.isNotEmpty(poLineInvoices) && isAnyInvoicePaid(poLineInvoices)) {
       var invoiceLines = poLineInvoiceLinesMap.get(poLine.getId());
       if (isAnyInvoiceLineReleaseEncumbrance(invoiceLines)) {
         poLine.setPaymentStatus(CompositePoLine.PaymentStatus.FULLY_PAID);
@@ -122,9 +122,8 @@ public class ReOpenCompositeOrderManager {
     return invoiceLines.stream().anyMatch(InvoiceLine::getReleaseEncumbrance);
   }
 
-  private boolean isAnyInvoicesApprovedOrPaid(List<Invoice> poLineInvoices) {
-    return poLineInvoices.stream().anyMatch(invoice -> Invoice.Status.APPROVED.equals(invoice.getStatus()) ||
-                                                            Invoice.Status.PAID.equals(invoice.getStatus()));
+  private boolean isAnyInvoicePaid(List<Invoice> poLineInvoices) {
+    return poLineInvoices.stream().anyMatch(invoice -> Invoice.Status.PAID.equals(invoice.getStatus()));
   }
 
   private void updatePoLineReceiptStatus(CompositePoLine poLine, ReOpenCompositeOrderHolder holder) {

--- a/src/test/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManagerTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManagerTest.java
@@ -111,11 +111,10 @@ public class ReOpenCompositeOrderManagerTest {
 
   @ParameterizedTest
   @CsvSource(value = {"Open:Expected:Awaiting Receipt:Awaiting Payment",
-                      "Approved:Received:Partially Received:Fully Paid",
+                      "Approved:Received:Partially Received:Awaiting Payment",
                       "Paid:Received:Partially Received:Fully Paid"}, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveSameStatuses(
-        String invoiceStatus, String pieceStatus, String expReceiptStatus, String expPaymentStatus)
-                      throws ExecutionException, InterruptedException {
+      String invoiceStatus, String pieceStatus, String expReceiptStatus, String expPaymentStatus) {
     CompositePurchaseOrder oldOrder = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     CompositePoLine poLine1 = oldOrder.getCompositePoLines().get(0);
     String poLineId1 = poLine1.getId();
@@ -174,17 +173,16 @@ public class ReOpenCompositeOrderManagerTest {
   }
 
   @ParameterizedTest
-  @CsvSource(value = {"Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Partially Paid:true:false",
-                      "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Fully Paid:true:true",
-                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment:true:true",
-                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment:true:false",
+  @CsvSource(value = {"Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Awaiting Payment:true:false",
+                      "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Awaiting Payment:true:true",
+                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Awaiting Payment:Awaiting Payment:true:true",
+                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Awaiting Payment:Awaiting Payment:true:false",
                       "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Fully Paid:Awaiting Payment:true:true",
                       "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Partially Paid:Awaiting Payment:false:true"}, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveDifferentStatuses(
-                  String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
-                  String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2,
-                  boolean releaseEncumbrances1, boolean releaseEncumbrances2)
-    throws ExecutionException, InterruptedException {
+      String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
+      String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2,
+      boolean releaseEncumbrances1, boolean releaseEncumbrances2) {
     CompositePurchaseOrder oldOrder = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     CompositePoLine poLine1 = oldOrder.getCompositePoLines().get(0);
     String poLineId1 = poLine1.getId();
@@ -246,14 +244,13 @@ public class ReOpenCompositeOrderManagerTest {
 
   @ParameterizedTest
   @CsvSource(value = {
-    "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Fully Paid",
-    "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment",
+    "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Awaiting Payment",
+    "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Awaiting Payment:Awaiting Payment",
     "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Fully Paid:Awaiting Payment"
   }, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveDifferentStatusesAndPolCoveredMoreThenOneInvoice(
-    String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
-    String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2)
-    throws ExecutionException, InterruptedException {
+      String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
+      String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2) {
     CompositePurchaseOrder oldOrder = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     CompositePoLine poLine1 = oldOrder.getCompositePoLines().get(0);
     String poLineId1 = poLine1.getId();


### PR DESCRIPTION
## Purpose
[MODORDERS-1071](https://folio-org.atlassian.net/browse/MODORDERS-1071) - PaymentStatus can be wrong after reopening an order

## Approach
- When reopening and updating paymentStatus, changed invoice status check to ignore approved invoices
- Updated tests

[Integration test](https://github.com/folio-org/folio-integration-tests/pull/1302)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
