### PR TITLE
[MODORDERS-1079] Change in PE mix location updates + async bug fix

### DIFF
--- a/src/main/java/org/folio/service/pieces/flows/strategies/ProcessInventoryMixedStrategy.java
+++ b/src/main/java/org/folio/service/pieces/flows/strategies/ProcessInventoryMixedStrategy.java
@@ -80,13 +80,13 @@ public class ProcessInventoryMixedStrategy extends ProcessInventoryStrategy {
   private void updateLocations(CompositePoLine compPOL) {
     List<Location> locations = new ArrayList<>();
     for (Location location : compPOL.getLocations()) {
-      boolean physical = location.getQuantityPhysical() != null && location.getQuantityPhysical() > 0;
-      boolean electronic = location.getQuantityElectronic() != null && location.getQuantityElectronic() > 0;
-      boolean physicalUpdate = physical && isHoldingUpdateRequiredForPhysical(compPOL);
-      boolean electronicUpdate = electronic && isHoldingUpdateRequiredForEresource(compPOL);
+      boolean physicalResource = location.getQuantityPhysical() != null && location.getQuantityPhysical() > 0;
+      boolean electronicResource = location.getQuantityElectronic() != null && location.getQuantityElectronic() > 0;
+      boolean physicalHolding = physicalResource && isHoldingUpdateRequiredForPhysical(compPOL);
+      boolean electronicHolding = electronicResource && isHoldingUpdateRequiredForEresource(compPOL);
       Location newLocation = JsonObject.mapFrom(location).mapTo(Location.class);
-      // Split locations only if one type is getting a holdings update but not the other
-      if (electronicUpdate && physical && !physicalUpdate) {
+      // Split locations only if one resource type is getting a holdings update but not the other
+      if (electronicHolding && physicalResource && !physicalHolding) {
         Location newElectronicLocation = JsonObject.mapFrom(location).mapTo(Location.class);
         newElectronicLocation.setQuantityPhysical(null);
         newElectronicLocation.setLocationId(null);
@@ -95,7 +95,7 @@ public class ProcessInventoryMixedStrategy extends ProcessInventoryStrategy {
         newLocation.setQuantityElectronic(null);
         newLocation.setHoldingId(null);
         newLocation.setQuantity(location.getQuantityPhysical());
-      } else if (physicalUpdate && electronic && !electronicUpdate) {
+      } else if (physicalHolding && electronicResource && !electronicHolding) {
         Location newPhysicalLocation = JsonObject.mapFrom(location).mapTo(Location.class);
         newPhysicalLocation.setQuantityElectronic(null);
         newPhysicalLocation.setLocationId(null);
@@ -105,7 +105,7 @@ public class ProcessInventoryMixedStrategy extends ProcessInventoryStrategy {
         newLocation.setHoldingId(null);
         newLocation.setQuantity(location.getQuantityElectronic());
       } else {
-        if (physicalUpdate || electronicUpdate) {
+        if (physicalHolding || electronicHolding) {
           newLocation.setLocationId(null);
         } else {
           newLocation.setHoldingId(null);

--- a/src/main/java/org/folio/service/pieces/flows/strategies/ProcessInventoryMixedStrategy.java
+++ b/src/main/java/org/folio/service/pieces/flows/strategies/ProcessInventoryMixedStrategy.java
@@ -85,7 +85,9 @@ public class ProcessInventoryMixedStrategy extends ProcessInventoryStrategy {
       boolean physicalHolding = physicalResource && isHoldingUpdateRequiredForPhysical(compPOL);
       boolean electronicHolding = electronicResource && isHoldingUpdateRequiredForEresource(compPOL);
       Location newLocation = JsonObject.mapFrom(location).mapTo(Location.class);
-      // Split locations only if one resource type is getting a holdings update but not the other
+      // Physical/electronic locations have to be merged when they have the same holdingId or locationId,
+      // but separate otherwise, and they can't have both holdingId and locationId.
+      // This will split locations only if one resource type is getting a holdings update but not the other.
       if (electronicHolding && physicalResource && !physicalHolding) {
         Location newElectronicLocation = JsonObject.mapFrom(location).mapTo(Location.class);
         newElectronicLocation.setQuantityPhysical(null);

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -107,7 +107,7 @@ public class PieceUpdateFlowManager {
     CompositePoLine originPoLine = holder.getOriginPoLine();
 
     return pieceStorageService.getPiecesByLineId(originPoLine.getId(), requestContext)
-      .map(pieces -> {
+      .compose(pieces -> {
         CompositePurchaseOrder order = holder.getOriginPurchaseOrder();
         if (order.getOrderType() != OrderType.ONE_TIME || order.getWorkflowStatus() != WorkflowStatus.OPEN) {
           return Future.succeededFuture();
@@ -116,7 +116,7 @@ public class PieceUpdateFlowManager {
         CompositePoLine poLineToSave = holder.getPoLineToSave();
         poLineToSave.setReceiptStatus(calculatePoLineReceiptStatus(originPoLine, pieces, piecesToUpdate));
         return purchaseOrderLineService.saveOrderLine(poLineToSave, requestContext);
-      }).compose(t -> {
+      }).compose(v -> {
         if (!Boolean.TRUE.equals(originPoLine.getIsPackage()) &&
           !Boolean.TRUE.equals(originPoLine.getCheckinItems())) {
           return updatePoLineService.updatePoLine(holder, requestContext);

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
@@ -84,6 +84,7 @@ public class PieceUpdateFlowManagerTest {
   @Autowired PieceService pieceService;
   @Autowired BasePieceFlowHolderBuilder basePieceFlowHolderBuilder;
   @Autowired PieceUpdateFlowPoLineService pieceUpdateFlowPoLineService;
+  @Autowired PurchaseOrderLineService purchaseOrderLineService;
 
   private final Context ctx = getFirstContextFromVertx(getVertx());
   @Mock
@@ -119,8 +120,8 @@ public class PieceUpdateFlowManagerTest {
   @AfterEach
   void resetMocks() {
     clearServiceInteractions();
-    Mockito.reset(pieceStorageService, pieceService, protectionService,
-                  pieceUpdateFlowPoLineService, pieceUpdateFlowInventoryManager, basePieceFlowHolderBuilder);
+    Mockito.reset(pieceStorageService, pieceService, protectionService, pieceUpdateFlowPoLineService,
+      pieceUpdateFlowInventoryManager, basePieceFlowHolderBuilder, purchaseOrderLineService);
   }
 
   @Test
@@ -173,6 +174,8 @@ public class PieceUpdateFlowManagerTest {
     doReturn(succeededFuture(null)).when(pieceUpdateFlowInventoryManager).processInventory(any(PieceUpdateHolder.class), eq(requestContext));
     doNothing().when(pieceService).receiptConsistencyPiecePoLine(any(JsonObject.class), eq(requestContext));
     doReturn(succeededFuture(null)).when(pieceUpdateFlowPoLineService).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null))
+      .when(purchaseOrderLineService).saveOrderLine(any(CompositePoLine.class), eq(requestContext));
 
     //When
     pieceUpdateFlowManager.updatePiece(pieceToUpdate, true, true, requestContext).result();
@@ -410,8 +413,8 @@ public class PieceUpdateFlowManagerTest {
       return mock(InventoryCache.class);
     }
 
-    @Bean PurchaseOrderLineService defaultPurchaseOrderLineService(RestClient restClient, InventoryCache inventoryCache) {
-      return spy(new PurchaseOrderLineService(restClient, inventoryCache));
+    @Bean PurchaseOrderLineService purchaseOrderLineService() {
+      return mock(PurchaseOrderLineService.class);
     }
 
     @Bean


### PR DESCRIPTION
## Purpose
[MODORDERS-1079](https://folio-org.atlassian.net/browse/MODORDERS-1079) - Could not edit holdings for piece created from P/E mix Po Line

## Approach
The piece/location handling code has some constraints on locations after an order is opened (physical/electronic locations have to be merged when they have the same holdingId or locationId, but separate otherwise, and they can't have both holdingId and locationId). These modifications ensure opening an order updates the locations according to these constraints.
- New logic to update locations when an order is opened
- Fixed an unrelated bug causing unwanted async processing and preventing po line location updates (introduced by MODORDERS-1027)

[Integration test](https://github.com/folio-org/folio-integration-tests/pull/1313)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
