### PR TITLE
[MODORDERS-1006] Add intuitive error message for duplicate names

### DIFF
--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -121,6 +121,7 @@ public enum ErrorCodes {
   INVALID_ROUTING_LIST_FOR_PO_LINE_FORMAT("invalidRoutingListForPoLineFormat", "Cannot create routing list for POL without 'Physical' or 'P/E Mix' order format"),
   ROUTING_LIST_LIMIT_REACHED_FOR_PO_LINE("routingListLimitReachedForPoLine", "Cannot create routing list for POL as the associated lists' amount is not less than Physical copies"),
   PO_LINE_NOT_FOUND_FOR_ROUTING_LIST("poLineNotFoundForRoutingList", "Cannot find a corresponding PO Line with the provided id"),
+  ROUTING_LIST_UNIQUE_NAME_VIOLATION("routingListUniqueNameViolation", "Routing list with the same name already exists"),
   ORDER_FORMAT_INCORRECT_FOR_BINDARY_ACTIVE("orderFormatIncorrectForBindaryActive", "When PoLine is bindery active, its format must be 'P/E Mix' or 'Physical Resource'"),
   CREATE_INVENTORY_INCORRECT_FOR_BINDARY_ACTIVE("createInventoryIncorrectForBindaryActive", "When PoLine is bindery active, Create Inventory must be 'Instance, Holding, Item'"),
   RECEIVING_WORKFLOW_INCORRECT_FOR_BINDARY_ACTIVE("receivingWorkflowIncorrectForBindaryActive", "When PoLine is bindery active, its receiving workflow must be set to 'Independent order and receipt quantity'");

--- a/src/main/java/org/folio/rest/impl/RoutingListsAPI.java
+++ b/src/main/java/org/folio/rest/impl/RoutingListsAPI.java
@@ -1,11 +1,14 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.core.exceptions.ErrorCodes.ROUTING_LIST_UNIQUE_NAME_VIOLATION;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.RoutingList;
 import org.folio.rest.jaxrs.resource.OrdersRoutingLists;
@@ -19,6 +22,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
 public class RoutingListsAPI extends BaseApi implements OrdersRoutingLists {
+
+  private static final String ROUTING_LIST_UNIQUE_NAME_VIOLATION_ERROR = "lower(f_unaccent(jsonb ->> 'name'::text)) value already exists in table routing_list";
 
   @Autowired
   private RoutingListService routingListService;
@@ -40,7 +45,7 @@ public class RoutingListsAPI extends BaseApi implements OrdersRoutingLists {
   public void postOrdersRoutingLists(RoutingList entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     routingListService.createRoutingList(entity, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(list -> asyncResultHandler.handle(succeededFuture(buildOkResponse(list))))
-      .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
+      .onFailure(fail -> handlePostPutErrorResponse(asyncResultHandler, fail));
   }
 
   @Override
@@ -65,7 +70,7 @@ public class RoutingListsAPI extends BaseApi implements OrdersRoutingLists {
   public void putOrdersRoutingListsById(String id, RoutingList entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     routingListService.updateRoutingList(entity, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(list -> asyncResultHandler.handle(succeededFuture(buildNoContentResponse())))
-      .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
+      .onFailure(fail -> handlePostPutErrorResponse(asyncResultHandler, fail));
   }
 
   @Override
@@ -75,4 +80,13 @@ public class RoutingListsAPI extends BaseApi implements OrdersRoutingLists {
       .onSuccess(jsonObject -> asyncResultHandler.handle(succeededFuture(this.buildOkResponse(jsonObject))))
       .onFailure(t -> handleErrorResponse(asyncResultHandler, t));
   }
+
+  private void handlePostPutErrorResponse(Handler<AsyncResult<Response>> asyncResultHandler, Throwable t) {
+    if (StringUtils.isNotEmpty(t.getMessage()) && t.getMessage().contains(ROUTING_LIST_UNIQUE_NAME_VIOLATION_ERROR)) {
+      handleErrorResponse(asyncResultHandler, new HttpException(409, ROUTING_LIST_UNIQUE_NAME_VIOLATION.toError()));
+    } else {
+      handleErrorResponse(asyncResultHandler, t);
+    }
+  }
+
 }


### PR DESCRIPTION
## Purpose
Add intuitive error message for duplicate names

## Approach
Replace `lower(f_unaccent(jsonb ->> 'name'::text)) value already exists in table routing_list` with a readable error message
