### PR TITLE
[MODORDERS-1073] Using the new permission in mod-invoice to bypass acq unit checks

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -92,7 +92,8 @@
             "orders-storage.configuration.suffixes.collection.get",
             "finance.funds.item.get",
             "finance.transactions.collection.get",
-            "finance.transactions.batch"
+            "finance.transactions.batch",
+            "invoices.bypass-acquisition-units"
           ]
         },
         {
@@ -267,6 +268,7 @@
             "organizations-storage.organizations.collection.get",
             "invoice.invoice-lines.collection.get",
             "invoice.invoice-lines.item.put",
+            "invoices.bypass-acquisition-units",
             "orders-storage.order-invoice-relationships.collection.get",
             "user-tenants.collection.get",
             "consortia.sharing-instances.item.post"
@@ -1462,7 +1464,7 @@
     {
       "permissionName": "orders.bypass-acquisition-units",
       "displayName": "Bypass acquisition units checks",
-      "description": "Backend internal permission to bypass acquisition units checks"
+      "description": "Backend internal permission to bypass order acquisition units checks"
     },
     {
       "permissionName": "orders.acquisitions-units-assignments.assign",


### PR DESCRIPTION
## Purpose
[MODORDERS-1073](https://folio-org.atlassian.net/browse/MODORDERS-1073) - Invoice encumbrance link not removed because of acquisition unit

## Approach
Used the new permission in mod-invoice to bypass acq unit checks

[mod-invoice PR](https://github.com/folio-org/mod-invoice/pull/481) - integration test

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
