### PR TITLE
MODORDERS-1093. Missing interface dependencies in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1265,6 +1265,10 @@
     {
       "id": "template-engine",
       "version": "2.2"
+    },
+    {
+      "id": "holdings-sources",
+      "version": "1.0"
     }
   ],
   "optional": [


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDERS-1093