### PR TITLE
MODORDERS-1094: Reference "ISBN", "Invalid ISBN" by id, not by name

### DIFF
--- a/src/main/java/org/folio/service/caches/InventoryCache.java
+++ b/src/main/java/org/folio/service/caches/InventoryCache.java
@@ -25,8 +25,10 @@ public class InventoryCache {
 
   private final AsyncCache<String, String> asyncCache;
   private final AsyncCache<String, JsonObject> asyncJsonCache;
-  private static final String ISBN_PRODUCT_TYPE_NAME = "ISBN";
-  private static final String INVALID_ISBN_PRODUCT_TYPE_NAME = "Invalid ISBN";
+  // https://github.com/folio-org/mod-inventory-storage/blob/v27.1.0/reference-data/identifier-types/isbn.json
+  private static final String ISBN_PRODUCT_TYPE_ID = "8261054f-be78-422d-bd51-4ed9f33c3422";
+  // https://github.com/folio-org/mod-inventory-storage/blob/v27.1.0/reference-data/identifier-types/InvalidIsbn.json
+  private static final String INVALID_ISBN_PRODUCT_TYPE_ID = "fcca2643-406a-482a-b760-7a7f8aec640e";
   private static final String UNIQUE_CACHE_KEY_PATTERN = "%s_%s_%s";
   private final InventoryService inventoryService;
 
@@ -46,11 +48,11 @@ public class InventoryCache {
   }
 
   public Future<String> getISBNProductTypeId(RequestContext requestContext) {
-    return getProductTypeUuid(ISBN_PRODUCT_TYPE_NAME, requestContext);
+    return Future.succeededFuture(ISBN_PRODUCT_TYPE_ID);
   }
 
   public Future<String> getInvalidISBNProductTypeId(RequestContext requestContext) {
-    return getProductTypeUuid(INVALID_ISBN_PRODUCT_TYPE_NAME, requestContext);
+    return Future.succeededFuture(INVALID_ISBN_PRODUCT_TYPE_ID);
   }
 
   /**


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDERS-1094

## Purpose
Reference product types = inventory identifier types ("ISBN", "Invalid ISBN") by id, not by name, because libraries my translate the name.

## Approach
Don't lookup the id by name in inventory.
Directly hard-code the id that inventory has published as reference data: https://github.com/folio-org/mod-inventory-storage/tree/v27.1.0/reference-data/identifier-types

The fix is provided in two parts:

* A minimal fix that can be back-ported to Quesnelia (this PR).

* A complete cleanup that removes all code that is no longer needed.

## TODOS and Open Questions
- [ ] Change the Karate test to use the correct id: https://github.com/folio-org/folio-integration-tests/blob/master/acquisitions/src/main/resources/thunderjet/mod-orders/features/productIds-field-error-when-attempting-to-update-unmodified-order.feature
- [ ] Update the release notes that the two identifiery type reference records for ISBN and Invalid ISBN must exist with the official ids "8261054f-be78-422d-bd51-4ed9f33c3422", "fcca2643-406a-482a-b760-7a7f8aec640e".

## Learning
Use id to reference reference data; names can get translated.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.