### PR TITLE
[MODORDERS-1078] Avoid onSuccess terminal operators in the middle of executing chain

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -461,7 +461,7 @@ public class PurchaseOrderHelper {
       .map(v -> errors.addAll(validatePoLineLimit(compPO, tenantConfig)))
       .compose(v -> purchaseOrderLineService.validateAndNormalizeISBN(compPO.getCompositePoLines(), requestContext))
       .compose(v -> validateVendor(compPO, requestContext))
-      .onSuccess(errors::addAll)
+      .map(errors::addAll)
       .map(v -> {
         errors.addAll(validateRenewalInfo(compPO));
         return errors;

--- a/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
+++ b/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
@@ -67,7 +67,7 @@ public class ReceiptStatusConsistency extends BaseHelper implements Handler<Mess
 
     // 1. Get all pieces for poLineId
     getPieces(query, requestContext)
-      .onSuccess(listOfPieces ->
+      .compose(listOfPieces ->
         // 2. Get PoLine for the poLineId which will be used to calculate PoLineReceiptStatus
         purchaseOrderLineService.getOrderLineById(poLineIdUpdate, requestContext)
           .map(poLine -> {

--- a/src/main/java/org/folio/rest/impl/CompositePoLineAPI.java
+++ b/src/main/java/org/folio/rest/impl/CompositePoLineAPI.java
@@ -126,8 +126,8 @@ public class CompositePoLineAPI extends BaseApi implements OrdersOrderLines {
     configurationEntriesCache.loadConfiguration(ORDER_CONFIG_MODULE_NAME, requestContext)
       .compose(tenantConfig -> helper.setTenantDefaultCreateInventoryValues(poLine, tenantConfig))
       .compose(v -> compositePoLineValidationService.validatePoLine(poLine, requestContext))
-      .onSuccess(errors::addAll)
-      .onSuccess(empty -> {
+      .map(errors::addAll)
+      .onSuccess(b -> {
         if (!errors.isEmpty()) {
           PutOrdersOrderLinesByIdResponse response = PutOrdersOrderLinesByIdResponse
             .respond422WithApplicationJson(new Errors().withErrors(errors));

--- a/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
@@ -54,7 +54,7 @@ public class CompositePoLineValidationService extends BaseValidationService {
 
     return expenseClassValidationService.validateExpenseClasses(List.of(compPOL), false, requestContext)
       .map(v -> errors.addAll(validatePoLineFormats(compPOL)))
-      .map(v -> errors.addAll(validateLocations(compPOL)))
+      .map(b -> errors.addAll(validateLocations(compPOL)))
       .map(b -> {
         errors.addAll(validateCostPrices(compPOL));
         return errors;

--- a/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
@@ -53,8 +53,8 @@ public class CompositePoLineValidationService extends BaseValidationService {
     }
 
     return expenseClassValidationService.validateExpenseClasses(List.of(compPOL), false, requestContext)
-      .onSuccess(v -> errors.addAll(validatePoLineFormats(compPOL)))
-      .onSuccess(v -> errors.addAll(validateLocations(compPOL)))
+      .map(v -> errors.addAll(validatePoLineFormats(compPOL)))
+      .map(v -> errors.addAll(validateLocations(compPOL)))
       .map(v -> {
         errors.addAll(validateCostPrices(compPOL));
         return errors;

--- a/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
@@ -55,7 +55,7 @@ public class CompositePoLineValidationService extends BaseValidationService {
     return expenseClassValidationService.validateExpenseClasses(List.of(compPOL), false, requestContext)
       .map(v -> errors.addAll(validatePoLineFormats(compPOL)))
       .map(v -> errors.addAll(validateLocations(compPOL)))
-      .map(v -> {
+      .map(b -> {
         errors.addAll(validateCostPrices(compPOL));
         return errors;
       });

--- a/src/main/java/org/folio/service/orders/OrderReEncumberService.java
+++ b/src/main/java/org/folio/service/orders/OrderReEncumberService.java
@@ -175,11 +175,13 @@ public class OrderReEncumberService implements CompositeOrderDynamicDataPopulate
             .map(ReEncumbranceHolder::getRollover)
             .filter(Objects::nonNull)
             .map(rollover -> ledgerRolloverProgressService.getRolloversProgress(rollover.getId(), requestContext)
-                    .onSuccess(progresses -> {
-                      if (isRolloverNotCompleted(progresses)) {
-                        ledgerIds.add(rollover.getLedgerId());
-                      }
-                    }))
+              .map(progresses -> {
+                if (isRolloverNotCompleted(progresses)) {
+                  ledgerIds.add(rollover.getLedgerId());
+                }
+                return null;
+              })
+            )
             .toList())
             .map(aVoid -> ledgerIds);
   }

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -108,8 +108,8 @@ public class OrderRolloverService {
 
   public Future<Void> rollover(LedgerFiscalYearRollover ledgerFYRollover, RequestContext requestContext) {
     return prepareRollover(ledgerFYRollover, requestContext)
-      .compose(v -> ledgerRolloverProgressService.getRolloversProgressByRolloverId(ledgerFYRollover.getId(), requestContext)
-      .compose(progress -> startRollover(ledgerFYRollover, progress, requestContext)));
+      .compose(v -> ledgerRolloverProgressService.getRolloversProgressByRolloverId(ledgerFYRollover.getId(), requestContext))
+      .compose(progress -> startRollover(ledgerFYRollover, progress, requestContext));
   }
 
 

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -108,8 +108,8 @@ public class OrderRolloverService {
 
   public Future<Void> rollover(LedgerFiscalYearRollover ledgerFYRollover, RequestContext requestContext) {
     return prepareRollover(ledgerFYRollover, requestContext)
-      .onSuccess(v -> ledgerRolloverProgressService.getRolloversProgressByRolloverId(ledgerFYRollover.getId(), requestContext)
-        .compose(progress -> startRollover(ledgerFYRollover, progress, requestContext)));
+      .compose(v -> ledgerRolloverProgressService.getRolloversProgressByRolloverId(ledgerFYRollover.getId(), requestContext)
+      .compose(progress -> startRollover(ledgerFYRollover, progress, requestContext)));
   }
 
 

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderHolderBuilder.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderHolderBuilder.java
@@ -44,13 +44,13 @@ public class OpenCompositeOrderHolderBuilder {
     OpenOrderPieceHolder holder = new OpenOrderPieceHolder(titleId);
     return pieceStorageService.getPiecesByPoLineId(compPOL, requestContext)
       .map(holder::withExistingPieces)
-      .map(aVoid -> {
+      .map(aHolder -> {
         holder.withPiecesWithLocationToProcess(buildPiecesByLocationId(compPOL, expectedPiecesWithItem, holder.getExistingPieces()));
         holder.withPiecesWithHoldingToProcess(buildPiecesByHoldingId(compPOL, expectedPiecesWithItem, holder.getExistingPieces()));
         return null;
       })
       .map(aVoid -> holder.withPiecesWithChangedLocation(getPiecesWithChangedLocation(compPOL, holder.getPiecesWithLocationToProcess(), holder.getExistingPieces())))
-      .map(aVoid -> {
+      .map(aHolder -> {
         if (CollectionUtils.isEmpty(compPOL.getLocations())) {
           holder.withPiecesWithoutLocationId(createPiecesWithoutLocationId(compPOL, holder.getExistingPieces()));
         }

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderHolderBuilder.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderHolderBuilder.java
@@ -43,16 +43,18 @@ public class OpenCompositeOrderHolderBuilder {
                 RequestContext requestContext) {
     OpenOrderPieceHolder holder = new OpenOrderPieceHolder(titleId);
     return pieceStorageService.getPiecesByPoLineId(compPOL, requestContext)
-      .onSuccess(holder::withExistingPieces)
-      .onSuccess(aVoid -> {
+      .map(holder::withExistingPieces)
+      .map(aVoid -> {
         holder.withPiecesWithLocationToProcess(buildPiecesByLocationId(compPOL, expectedPiecesWithItem, holder.getExistingPieces()));
         holder.withPiecesWithHoldingToProcess(buildPiecesByHoldingId(compPOL, expectedPiecesWithItem, holder.getExistingPieces()));
+        return null;
       })
-      .onSuccess(aVoid -> holder.withPiecesWithChangedLocation(getPiecesWithChangedLocation(compPOL, holder.getPiecesWithLocationToProcess(), holder.getExistingPieces())))
-      .onSuccess(aVoid -> {
+      .map(aVoid -> holder.withPiecesWithChangedLocation(getPiecesWithChangedLocation(compPOL, holder.getPiecesWithLocationToProcess(), holder.getExistingPieces())))
+      .map(aVoid -> {
         if (CollectionUtils.isEmpty(compPOL.getLocations())) {
           holder.withPiecesWithoutLocationId(createPiecesWithoutLocationId(compPOL, holder.getExistingPieces()));
         }
+        return null;
       })
       .map(aVoid -> holder);
   }

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
@@ -141,13 +141,9 @@ public class OpenCompositeOrderPieceService {
             }
             return null;
           })
-          .onFailure(e -> {
-            logger.error("Error updating piece by id to storage {}", piece.getId(), e);
-          });
+          .onFailure(e -> logger.error("Error updating piece by id to storage {}", piece.getId(), e));
       })
-      .onFailure(e -> {
-        logger.error("Error getting piece by id from storage {}", piece.getId(), e);
-      })
+      .onFailure(e -> logger.error("Error getting piece by id from storage {}", piece.getId(), e))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
@@ -130,7 +130,7 @@ public class OpenCompositeOrderPieceService {
         }
 
         return pieceStorageService.updatePiece(piece, requestContext)
-          .compose(ok -> {
+          .map(ok -> {
             JsonObject messageToEventBus = new JsonObject();
             messageToEventBus.put("poLineIdUpdate", piece.getPoLineId());
             logger.debug("receivingStatusStorage -- {}", receivingStatusStorage);

--- a/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
@@ -139,10 +139,10 @@ public class ReOpenCompositeOrderManager {
   private Future<ReOpenCompositeOrderHolder> buildHolder(String orderId, List<CompositePoLine> poLines, RequestContext requestContext) {
     ReOpenCompositeOrderHolder holder = new ReOpenCompositeOrderHolder(orderId);
     return getPieces(poLines, requestContext)
-              .onSuccess(holder::withPieces)
+              .map(holder::withPieces)
               .map(v -> poLines.stream().map(CompositePoLine::getId).distinct().collect(toList()))
               .compose(poLineIds -> invoiceLineService.getInvoiceLinesByOrderLineIds(poLineIds, requestContext))
-              .onSuccess(holder::withInvoiceLines)
+              .map(holder::withInvoiceLines)
               .compose(v -> invoiceService.getInvoicesByOrderId(orderId, requestContext))
               .map(holder::withOrderInvoices)
               .map(v -> holder);

--- a/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
@@ -140,10 +140,10 @@ public class ReOpenCompositeOrderManager {
     ReOpenCompositeOrderHolder holder = new ReOpenCompositeOrderHolder(orderId);
     return getPieces(poLines, requestContext)
               .map(holder::withPieces)
-              .map(v -> poLines.stream().map(CompositePoLine::getId).distinct().collect(toList()))
+              .map(aHolder -> poLines.stream().map(CompositePoLine::getId).distinct().collect(toList()))
               .compose(poLineIds -> invoiceLineService.getInvoiceLinesByOrderLineIds(poLineIds, requestContext))
               .map(holder::withInvoiceLines)
-              .compose(v -> invoiceService.getInvoicesByOrderId(orderId, requestContext))
+              .compose(aHolder -> invoiceService.getInvoicesByOrderId(orderId, requestContext))
               .map(holder::withOrderInvoices)
               .map(v -> holder);
   }

--- a/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManager.java
@@ -106,7 +106,7 @@ public class ReOpenCompositeOrderManager {
     var poLineInvoiceLinesMap = holder.getOrderLineInvoiceLines().stream().collect(groupingBy(InvoiceLine::getPoLineId));
 
     List<Invoice> poLineInvoices = poLineInvoicesMap.get(poLine.getId());
-    if (CollectionUtils.isNotEmpty(poLineInvoices) && isAnyInvoicesApprovedOrPaid(poLineInvoices)) {
+    if (CollectionUtils.isNotEmpty(poLineInvoices) && isAnyInvoicePaid(poLineInvoices)) {
       var invoiceLines = poLineInvoiceLinesMap.get(poLine.getId());
       if (isAnyInvoiceLineReleaseEncumbrance(invoiceLines)) {
         poLine.setPaymentStatus(CompositePoLine.PaymentStatus.FULLY_PAID);
@@ -122,9 +122,8 @@ public class ReOpenCompositeOrderManager {
     return invoiceLines.stream().anyMatch(InvoiceLine::getReleaseEncumbrance);
   }
 
-  private boolean isAnyInvoicesApprovedOrPaid(List<Invoice> poLineInvoices) {
-    return poLineInvoices.stream().anyMatch(invoice -> Invoice.Status.APPROVED.equals(invoice.getStatus()) ||
-                                                            Invoice.Status.PAID.equals(invoice.getStatus()));
+  private boolean isAnyInvoicePaid(List<Invoice> poLineInvoices) {
+    return poLineInvoices.stream().anyMatch(invoice -> Invoice.Status.PAID.equals(invoice.getStatus()));
   }
 
   private void updatePoLineReceiptStatus(CompositePoLine poLine, ReOpenCompositeOrderHolder holder) {

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -57,7 +57,10 @@ public class PieceCreateFlowInventoryManager {
       .compose(title -> packageUpdateTitleWithInstance(title, requestContext))
       .compose(title -> handleHolding(compPOL, piece, title.getInstanceId(), requestContext))
       .compose(holdingId -> handleItem(compPOL, createItem, piece, requestContext))
-      .onSuccess(itemId -> Optional.ofNullable(itemId).ifPresent(piece::withItemId))
+      .map(itemId -> {
+        Optional.ofNullable(itemId).ifPresent(piece::withItemId);
+        return null;
+      })
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -70,19 +70,22 @@ public class PieceDeleteFlowManager {
   private Future<Void> isDeletePieceRequestValid(PieceDeletionHolder holder, RequestContext requestContext) {
     List<Error> combinedErrors = new ArrayList<>();
     if (holder.getPieceToDelete().getItemId() != null) {
-      return inventoryManager.getNumberOfRequestsByItemId(holder.getPieceToDelete().getItemId(), requestContext).onSuccess(numOfRequests -> {
-        if (numOfRequests != null && numOfRequests > 0) {
-          combinedErrors.add(ErrorCodes.REQUEST_FOUND.toError());
-        }
-      }).map(numOfRequests -> {
-        if (CollectionUtils.isNotEmpty(combinedErrors)) {
-          Errors errors = new Errors().withErrors(combinedErrors).withTotalRecords(combinedErrors.size());
-          logger.error("Validation error : " + JsonObject.mapFrom(errors).encodePrettily());
-          throw new HttpException(RestConstants.VALIDATION_ERROR, errors);
-        }
-        return null;
-      })
-        .mapEmpty();
+      return inventoryManager.getNumberOfRequestsByItemId(holder.getPieceToDelete().getItemId(), requestContext)
+        .map(numOfRequests -> {
+          if (numOfRequests != null && numOfRequests > 0) {
+            combinedErrors.add(ErrorCodes.REQUEST_FOUND.toError());
+          }
+          return null;
+        })
+        .map(v -> {
+          if (CollectionUtils.isNotEmpty(combinedErrors)) {
+            Errors errors = new Errors().withErrors(combinedErrors).withTotalRecords(combinedErrors.size());
+            logger.error("Validation error : " + JsonObject.mapFrom(errors).encodePrettily());
+            throw new HttpException(RestConstants.VALIDATION_ERROR, errors);
+          }
+          return null;
+        })
+      .mapEmpty();
     }
     return Future.succeededFuture();
   }

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -53,7 +53,7 @@ public class PieceUpdateFlowInventoryManager {
   private Future<Void> nonPackagePoLineUpdateInventory(PieceUpdateHolder holder, RequestContext requestContext) {
     return nonPackageUpdateTitleWithInstance(holder, requestContext)
       .map(holder::withInstanceId)
-      .compose(instanceId -> handleHolding(holder, requestContext))
+      .compose(aHolder -> handleHolding(holder, requestContext))
       .compose(holdingId -> handleItem(holder, requestContext))
       .map(itemId -> {
         Optional.ofNullable(itemId).ifPresent(holder.getPieceToUpdate()::withItemId);
@@ -68,7 +68,7 @@ public class PieceUpdateFlowInventoryManager {
     return titlesService.getTitleById(holder.getPieceToUpdate().getTitleId(), requestContext)
       .compose(title -> packageUpdateTitleWithInstance(title, requestContext))
       .map(title -> holder.withInstanceId(title.getInstanceId()))
-      .compose(title -> handleHolding(holder, requestContext))
+      .compose(aHolder -> handleHolding(holder, requestContext))
       .compose(holdingId -> handleItem(holder, requestContext))
       .map(itemId -> {
         Optional.ofNullable(itemId).ifPresent(holder.getPieceToUpdate()::withItemId);

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -52,10 +52,13 @@ public class PieceUpdateFlowInventoryManager {
 
   private Future<Void> nonPackagePoLineUpdateInventory(PieceUpdateHolder holder, RequestContext requestContext) {
     return nonPackageUpdateTitleWithInstance(holder, requestContext)
-      .onSuccess(holder::withInstanceId)
+      .map(holder::withInstanceId)
       .compose(instanceId -> handleHolding(holder, requestContext))
       .compose(holdingId -> handleItem(holder, requestContext))
-      .onSuccess(itemId -> Optional.ofNullable(itemId).ifPresent(holder.getPieceToUpdate()::withItemId))
+      .map(itemId -> {
+        Optional.ofNullable(itemId).ifPresent(holder.getPieceToUpdate()::withItemId);
+        return null;
+      })
       .compose(aVoid -> deleteHolding(holder, requestContext))
       .onSuccess(pair -> logger.debug(UPDATE_INVENTORY_FOR_LINE_DONE))
       .mapEmpty();
@@ -64,10 +67,13 @@ public class PieceUpdateFlowInventoryManager {
   private Future<Void> packagePoLineUpdateInventory(PieceUpdateHolder holder, RequestContext requestContext) {
     return titlesService.getTitleById(holder.getPieceToUpdate().getTitleId(), requestContext)
       .compose(title -> packageUpdateTitleWithInstance(title, requestContext))
-      .onSuccess(title -> holder.withInstanceId(title.getInstanceId()))
+      .map(title -> holder.withInstanceId(title.getInstanceId()))
       .compose(title -> handleHolding(holder, requestContext))
       .compose(holdingId -> handleItem(holder, requestContext))
-      .onSuccess(itemId -> Optional.ofNullable(itemId).ifPresent(holder.getPieceToUpdate()::withItemId))
+      .map(itemId -> {
+        Optional.ofNullable(itemId).ifPresent(holder.getPieceToUpdate()::withItemId);
+        return null;
+      })
       .compose(aVoid -> deleteHolding(holder, requestContext))
       .onSuccess(pair -> logger.debug(UPDATE_INVENTORY_FOR_LINE_DONE))
       .mapEmpty();

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -70,7 +70,7 @@ public class PieceUpdateFlowManager {
 
     Promise<Void> promise = Promise.promise();
     pieceStorageService.getPieceById(pieceToUpdate.getId(), requestContext)
-      .onSuccess(holder::withPieceFromStorage)
+      .map(holder::withPieceFromStorage)
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext))
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .map(v -> {

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -99,9 +99,7 @@ public class PieceUpdateFlowManager {
         }
         return null;
       })
-      .onFailure(t -> {
-        logger.error("User to update piece with id={}", holder.getPieceToUpdate().getId(), t.getCause());
-      })
+      .onFailure(t -> logger.error("User to update piece with id={}", holder.getPieceToUpdate().getId(), t.getCause()))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -29,7 +29,6 @@ import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
 import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
 public class PieceUpdateFlowManager {
@@ -68,8 +67,7 @@ public class PieceUpdateFlowManager {
       .withCreateItem(createItem)
       .withDeleteHolding(deleteHolding);
 
-    Promise<Void> promise = Promise.promise();
-    pieceStorageService.getPieceById(pieceToUpdate.getId(), requestContext)
+    return pieceStorageService.getPieceById(pieceToUpdate.getId(), requestContext)
       .map(holder::withPieceFromStorage)
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext))
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
@@ -101,12 +99,10 @@ public class PieceUpdateFlowManager {
         }
         return null;
       })
-      .onSuccess(v -> promise.complete())
       .onFailure(t -> {
         logger.error("User to update piece with id={}", holder.getPieceToUpdate().getId(), t.getCause());
-        promise.fail(t);
-      });
-    return promise.future();
+      })
+      .mapEmpty();
   }
 
   protected Future<Void> updatePoLine(PieceUpdateHolder holder, RequestContext requestContext) {

--- a/src/test/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManagerTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/reopen/ReOpenCompositeOrderManagerTest.java
@@ -111,11 +111,10 @@ public class ReOpenCompositeOrderManagerTest {
 
   @ParameterizedTest
   @CsvSource(value = {"Open:Expected:Awaiting Receipt:Awaiting Payment",
-                      "Approved:Received:Partially Received:Fully Paid",
+                      "Approved:Received:Partially Received:Awaiting Payment",
                       "Paid:Received:Partially Received:Fully Paid"}, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveSameStatuses(
-        String invoiceStatus, String pieceStatus, String expReceiptStatus, String expPaymentStatus)
-                      throws ExecutionException, InterruptedException {
+      String invoiceStatus, String pieceStatus, String expReceiptStatus, String expPaymentStatus) {
     CompositePurchaseOrder oldOrder = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     CompositePoLine poLine1 = oldOrder.getCompositePoLines().get(0);
     String poLineId1 = poLine1.getId();
@@ -174,17 +173,16 @@ public class ReOpenCompositeOrderManagerTest {
   }
 
   @ParameterizedTest
-  @CsvSource(value = {"Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Partially Paid:true:false",
-                      "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Fully Paid:true:true",
-                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment:true:true",
-                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment:true:false",
+  @CsvSource(value = {"Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Awaiting Payment:true:false",
+                      "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Awaiting Payment:true:true",
+                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Awaiting Payment:Awaiting Payment:true:true",
+                      "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Awaiting Payment:Awaiting Payment:true:false",
                       "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Fully Paid:Awaiting Payment:true:true",
                       "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Partially Paid:Awaiting Payment:false:true"}, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveDifferentStatuses(
-                  String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
-                  String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2,
-                  boolean releaseEncumbrances1, boolean releaseEncumbrances2)
-    throws ExecutionException, InterruptedException {
+      String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
+      String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2,
+      boolean releaseEncumbrances1, boolean releaseEncumbrances2) {
     CompositePurchaseOrder oldOrder = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     CompositePoLine poLine1 = oldOrder.getCompositePoLines().get(0);
     String poLineId1 = poLine1.getId();
@@ -246,14 +244,13 @@ public class ReOpenCompositeOrderManagerTest {
 
   @ParameterizedTest
   @CsvSource(value = {
-    "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Fully Paid",
-    "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Fully Paid:Awaiting Payment",
+    "Open:Approved:Expected:Received:Awaiting Receipt:Partially Received:Awaiting Payment:Awaiting Payment",
+    "Approved:Open:Received:Expected:Partially Received:Awaiting Receipt:Awaiting Payment:Awaiting Payment",
     "Paid:Open:Expected:Received:Awaiting Receipt:Partially Received:Fully Paid:Awaiting Payment"
   }, delimiter = ':')
   void shouldCheckPaymentAndReceiptStatusesIfInvoicesAndPiecesHaveDifferentStatusesAndPolCoveredMoreThenOneInvoice(
-    String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
-    String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2)
-    throws ExecutionException, InterruptedException {
+      String invoiceStatus1, String invoiceStatus2, String pieceStatus1, String pieceStatus2,
+      String expReceiptStatus1,  String expReceiptStatus2, String expPaymentStatus1, String expPaymentStatus2) {
     CompositePurchaseOrder oldOrder = getMockAsJson(ORDER_PATH).mapTo(CompositePurchaseOrder.class);
     CompositePoLine poLine1 = oldOrder.getCompositePoLines().get(0);
     String poLineId1 = poLine1.getId();


### PR DESCRIPTION
## Purpose
The handler used in onSuccess was called async and the method was not waiting for it to return. But also the API says:
WARNING: this is a terminal operation. If several handlers are registered, there is no guarantee that they will be invoked in order of registration.

We need to identify places where usage of onSuccess was incorrect and replace to use of map or compose methods
https://folio-org.atlassian.net/browse/MODORDERS-1078
