### PR TITLE
[MODORDERS-1098] Converting API unit tests - part 2

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -472,7 +472,7 @@ public class PurchaseOrderHelper {
     List<Future<CompositePoLine>> futures =
       compPO.getCompositePoLines()
             .stream()
-            .map(compositePoLine -> purchaseOrderLineHelper.createPoLine(compositePoLine, compPO, requestContext))
+            .map(compositePoLine -> purchaseOrderLineHelper.createPoLineWithOrder(compositePoLine, compPO, requestContext))
             .collect(Collectors.toList());
     return collectResultsOnSuccess(futures);
   }

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.Objects;
-import java.util.concurrent.CompletionException;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -435,8 +434,8 @@ public class PurchaseOrderLineHelper {
     return GenericCompositeFuture.join(new ArrayList<>(futures))
       .map(reportingIds -> line.put(REPORTING_CODES, reportingIds.list()))
       .recover(t -> {
-        logger.error("failed to create Reporting Codes", t);
-        throw new CompletionException(t.getCause());
+        logger.error("Failed to create reporting codes", t);
+        throw new HttpException(500, "Failed to create reporting codes", t);
       })
       .mapEmpty();
   }
@@ -453,8 +452,8 @@ public class PurchaseOrderLineHelper {
     return GenericCompositeFuture.join(new ArrayList<>(futures))
       .map(ids -> line.put(ALERTS, ids.list()))
       .recover(t -> {
-        logger.error("failed to create Alerts", t);
-        throw new CompletionException(t.getCause());
+        logger.error("Failed to create alerts", t);
+        throw new HttpException(500, "Failed to create alerts", t);
       })
       .mapEmpty();
   }

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -191,7 +191,7 @@ public class PurchaseOrderLineHelper {
             .map(this::validateOrderState)
             .compose(po -> protectionService.isOperationRestricted(po.getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext)
             .compose(v -> createShadowInstanceIfNeeded(compPOL, requestContext))
-            .compose(v -> createPoLine(compPOL, po, requestContext)));
+            .compose(v -> createPoLineWithOrder(compPOL, po, requestContext)));
         } else {
             Errors errors = new Errors().withErrors(validationErrors).withTotalRecords(validationErrors.size());
             logger.error("Create POL validation error : {}", JsonObject.mapFrom(errors).encodePrettily());
@@ -206,7 +206,8 @@ public class PurchaseOrderLineHelper {
    * @param compOrder associated {@link CompositePurchaseOrder} object
    * @return completable future which might hold {@link CompositePoLine} on success or an exception if any issue happens
    */
-  public Future<CompositePoLine> createPoLine(CompositePoLine compPoLine, CompositePurchaseOrder compOrder, RequestContext requestContext) {
+  public Future<CompositePoLine> createPoLineWithOrder(CompositePoLine compPoLine, CompositePurchaseOrder compOrder,
+      RequestContext requestContext) {
     // The id is required because sub-objects are being created first
     if (isEmpty(compPoLine.getId())) {
       compPoLine.setId(UUID.randomUUID().toString());
@@ -558,7 +559,7 @@ public class PurchaseOrderLineHelper {
   private List<Future<CompositePoLine>> processPoLinesCreation(CompositePurchaseOrder compOrder, List<PoLine> poLinesFromStorage,
     RequestContext requestContext) {
     return getNewPoLines(compOrder, poLinesFromStorage)
-      .map(compPOL -> createPoLine(compPOL, compOrder, requestContext))
+      .map(compPOL -> createPoLineWithOrder(compPOL, compOrder, requestContext))
       .toList();
   }
 

--- a/src/main/java/org/folio/rest/core/exceptions/HttpException.java
+++ b/src/main/java/org/folio/rest/core/exceptions/HttpException.java
@@ -23,6 +23,19 @@ public class HttpException extends RuntimeException {
       .withTotalRecords(1);
   }
 
+  public HttpException(int code, String message, Throwable cause) {
+    super(message, cause);
+    this.code = code;
+    Parameter causeParam = new Parameter().withKey("cause").withValue(cause.getMessage());
+    Error error = new Error()
+      .withCode(ErrorCodes.GENERIC_ERROR_CODE.getCode())
+      .withMessage(message)
+      .withParameters(List.of(causeParam));
+    this.errors = new Errors()
+      .withErrors(List.of(error))
+      .withTotalRecords(1);
+  }
+
   public HttpException(int code, ErrorCodes errCodes) {
     this(code, errCodes, Lists.newArrayList());
   }

--- a/src/main/java/org/folio/rest/impl/BaseApi.java
+++ b/src/main/java/org/folio/rest/impl/BaseApi.java
@@ -59,6 +59,9 @@ public class BaseApi {
 
   public Response buildErrorResponse(Throwable throwable) {
     logger.error("Exception encountered", throwable);
+    if (throwable instanceof HttpException exception) {
+      return buildErrorResponseFromHttpException(exception);
+    }
     final int code = defineErrorCode(throwable);
     final Errors errors = convertToErrors(throwable);
     final Response.ResponseBuilder responseBuilder = createResponseBuilder(code);
@@ -89,6 +92,13 @@ public class BaseApi {
 
     return responseBuilder.header(CONTENT_TYPE, APPLICATION_JSON)
       .entity(getProcessingErrors())
+      .build();
+  }
+
+  private static Response buildErrorResponseFromHttpException(HttpException exception) {
+    return Response.status(exception.getCode())
+      .header(CONTENT_TYPE, APPLICATION_JSON)
+      .entity(exception.getErrors())
       .build();
   }
 

--- a/src/test/java/org/folio/TestUtils.java
+++ b/src/test/java/org/folio/TestUtils.java
@@ -2,7 +2,6 @@ package org.folio;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.TestConstants.EXISTED_ITEM_ID;
-import static org.folio.TestConstants.ID;
 import static org.folio.TestConstants.LOCATION_ID;
 import static org.folio.TestConstants.MIN_PO_ID;
 import static org.folio.TestConstants.MIN_PO_LINE_ID;
@@ -10,7 +9,6 @@ import static org.folio.TestConstants.PIECE_ID;
 import static org.folio.orders.utils.ResourcePathResolver.PURCHASE_ORDER_STORAGE;
 import static org.folio.orders.utils.ResourcePathResolver.TITLES;
 import static org.folio.rest.impl.MockServer.getPoLineSearches;
-import static org.folio.rest.impl.MockServer.getPoLineUpdates;
 import static org.folio.rest.impl.MockServer.serverRqRs;
 import static org.folio.rest.impl.TitlesApiTest.SAMPLE_TITLE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,8 +20,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -33,8 +29,6 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.rest.impl.MockServer;
 import org.folio.rest.jaxrs.model.BindItem;
 import org.folio.rest.jaxrs.model.CheckInPiece;
@@ -59,7 +53,6 @@ import io.vertx.junit5.VertxTestContext;
 
 public final class TestUtils {
 
-  private static final Logger logger = LogManager.getLogger();
   public static final String PURCHASE_METHOD = "df26d81b-9d63-4ff8-bf41-49bf75cfa70e";
   public static final String APPROVAL_PLAN_METHOD = "796596c4-62b5-4b64-a2ce-524c747afaa2";
   public static final String DEPOSITORY_METHOD = "d2420b93-7b93-41b7-8b42-798f64cb6dd2";
@@ -92,12 +85,6 @@ public final class TestUtils {
       fail(e.getMessage());
     }
     return new JsonObject();
-  }
-
-  public static Date convertLocalDateTimeToDate(LocalDateTime dateToConvert) {
-    return Date
-      .from(dateToConvert.atZone(ZoneId.systemDefault())
-        .toInstant());
   }
 
   public static Object[] getModifiedProtectedFields(Error error) {
@@ -246,14 +233,6 @@ public final class TestUtils {
 
   public static String getRandomId() {
     return UUID.randomUUID().toString();
-  }
-
-  public static void validateSavedPoLines() {
-    getPoLineUpdates()
-      .forEach(poline -> {
-        logger.info("validate poline {}", poline.getString(ID));
-        poline.mapTo(PoLine.class);
-      });
   }
 
   public static List<Location> getLocationPhysicalCopies(int n) {

--- a/src/test/java/org/folio/helper/FinanceInteractionsTestHelper.java
+++ b/src/test/java/org/folio/helper/FinanceInteractionsTestHelper.java
@@ -7,32 +7,14 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.FundDistribution;
 import org.folio.rest.jaxrs.model.PoLine;
 
 public final class FinanceInteractionsTestHelper {
-
-  public static void verifyEncumbrancesOnPoCreation(CompositePurchaseOrder rqPo, CompositePurchaseOrder rsPo) {
-    // Check that number of linked encumbrances corresponds to FundDistribution count
-    int fundDistributionCount = getFundDistributionCount(rqPo);
-    assertThat(fundDistributionCount, equalTo(getEncumbrancesCount(rsPo)));
-
-    List<Transaction> createdEncumbrances = getCreatedEncumbrances();
-    assertThat(fundDistributionCount, equalTo(createdEncumbrances.size()));
-
-    for (CompositePoLine compositePoLine : rsPo.getCompositePoLines()) {
-      for (FundDistribution fundDistr : compositePoLine.getFundDistribution()) {
-        Transaction encumbrance = getEncumbranceById(createdEncumbrances, fundDistr.getEncumbrance());
-        assertThat(fundDistr.getFundId(), equalTo(encumbrance.getFromFundId()));
-      }
-    }
-  }
 
   public static void verifyEncumbrancesOnPoUpdate(CompositePurchaseOrder rqPo) {
     verifyEncumbrancesOnPoUpdate(rqPo, getFundDistributionCount(rqPo));
@@ -79,14 +61,5 @@ public final class FinanceInteractionsTestHelper {
       .stream()
       .mapToInt(pol -> pol.getFundDistribution().size())
       .sum();
-  }
-
-  private static int getEncumbrancesCount(CompositePurchaseOrder po) {
-    return (int) po.getCompositePoLines()
-      .stream()
-      .flatMap(pol -> pol.getFundDistribution().stream())
-      .map(FundDistribution::getEncumbrance)
-      .filter(Objects::nonNull)
-      .count();
   }
 }

--- a/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
+++ b/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
@@ -135,7 +135,7 @@ public class PurchaseOrderHelperTest {
     doAnswer((Answer<Future<CompositePoLine>>) invocation -> {
       CompositePoLine poLine = invocation.getArgument(0);
       return succeededFuture(poLine);
-    }).when(purchaseOrderLineHelper).createPoLine(any(CompositePoLine.class), any(CompositePurchaseOrder.class),
+    }).when(purchaseOrderLineHelper).createPoLineWithOrder(any(CompositePoLine.class), any(CompositePurchaseOrder.class),
       eq(requestContext));
     doReturn(succeededFuture(null))
       .when(orderValidationService).checkOrderApprovalRequired(any(CompositePurchaseOrder.class), eq(requestContext));

--- a/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
+++ b/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
@@ -6,7 +6,6 @@ import static org.folio.orders.utils.HelperUtils.ORDER_CONFIG_MODULE_NAME;
 import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -105,15 +104,9 @@ public class PurchaseOrderHelperTest {
 
   @Test
   @DisplayName("Test POST open composite order")
-  void testPostOpenCompositeOrder() {
+  void testPostOpenCompositeOrder() throws IOException {
     // Given
-    JsonObject order;
-    try {
-      order = new JsonObject(getMockData(LISTED_PRINT_SERIAL_PATH));
-    } catch (IOException ex) {
-      fail(ex);
-      return;
-    }
+    JsonObject order = new JsonObject(getMockData(LISTED_PRINT_SERIAL_PATH));
     CompositePurchaseOrder compPO = order.mapTo(CompositePurchaseOrder.class);
     prepareOrderForPostRequest(compPO);
     compPO.setWorkflowStatus(OPEN);
@@ -167,15 +160,9 @@ public class PurchaseOrderHelperTest {
 
   @Test
   @DisplayName("Test PUT pending composite order (no change)")
-  void testPutPendingCompositeOrder() {
+  void testPutPendingCompositeOrder() throws IOException {
     // Given
-    JsonObject order;
-    try {
-      order = new JsonObject(getMockData(LISTED_PRINT_SERIAL_PATH));
-    } catch (IOException ex) {
-      fail(ex);
-      return;
-    }
+    JsonObject order = new JsonObject(getMockData(LISTED_PRINT_SERIAL_PATH));
     CompositePurchaseOrder compPO = order.mapTo(CompositePurchaseOrder.class);
     prepareOrderForPostRequest(compPO);
     compPO.setId(UUID.randomUUID().toString());

--- a/src/test/java/org/folio/helper/PurchaseOrderLineHelperTest.java
+++ b/src/test/java/org/folio/helper/PurchaseOrderLineHelperTest.java
@@ -1,44 +1,158 @@
 package org.folio.helper;
 
-import static org.folio.TestConfig.clearServiceInteractions;
-import static org.folio.TestConfig.initSpringContext;
-import static org.folio.TestConfig.isVerticleNotDeployed;
-import static org.folio.rest.impl.MockServer.BASE_MOCK_DATA_PATH;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import org.folio.ApiTestSuite;
-import org.folio.config.ApplicationConfig;
-import org.junit.jupiter.api.AfterAll;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.acq.model.SequenceNumbers;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.exceptions.HttpException;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.Alert;
+import org.folio.rest.jaxrs.model.CompositePoLine;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Cost;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.ReportingCode;
+import org.folio.service.orders.PurchaseOrderLineService;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.UUID;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 
 public class PurchaseOrderLineHelperTest {
-  private static final String ORDER_ID = "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14";
-  private static final String ORDER_PATH = BASE_MOCK_DATA_PATH + "compositeOrders/" + ORDER_ID + ".json";
+  private AutoCloseable mockitoMocks;
+  @InjectMocks
+  private PurchaseOrderLineHelper purchaseOrderLineHelper;
+  @Mock
+  private PurchaseOrderLineService purchaseOrderLineService;
+  @Mock
+  private RequestContext requestContext;
+  @Mock
+  private RestClient restClient;
 
-  private static boolean runningOnOwn;
-
-  @BeforeAll
-  static void before() throws InterruptedException, ExecutionException, TimeoutException {
-    if (isVerticleNotDeployed()) {
-      ApiTestSuite.before();
-      runningOnOwn = true;
-    }
-    initSpringContext(ApplicationConfig.class);
+  @BeforeEach
+  void beforeEach() {
+    mockitoMocks = MockitoAnnotations.openMocks(this);
   }
 
   @AfterEach
-  void afterEach() {
-    clearServiceInteractions();
+  void resetMocks() throws Exception {
+    mockitoMocks.close();
   }
 
-  @AfterAll
-  static void after() {
-    if (runningOnOwn) {
-      ApiTestSuite.after();
-    }
+  @Test
+  @DisplayName("Test createPoLineWithOrder")
+  void testCreatePoLineWithOrder() {
+    // Given
+    Alert alert = new Alert()
+      .withAlert("alert");
+    ReportingCode reportingCode = new ReportingCode()
+      .withCode("code");
+    CompositePurchaseOrder compPO = new CompositePurchaseOrder()
+      .withId(UUID.randomUUID().toString())
+      .withPoNumber("1");
+    Cost cost = new Cost()
+      .withCurrency("USD");
+    CompositePoLine poLine = new CompositePoLine()
+      .withAlerts(List.of(alert))
+      .withReportingCodes(List.of(reportingCode))
+        .withCost(cost);
+
+    doAnswer((Answer<Future<Alert>>) invocation -> {
+      Alert al = invocation.getArgument(1);
+      if (al.getId() == null) {
+        al.setId(UUID.randomUUID().toString());
+      }
+      return succeededFuture(al);
+    }).when(restClient).post(any(RequestEntry.class), any(Alert.class), eq(Alert.class), eq(requestContext));
+    doAnswer((Answer<Future<ReportingCode>>) invocation -> {
+      ReportingCode rc = invocation.getArgument(1);
+      if (rc.getId() == null) {
+        rc.setId(UUID.randomUUID().toString());
+      }
+      return succeededFuture(rc);
+    }).when(restClient).post(any(RequestEntry.class), any(ReportingCode.class), eq(ReportingCode.class), eq(requestContext));
+    SequenceNumbers seqNumbers = new SequenceNumbers()
+      .withSequenceNumbers(List.of("1"));
+    doReturn(succeededFuture(JsonObject.mapFrom(seqNumbers)))
+      .when(restClient).getAsJsonObject(any(RequestEntry.class), eq(requestContext));
+    doReturn(succeededFuture(List.of()))
+      .when(purchaseOrderLineService).retrieveSearchLocationIds(any(PoLine.class), eq(requestContext));
+    doAnswer((Answer<Future<PoLine>>) invocation -> {
+      PoLine pol = invocation.getArgument(1);
+      return succeededFuture(pol);
+    }).when(restClient).post(any(RequestEntry.class), any(PoLine.class), eq(PoLine.class), eq(requestContext));
+
+    // When
+    Future<CompositePoLine> future = purchaseOrderLineHelper.createPoLineWithOrder(poLine, compPO, requestContext);
+
+    // Then
+    assertTrue(future.succeeded());
+  }
+
+  @Test
+  @DisplayName("Test error when creating a reporting code")
+  void testErrorWhenCreatingAReportingCode() {
+    // Given
+    Alert alert = new Alert()
+      .withAlert("alert");
+    ReportingCode reportingCode = new ReportingCode()
+      .withCode("code");
+    CompositePurchaseOrder compPO = new CompositePurchaseOrder()
+      .withId(UUID.randomUUID().toString())
+      .withPoNumber("1");
+    Cost cost = new Cost()
+      .withCurrency("USD");
+    CompositePoLine poLine = new CompositePoLine()
+      .withAlerts(List.of(alert))
+      .withReportingCodes(List.of(reportingCode))
+      .withCost(cost);
+
+    doAnswer((Answer<Future<Alert>>) invocation -> {
+      Alert al = invocation.getArgument(1);
+      if (al.getId() == null) {
+        al.setId(UUID.randomUUID().toString());
+      }
+      return succeededFuture(al);
+    }).when(restClient).post(any(RequestEntry.class), any(Alert.class), eq(Alert.class), eq(requestContext));
+    doReturn(failedFuture(new Exception("test error")))
+      .when(restClient).post(any(RequestEntry.class), any(ReportingCode.class), eq(ReportingCode.class), eq(requestContext));
+    SequenceNumbers seqNumbers = new SequenceNumbers()
+      .withSequenceNumbers(List.of("1"));
+    doReturn(succeededFuture(JsonObject.mapFrom(seqNumbers)))
+      .when(restClient).getAsJsonObject(any(RequestEntry.class), eq(requestContext));
+    doReturn(succeededFuture(List.of()))
+      .when(purchaseOrderLineService).retrieveSearchLocationIds(any(PoLine.class), eq(requestContext));
+    doAnswer((Answer<Future<PoLine>>) invocation -> {
+      PoLine pol = invocation.getArgument(1);
+      return succeededFuture(pol);
+    }).when(restClient).post(any(RequestEntry.class), any(PoLine.class), eq(PoLine.class), eq(requestContext));
+
+    // When
+    Future<CompositePoLine> future = purchaseOrderLineHelper.createPoLineWithOrder(poLine, compPO, requestContext);
+
+    // Then
+    assertTrue(future.failed());
+    Throwable cause = future.cause();
+    HttpException ex = (HttpException)cause;
+    assertEquals("Failed to create reporting codes", ex.getMessage());
+    assertEquals("test error", ex.getCause().getMessage());
   }
 
 }

--- a/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
+++ b/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
@@ -1,34 +1,58 @@
 package org.folio.service.orders;
 
-import static org.folio.rest.core.exceptions.ErrorCodes.CREATE_INVENTORY_INCORRECT_FOR_BINDARY_ACTIVE;
-import static org.folio.rest.core.exceptions.ErrorCodes.ORDER_FORMAT_INCORRECT_FOR_BINDARY_ACTIVE;
-import static org.folio.rest.core.exceptions.ErrorCodes.RECEIVING_WORKFLOW_INCORRECT_FOR_BINDARY_ACTIVE;
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.core.exceptions.ErrorCodes.*;
+import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.OTHER;
+import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.P_E_MIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import io.vertx.core.Future;
 import org.folio.rest.core.exceptions.ErrorCodes;
+import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.Details;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Physical;
+import org.folio.service.finance.expenceclass.ExpenseClassValidationService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class CompositePoLineValidationServiceTest {
+  private AutoCloseable mockitoMocks;
+  @Mock
+  private ExpenseClassValidationService expenseClassValidationService;
   @InjectMocks
   private CompositePoLineValidationService compositePoLineValidationService;
+  @Mock
+  private RequestContext requestContext;
 
   @BeforeEach
   public void initMocks(){
-    MockitoAnnotations.openMocks(this);
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  void afterEach() throws Exception {
+    mockitoMocks.close();
   }
 
   @Test
@@ -136,7 +160,7 @@ public class CompositePoLineValidationServiceTest {
     var compositePoLine = new CompositePoLine()
       .withDetails(new Details().withIsBindaryActive(true))
       .withPhysical(new Physical().withCreateInventory(Physical.CreateInventory.INSTANCE_HOLDING))
-      .withOrderFormat(CompositePoLine.OrderFormat.P_E_MIX)
+      .withOrderFormat(P_E_MIX)
       .withCheckinItems(true);
     var errors = compositePoLineValidationService.validateForBinadryActive(compositePoLine);
 
@@ -149,7 +173,7 @@ public class CompositePoLineValidationServiceTest {
     var compositePoLine = new CompositePoLine()
       .withDetails(new Details().withIsBindaryActive(true))
       .withPhysical(new Physical().withCreateInventory(Physical.CreateInventory.INSTANCE_HOLDING_ITEM))
-      .withOrderFormat(CompositePoLine.OrderFormat.P_E_MIX)
+      .withOrderFormat(P_E_MIX)
       .withCheckinItems(false);
     var errors = compositePoLineValidationService.validateForBinadryActive(compositePoLine);
 
@@ -171,7 +195,7 @@ public class CompositePoLineValidationServiceTest {
     var compositePoLineWithPEMix = new CompositePoLine()
       .withDetails(new Details().withIsBindaryActive(true))
       .withPhysical(new Physical().withCreateInventory(Physical.CreateInventory.INSTANCE_HOLDING_ITEM))
-      .withOrderFormat(CompositePoLine.OrderFormat.P_E_MIX)
+      .withOrderFormat(P_E_MIX)
       .withCheckinItems(true);
     var errors2 = compositePoLineValidationService.validateForBinadryActive(compositePoLineWithPEMix);
 
@@ -187,5 +211,166 @@ public class CompositePoLineValidationServiceTest {
     var errors = compositePoLineValidationService.validateForBinadryActive(compositePoLine);
 
     assertEquals(0, errors.size());
+  }
+
+  @Test
+  @DisplayName("Test validatePoLine with incorrect cost for PE Mix format")
+  void testValidatePoLineWithIncorrectCostForPEMixFormat() {
+    // Given
+    // Set incorrect quantities for the PO Line
+    Cost cost = new Cost()
+      .withQuantityPhysical(1)
+      .withQuantityElectronic(0)
+      .withListUnitPrice(-10d)
+      .withListUnitPriceElectronic(-5d);
+    Location location = new Location()
+      .withLocationId(UUID.randomUUID().toString())
+      .withQuantityElectronic(1)
+      .withQuantityPhysical(2);
+    CompositePoLine poLine = new CompositePoLine()
+      .withOrderFormat(P_E_MIX)
+      .withCost(cost)
+      .withLocations(List.of(location));
+
+    doReturn(succeededFuture(null))
+      .when(expenseClassValidationService).validateExpenseClasses(eq(List.of(poLine)), eq(false), eq(requestContext));
+
+    // When
+    Future<List<Error>> future = compositePoLineValidationService.validatePoLine(poLine, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(5));
+    Set<String> errorCodes = errorsToCodes(errors);
+
+    assertThat(errorCodes, containsInAnyOrder(
+      ZERO_COST_ELECTRONIC_QTY.getCode(),
+      PHYSICAL_COST_LOC_QTY_MISMATCH.getCode(),
+      ELECTRONIC_COST_LOC_QTY_MISMATCH.getCode(),
+      COST_UNIT_PRICE_ELECTRONIC_INVALID.getCode(),
+      COST_UNIT_PRICE_INVALID.getCode()));
+  }
+
+  @Test
+  @DisplayName("Test validatePoLine with incorrect cost for Other format")
+  void testValidatePoLineWithIncorrectCostForOtherFormat() {
+    // Given
+    // Set incorrect quantities for the PO Line
+    Cost cost = new Cost()
+      .withQuantityPhysical(0)
+      .withQuantityElectronic(1)
+      .withListUnitPrice(-1d)
+      .withListUnitPriceElectronic(10d);
+    Location location = new Location()
+      .withLocationId(UUID.randomUUID().toString())
+      .withQuantityElectronic(0)
+      .withQuantityPhysical(1);
+    CompositePoLine poLine = new CompositePoLine()
+      .withOrderFormat(OTHER)
+      .withCost(cost)
+      .withLocations(List.of(location));
+
+    doReturn(succeededFuture(null))
+      .when(expenseClassValidationService).validateExpenseClasses(eq(List.of(poLine)), eq(false), eq(requestContext));
+
+    // When
+    Future<List<Error>> future = compositePoLineValidationService.validatePoLine(poLine, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(5));
+    Set<String> errorCodes = errorsToCodes(errors);
+
+    assertThat(errorCodes, containsInAnyOrder(ZERO_COST_PHYSICAL_QTY.getCode(),
+      NON_ZERO_COST_ELECTRONIC_QTY.getCode(),
+      PHYSICAL_COST_LOC_QTY_MISMATCH.getCode(),
+      COST_UNIT_PRICE_ELECTRONIC_INVALID.getCode(),
+      COST_UNIT_PRICE_INVALID.getCode()));
+  }
+
+  @Test
+  @DisplayName("Test validatePoLine with incorrect quantities")
+  void testValidatePoLineWithIncorrectQuantities() {
+    // Given
+    // Set incorrect quantities for the PO Line
+    Cost cost = new Cost()
+      .withQuantityPhysical(0)
+      .withQuantityElectronic(0)
+      .withListUnitPrice(24.99)
+      .withListUnitPriceElectronic(20.99);
+    Location location1 = new Location()
+      .withLocationId(UUID.randomUUID().toString())
+      .withQuantityElectronic(1)
+      .withQuantityPhysical(1);
+    Location location2 = new Location()
+      .withLocationId(location1.getLocationId())
+      .withQuantityElectronic(0)
+      .withQuantityPhysical(0);
+    CompositePoLine poLine = new CompositePoLine()
+      .withOrderFormat(P_E_MIX)
+      .withCost(cost)
+      .withLocations(List.of(location1, location2));
+
+    doReturn(succeededFuture(null))
+      .when(expenseClassValidationService).validateExpenseClasses(eq(List.of(poLine)), eq(false), eq(requestContext));
+
+    // When
+    Future<List<Error>> future = compositePoLineValidationService.validatePoLine(poLine, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(5));
+    Set<String> errorCodes = errorsToCodes(errors);
+
+    assertThat(errorCodes, containsInAnyOrder(ZERO_COST_ELECTRONIC_QTY.getCode(),
+      ZERO_COST_PHYSICAL_QTY.getCode(),
+      ELECTRONIC_COST_LOC_QTY_MISMATCH.getCode(),
+      PHYSICAL_COST_LOC_QTY_MISMATCH.getCode(),
+      ZERO_LOCATION_QTY.getCode()));
+  }
+
+  @Test
+  @DisplayName("Test validatePoLine with zero quantities without locations")
+  void testValidatePoLineWithZeroQuantitiesWithoutLocations() {
+    // MODORDERS-584
+    // Skip quantity validation with 0 electronic and physical quantities and without location
+    // Given
+    Cost cost = new Cost()
+      .withQuantityPhysical(0)
+      .withQuantityElectronic(0)
+      .withListUnitPrice(24.99)
+      .withListUnitPriceElectronic(20.99);
+    CompositePoLine poLine = new CompositePoLine()
+      .withOrderFormat(P_E_MIX)
+      .withCost(cost);
+
+    doReturn(succeededFuture(null))
+      .when(expenseClassValidationService).validateExpenseClasses(eq(List.of(poLine)), eq(false), eq(requestContext));
+
+    // When
+    Future<List<Error>> future = compositePoLineValidationService.validatePoLine(poLine, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(0));
+  }
+
+  private Set<String> errorsToCodes(List<Error> errors) {
+    return errors
+      .stream()
+      .map(Error::getCode)
+      .collect(Collectors.toSet());
   }
 }

--- a/src/test/java/org/folio/service/orders/OrderValidationServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderValidationServiceTest.java
@@ -1,0 +1,173 @@
+package org.folio.service.orders;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.folio.helper.PurchaseOrderLineHelper;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePoLine;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Ongoing;
+import org.folio.service.caches.ConfigurationEntriesCache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.TestUtils.getMinimalContentCompositePurchaseOrder;
+import static org.folio.TestUtils.getMockData;
+import static org.folio.orders.utils.HelperUtils.ORDER_CONFIG_MODULE_NAME;
+import static org.folio.rest.core.exceptions.ErrorCodes.COST_UNIT_PRICE_ELECTRONIC_INVALID;
+import static org.folio.rest.core.exceptions.ErrorCodes.COST_UNIT_PRICE_INVALID;
+import static org.folio.rest.core.exceptions.ErrorCodes.ELECTRONIC_COST_LOC_QTY_MISMATCH;
+import static org.folio.rest.core.exceptions.ErrorCodes.MISSING_ONGOING;
+import static org.folio.rest.core.exceptions.ErrorCodes.NON_ZERO_COST_ELECTRONIC_QTY;
+import static org.folio.rest.core.exceptions.ErrorCodes.ONGOING_NOT_ALLOWED;
+import static org.folio.rest.core.exceptions.ErrorCodes.PHYSICAL_COST_LOC_QTY_MISMATCH;
+import static org.folio.rest.core.exceptions.ErrorCodes.ZERO_COST_ELECTRONIC_QTY;
+import static org.folio.rest.core.exceptions.ErrorCodes.ZERO_COST_PHYSICAL_QTY;
+import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.OrderType.ONE_TIME;
+import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.OrderType.ONGOING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+public class OrderValidationServiceTest {
+  static final String LISTED_PRINT_MONOGRAPH_PATH = "po_listed_print_monograph.json";
+  @InjectMocks
+  private OrderValidationService orderValidationService;
+  @Mock
+  private CompositePoLineValidationService compositePoLineValidationService;
+  @Mock
+  private PurchaseOrderLineHelper purchaseOrderLineHelper;
+  @Mock
+  private PurchaseOrderLineService purchaseOrderLineService;
+  @Mock
+  private ConfigurationEntriesCache configurationEntriesCache;
+  @Mock
+  private RequestContext requestContext;
+  private AutoCloseable mockitoMocks;
+
+  @BeforeEach
+  public void initMocks() {
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+
+    doReturn(succeededFuture(null))
+      .when(purchaseOrderLineHelper).setTenantDefaultCreateInventoryValues(any(CompositePoLine.class), any(JsonObject.class));
+    doReturn(succeededFuture(List.of()))
+      .when(compositePoLineValidationService).validatePoLine(any(CompositePoLine.class), eq(requestContext));
+    doReturn(succeededFuture(null))
+      .when(purchaseOrderLineService).validateAndNormalizeISBN(anyList(), eq(requestContext));
+  }
+
+  @AfterEach
+  void afterEach() throws Exception {
+    mockitoMocks.close();
+  }
+
+  @Test
+  @DisplayName("Test validateOrderForPost with Ongoing field")
+  void testValidateOrderForPostWithOngoingField() {
+    // Given
+    JsonObject tenantConfig = new JsonObject();
+    CompositePurchaseOrder compPO = getMinimalContentCompositePurchaseOrder();
+    compPO.setOrderType(ONE_TIME);
+    compPO.setOngoing(new Ongoing());
+
+    // When
+    Future<List<Error>> future = orderValidationService.validateOrderForPost(compPO, tenantConfig, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(1));
+    assertThat(errors.get(0).getCode(), is(ONGOING_NOT_ALLOWED.getCode()));
+  }
+
+  @Test
+  @DisplayName("Test validateOrderForPost without Ongoing field")
+  void testValidateOrderForPostWithoutOngoingField() {
+    // Given
+    JsonObject tenantConfig = new JsonObject();
+    CompositePurchaseOrder compPO = getMinimalContentCompositePurchaseOrder();
+    compPO.setOrderType(ONGOING);
+
+    // When
+    Future<List<Error>> future = orderValidationService.validateOrderForPost(compPO, tenantConfig, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(1));
+    assertThat(errors.get(0).getCode(), is(MISSING_ONGOING.getCode()));
+  }
+
+  @Test
+  @DisplayName("Test validateOrderForPut with Ongoing field")
+  void testValidateOrderForPutWithOngoingField() {
+    // Given
+    JsonObject tenantConfig = new JsonObject();
+    CompositePurchaseOrder compPO = getMinimalContentCompositePurchaseOrder();
+    compPO.setOrderType(ONE_TIME);
+    compPO.setOngoing(new Ongoing());
+
+    doReturn(succeededFuture(tenantConfig))
+      .when(configurationEntriesCache).loadConfiguration(eq(ORDER_CONFIG_MODULE_NAME), eq(requestContext));
+
+    // When
+    Future<List<Error>> future = orderValidationService.validateOrderForPut(compPO.getId(), compPO, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(1));
+    assertThat(errors.get(0).getCode(), is(ONGOING_NOT_ALLOWED.getCode()));
+  }
+
+  @Test
+  @DisplayName("Test validateOrderForPut without Ongoing field")
+  void testValidateOrderForPutWithoutOngoingField() {
+    // Given
+    JsonObject tenantConfig = new JsonObject();
+    CompositePurchaseOrder compPO = getMinimalContentCompositePurchaseOrder();
+    compPO.setOrderType(ONGOING);
+
+    doReturn(succeededFuture(tenantConfig))
+      .when(configurationEntriesCache).loadConfiguration(eq(ORDER_CONFIG_MODULE_NAME), eq(requestContext));
+
+    // When
+    Future<List<Error>> future = orderValidationService.validateOrderForPut(compPO.getId(), compPO, requestContext);
+
+    // Then
+    if (future.failed()) {
+      fail(future.cause());
+    }
+    List<Error> errors = future.result();
+    assertThat(errors, hasSize(1));
+    assertThat(errors.get(0).getCode(), is(MISSING_ONGOING.getCode()));
+  }
+
+}


### PR DESCRIPTION
## Purpose
[MODORDERS-1098](https://folio-org.atlassian.net/browse/MODORDERS-1098) - Rewrite PurchaseOrdersApiTest tests without using MockServer

## Approach
Converted more tests.

- `testPostOrderWithIncorrectCost()`
-> `CompositePoLineValidationServiceTest.testValidatePoLineWithIncorrectCostForPEMixFormat()`
and `CompositePoLineValidationServiceTest.testValidatePoLineWithIncorrectCostForOtherFormat()`

- `testPostOneTimeOrderWithOngoingFields()`
-> `OrderValidationServiceTest.testValidateOrderForPostWithOngoingField()`

- `testPostOngoingOrderWithoutOngoingFields()`
-> `OrderValidationServiceTest.testValidateOrderForPostWithoutOngoingField()`

- `testPutOneTimeOrderWithOngoingField()`
-> `OrderValidationServiceTest.testValidateOrderForPutWithOngoingField()`

- `testPutOngoingOrderWithoutOngoingField()`
-> `OrderValidationServiceTest.testValidateOrderForPutWithoutOngoingField()`

- `testPutOrderWithIncorrectQuantities()`
-> `CompositePoLineValidationServiceTest.testValidatePoLineWithIncorrectQuantities()`
   + `PurchaseOrderHelperTest.testPutPendingCompositeOrder()`

- `testPutOrderWithZeroQuantitiesWithoutLocations()`
-> `CompositePoLineValidationServiceTest.testValidatePoLineWithZeroQuantitiesWithoutLocations`

- `testListedPrintMonographInOpenStatus()`
-> new integration test, `create-open-composite-order.feature` ([see PR](https://github.com/folio-org/folio-integration-tests/pull/1357))

- `testPostListedPrintSerialInOpenStatus()` (currently disabled)
-> removed. Notes:
  - was disabled
  - was created for MODORDERS-459
  - contains a lot of tests that are not related to the ticket
  - is redundant with `open-ongoing-order.feature`

- `tesPutListedPrintSerialInOpenStatus()`
-> removed, redundant with `open-ongoing-order.feature`

Also improved error handling when creating reporting codes and alerts (previously there was no error message). Added unit tests to cover that too.

#### TODOS and Open Questions
TODO: more PRs for that ticket.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
