### PR TITLE
[MODORDERS-1108] Update PiecesAPI CRUD methods  to process inventory in desired tenant

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -108,6 +108,7 @@ import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
 import org.folio.service.pieces.flows.create.PieceCreateFlowInventoryManager;
 import org.folio.service.pieces.flows.create.PieceCreateFlowManager;
 import org.folio.service.pieces.flows.create.PieceCreateFlowPoLineService;
+import org.folio.service.pieces.flows.delete.PieceDeleteFlowInventoryManager;
 import org.folio.service.pieces.flows.delete.PieceDeleteFlowManager;
 import org.folio.service.pieces.flows.delete.PieceDeleteFlowPoLineService;
 import org.folio.service.pieces.flows.strategies.ProcessInventoryElectronicStrategy;
@@ -580,36 +581,46 @@ public class ApplicationConfig {
     return new PieceUpdateInventoryService(inventoryItemManager, inventoryHoldingManager, pieceStorageService);
   }
 
-  @Bean PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService,
+  @Bean
+  PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService,
                     PurchaseOrderLineService purchaseOrderLineService, ReceivingEncumbranceStrategy receivingEncumbranceStrategy) {
     return new PieceDeleteFlowPoLineService(purchaseOrderStorageService, purchaseOrderLineService, receivingEncumbranceStrategy);
   }
 
-  @Bean PieceDeleteFlowManager pieceDeletionFlowManager(PieceStorageService pieceStorageService,
-                                                        ProtectionService protectionService,
-                                                        InventoryItemManager inventoryItemManager,
-                                                        PieceUpdateInventoryService pieceUpdateInventoryService,
-                                                        PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService,
-                                                        BasePieceFlowHolderBuilder basePieceFlowHolderBuilder,
-                                                        CirculationRequestsRetriever circulationRequestsRetriever) {
-    return new PieceDeleteFlowManager(pieceStorageService, protectionService, inventoryItemManager, pieceUpdateInventoryService,
-                      pieceDeleteFlowPoLineService, basePieceFlowHolderBuilder, circulationRequestsRetriever);
+  @Bean
+  PieceDeleteFlowManager pieceDeletionFlowManager(PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager,
+                                                  PieceStorageService pieceStorageService,
+                                                  ProtectionService protectionService,
+                                                  PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService,
+                                                  BasePieceFlowHolderBuilder basePieceFlowHolderBuilder,
+                                                  CirculationRequestsRetriever circulationRequestsRetriever) {
+    return new PieceDeleteFlowManager(pieceDeleteFlowInventoryManager, pieceStorageService, protectionService,
+      pieceDeleteFlowPoLineService, basePieceFlowHolderBuilder, circulationRequestsRetriever);
+  }
+
+  @Bean
+  PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager(InventoryItemManager inventoryItemManager,
+                                                                  PieceUpdateInventoryService pieceUpdateInventoryService) {
+    return new PieceDeleteFlowInventoryManager(inventoryItemManager, pieceUpdateInventoryService);
   }
 
 
-  @Bean BasePieceFlowHolderBuilder basePieceFlowHolderBuilder(PurchaseOrderStorageService purchaseOrderStorageService,
+  @Bean
+  BasePieceFlowHolderBuilder basePieceFlowHolderBuilder(PurchaseOrderStorageService purchaseOrderStorageService,
                                                               PurchaseOrderLineService purchaseOrderLineService, TitlesService titlesService) {
       return new BasePieceFlowHolderBuilder(purchaseOrderStorageService, purchaseOrderLineService, titlesService);
   }
 
-  @Bean PieceUpdateFlowPoLineService pieceUpdateFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService, PurchaseOrderLineService purchaseOrderLineService,
+  @Bean
+  PieceUpdateFlowPoLineService pieceUpdateFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService, PurchaseOrderLineService purchaseOrderLineService,
           ReceivingEncumbranceStrategy receivingEncumbranceStrategy, PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService,
           PieceCreateFlowPoLineService pieceCreateFlowPoLineService) {
     return new PieceUpdateFlowPoLineService(purchaseOrderStorageService, purchaseOrderLineService, receivingEncumbranceStrategy,
           pieceCreateFlowPoLineService, pieceDeleteFlowPoLineService);
   }
 
-  @Bean PieceUpdateFlowManager pieceUpdateFlowManager(PieceStorageService pieceStorageService, PieceService pieceService, ProtectionService protectionService,
+  @Bean
+  PieceUpdateFlowManager pieceUpdateFlowManager(PieceStorageService pieceStorageService, PieceService pieceService, ProtectionService protectionService,
             PieceUpdateFlowPoLineService pieceUpdateFlowPoLineService, PieceUpdateFlowInventoryManager pieceUpdateFlowInventoryManager,
             BasePieceFlowHolderBuilder basePieceFlowHolderBuilder, DefaultPieceFlowsValidator defaultPieceFlowsValidator,
             PurchaseOrderLineService purchaseOrderLineService) {

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -100,6 +100,7 @@ import org.folio.service.orders.lines.update.instance.WithHoldingOrderLineUpdate
 import org.folio.service.orders.lines.update.instance.WithoutHoldingOrderLineUpdateInstanceStrategy;
 import org.folio.service.organization.OrganizationService;
 import org.folio.service.pieces.PieceChangeReceiptStatusPublisher;
+import org.folio.service.pieces.PieceDeleteInventoryService;
 import org.folio.service.pieces.PieceService;
 import org.folio.service.pieces.PieceStorageService;
 import org.folio.service.pieces.PieceUpdateInventoryService;
@@ -590,6 +591,11 @@ public class ApplicationConfig {
   }
 
   @Bean
+  PieceDeleteInventoryService pieceDeleteInventoryService(InventoryItemManager inventoryItemManager) {
+    return new PieceDeleteInventoryService(inventoryItemManager);
+  }
+
+  @Bean
   PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService,
                     PurchaseOrderLineService purchaseOrderLineService, ReceivingEncumbranceStrategy receivingEncumbranceStrategy) {
     return new PieceDeleteFlowPoLineService(purchaseOrderStorageService, purchaseOrderLineService, receivingEncumbranceStrategy);
@@ -607,9 +613,9 @@ public class ApplicationConfig {
   }
 
   @Bean
-  PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager(InventoryItemManager inventoryItemManager,
+  PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager(PieceDeleteInventoryService pieceDeleteInventoryService,
                                                                   PieceUpdateInventoryService pieceUpdateInventoryService) {
-    return new PieceDeleteFlowInventoryManager(inventoryItemManager, pieceUpdateInventoryService);
+    return new PieceDeleteFlowInventoryManager(pieceDeleteInventoryService, pieceUpdateInventoryService);
   }
 
 

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -522,26 +522,34 @@ public class ApplicationConfig {
     return new PieceChangeReceiptStatusPublisher();
   }
 
-  @Bean PieceStorageService pieceStorageService(RestClient restClient) {
+  @Bean
+  PieceStorageService pieceStorageService(RestClient restClient) {
     return new PieceStorageService(restClient);
   }
 
-  @Bean PieceService piecesService(PieceChangeReceiptStatusPublisher receiptStatusPublisher) {
+  @Bean
+  PieceService piecesService(PieceChangeReceiptStatusPublisher receiptStatusPublisher) {
     return new PieceService(receiptStatusPublisher);
   }
 
-  @Bean DefaultPieceFlowsValidator pieceCreateFlowValidator() {
+  @Bean
+  DefaultPieceFlowsValidator pieceCreateFlowValidator() {
     return new DefaultPieceFlowsValidator();
   }
 
-  @Bean PieceCreateFlowPoLineService pieceCreateFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService,
-    PurchaseOrderLineService purchaseOrderLineService, ReceivingEncumbranceStrategy receivingEncumbranceStrategy) {
+  @Bean
+  PieceCreateFlowPoLineService pieceCreateFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService,
+                                                            PurchaseOrderLineService purchaseOrderLineService,
+                                                            ReceivingEncumbranceStrategy receivingEncumbranceStrategy) {
     return new PieceCreateFlowPoLineService(purchaseOrderStorageService, purchaseOrderLineService, receivingEncumbranceStrategy);
   }
 
-  @Bean PieceCreateFlowManager pieceCreationService(PieceStorageService pieceStorageService, ProtectionService protectionService,
-                PieceCreateFlowInventoryManager pieceCreateFlowInventoryManager, DefaultPieceFlowsValidator defaultPieceFlowsValidator,
-                PieceCreateFlowPoLineService pieceCreateFlowPoLineService, BasePieceFlowHolderBuilder basePieceFlowHolderBuilder) {
+  @Bean
+  PieceCreateFlowManager pieceCreationService(PieceStorageService pieceStorageService, ProtectionService protectionService,
+                                              PieceCreateFlowInventoryManager pieceCreateFlowInventoryManager,
+                                              DefaultPieceFlowsValidator defaultPieceFlowsValidator,
+                                              PieceCreateFlowPoLineService pieceCreateFlowPoLineService,
+                                              BasePieceFlowHolderBuilder basePieceFlowHolderBuilder) {
     return new PieceCreateFlowManager(pieceStorageService, protectionService, pieceCreateFlowInventoryManager,
       defaultPieceFlowsValidator, pieceCreateFlowPoLineService, basePieceFlowHolderBuilder);
   }

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -105,7 +105,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
 
               // When requests are to be transferred check if pieces contain different receivingTenantIds
               // Transferring requests between tenants is not a requirement for R
-              if (bindPiecesCollection.getRequestsAction().equals(TRANSFER) && !tenantToItem.keySet().isEmpty()) {
+              if (bindPiecesCollection.getRequestsAction().equals(TRANSFER) && tenantToItem.keySet().size() > 1) {
                 logger.warn("checkRequestsForPieceItems:: All pieces do not have the same receivingTenantId: {}", tenantToItem.keySet());
                 throw new HttpException(RestConstants.VALIDATION_ERROR, ErrorCodes.PIECES_HAVE_DIFFERENT_RECEIVING_TENANT_IDS);
               }

--- a/src/main/java/org/folio/orders/utils/RequestContextUtil.java
+++ b/src/main/java/org/folio/orders/utils/RequestContextUtil.java
@@ -6,6 +6,8 @@ import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.core.models.RequestContext;
 
+import java.util.Optional;
+
 public class RequestContextUtil {
   private static final Logger logger = LogManager.getLogger(RequestContextUtil.class);
 

--- a/src/main/java/org/folio/orders/utils/RequestContextUtil.java
+++ b/src/main/java/org/folio/orders/utils/RequestContextUtil.java
@@ -6,8 +6,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.core.models.RequestContext;
 
-import java.util.Optional;
-
 public class RequestContextUtil {
   private static final Logger logger = LogManager.getLogger(RequestContextUtil.class);
 

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
@@ -163,7 +163,7 @@ public class OpenCompositeOrderPieceService {
    * @return CompletableFuture with void.
    */
   public Future<Void> openOrderUpdateInventory(CompositePoLine compPOL, Piece piece, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
-    if (!Boolean.TRUE.equals(compPOL.getIsPackage())) {
+    if (Boolean.FALSE.equals(compPOL.getIsPackage())) {
       return inventoryItemManager.updateItemWithPieceFields(piece, requestContext);
     }
     var locationContext = createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
@@ -163,7 +163,7 @@ public class OpenCompositeOrderPieceService {
    * @return CompletableFuture with void.
    */
   public Future<Void> openOrderUpdateInventory(CompositePoLine compPOL, Piece piece, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
-    if (Boolean.FALSE.equals(compPOL.getIsPackage())) {
+    if (!Boolean.TRUE.equals(compPOL.getIsPackage())) {
       return inventoryItemManager.updateItemWithPieceFields(piece, requestContext);
     }
     var locationContext = createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());

--- a/src/main/java/org/folio/service/pieces/PieceDeleteInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/PieceDeleteInventoryService.java
@@ -1,0 +1,48 @@
+package org.folio.service.pieces;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.models.ItemStatus;
+import org.folio.models.pieces.PieceDeletionHolder;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.service.inventory.InventoryItemManager;
+
+import java.util.Optional;
+
+import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS;
+import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS_NAME;
+
+public class PieceDeleteInventoryService {
+
+  private final InventoryItemManager inventoryItemManager;
+
+  public PieceDeleteInventoryService(InventoryItemManager inventoryItemManager) {
+    this.inventoryItemManager = inventoryItemManager;
+  }
+
+  public Future<Void> deleteItem(PieceDeletionHolder holder, RequestContext requestContext) {
+    var piece = holder.getPieceToDelete();
+    return getOnOrderItemForPiece(piece, requestContext)
+      .compose(item -> Optional.ofNullable(item)
+        .map(mItem -> inventoryItemManager.deleteItem(piece.getItemId(), true, requestContext))
+        .orElse(Future.succeededFuture()));
+  }
+
+  private Future<JsonObject> getOnOrderItemForPiece(Piece piece, RequestContext requestContext) {
+    if (StringUtils.isEmpty(piece.getItemId())) {
+      return Future.succeededFuture();
+    }
+    return inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
+      .map(item -> getItemWithStatus(item, ItemStatus.ON_ORDER.value()));
+  }
+
+  private JsonObject getItemWithStatus(JsonObject item, String status) {
+    return Optional.ofNullable(item)
+      .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
+      .filter(itemStatus -> status.equalsIgnoreCase(itemStatus.getString(ITEM_STATUS_NAME)))
+      .orElse(null);
+  }
+
+}

--- a/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
@@ -63,33 +63,42 @@ public class PieceUpdateInventoryService {
   }
 
   public Future<Pair<String, String>> deleteHoldingConnectedToPiece(Piece piece, RequestContext requestContext) {
-    if (piece != null && piece.getHoldingId() != null) {
+      if (piece == null || piece.getHoldingId() == null) {
+          return Future.succeededFuture();
+      }
       var locationContext = createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
       String holdingId = piece.getHoldingId();
       return inventoryHoldingManager.getHoldingById(holdingId, true, locationContext)
-                  .compose(holding -> {
-                      if (holding != null && !holding.isEmpty()) {
-                          return pieceStorageService.getPiecesByHoldingId(holdingId, requestContext)
-                            .map(pieces -> skipPieceToProcess(piece, pieces))
-                                  .compose(existingPieces -> inventoryItemManager.getItemsByHoldingId(holdingId, locationContext)
-                                    .map(existingItems-> {
-                                      List<Piece> remainingPieces = skipPieceToProcess(piece, existingPieces);
-                                      if (CollectionUtils.isEmpty(remainingPieces) && CollectionUtils.isEmpty(existingItems)) {
-                                        return Pair.of(true, holding);
-                                      }
-                                      return Pair.of(false, new JsonObject());
-                                    }));
-                      }
-                      return Future.succeededFuture(Pair.of(false, new JsonObject()));
-                  })
-                  .compose(isUpdatePossibleVsHolding -> {
-                    if (isUpdatePossibleVsHolding.getKey() && !isUpdatePossibleVsHolding.getValue().isEmpty()) {
-                      String permanentLocationId = isUpdatePossibleVsHolding.getValue().getString(HOLDING_PERMANENT_LOCATION_ID);
-                      return inventoryHoldingManager.deleteHoldingById(holdingId, true, locationContext)
-                                              .map(v -> Pair.of(holdingId, permanentLocationId));
-                    }
-                    return Future.succeededFuture();
-                  });
+        .compose(holding -> getUpdatePossibleForHolding(holding, holdingId, piece, locationContext, requestContext))
+        .compose(isUpdatePossibleVsHolding -> deleteHoldingIfPossible(isUpdatePossibleVsHolding, holdingId, locationContext));
+  }
+
+  private Future<Pair<Boolean, JsonObject>> getUpdatePossibleForHolding(JsonObject holding, String holdingId, Piece piece,
+                                                                        RequestContext locationContext, RequestContext requestContext) {
+    if (holding == null || holding.isEmpty()) {
+      return Future.succeededFuture(Pair.of(false, new JsonObject()));
+    }
+    return pieceStorageService.getPiecesByHoldingId(holdingId, requestContext)
+      .map(pieces -> skipPieceToProcess(piece, pieces))
+      .compose(existingPieces -> inventoryItemManager.getItemsByHoldingId(holdingId, locationContext)
+        .map(existingItems-> {
+          List<Piece> remainingPieces = skipPieceToProcess(piece, existingPieces);
+          if (CollectionUtils.isEmpty(remainingPieces) && CollectionUtils.isEmpty(existingItems)) {
+            return Pair.of(true, holding);
+          }
+          return Pair.of(false, new JsonObject());
+        })
+      );
+  }
+
+  private Future<Pair<String, String>> deleteHoldingIfPossible(Pair<Boolean, JsonObject> isUpdatePossibleVsHolding,
+                                                               String holdingId, RequestContext locationContext) {
+    var isUpdatePossible = isUpdatePossibleVsHolding.getKey();
+    var holding = isUpdatePossibleVsHolding.getValue();
+    if (isUpdatePossible && !holding.isEmpty()) {
+      String permanentLocationId = holding.getString(HOLDING_PERMANENT_LOCATION_ID);
+      return inventoryHoldingManager.deleteHoldingById(holdingId, true, locationContext)
+        .map(v -> Pair.of(holdingId, permanentLocationId));
     }
     return Future.succeededFuture();
   }

--- a/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
@@ -1,5 +1,6 @@
 package org.folio.service.pieces;
 
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 import static org.folio.service.inventory.InventoryHoldingManager.HOLDING_PERMANENT_LOCATION_ID;
 
 import java.util.List;
@@ -9,7 +10,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Piece;
@@ -64,7 +64,7 @@ public class PieceUpdateInventoryService {
 
   public Future<Pair<String, String>> deleteHoldingConnectedToPiece(Piece piece, RequestContext requestContext) {
     if (piece != null && piece.getHoldingId() != null) {
-      var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
+      var locationContext = createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
       String holdingId = piece.getHoldingId();
       return inventoryHoldingManager.getHoldingById(holdingId, true, locationContext)
                   .compose(holding -> {

--- a/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
@@ -9,6 +9,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Piece;
@@ -63,13 +64,14 @@ public class PieceUpdateInventoryService {
 
   public Future<Pair<String, String>> deleteHoldingConnectedToPiece(Piece piece, RequestContext requestContext) {
     if (piece != null && piece.getHoldingId() != null) {
+      var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
       String holdingId = piece.getHoldingId();
-      return inventoryHoldingManager.getHoldingById(holdingId, true, requestContext)
+      return inventoryHoldingManager.getHoldingById(holdingId, true, locationContext)
                   .compose(holding -> {
                       if (holding != null && !holding.isEmpty()) {
                           return pieceStorageService.getPiecesByHoldingId(holdingId, requestContext)
                             .map(pieces -> skipPieceToProcess(piece, pieces))
-                                  .compose(existingPieces -> inventoryItemManager.getItemsByHoldingId(holdingId, requestContext)
+                                  .compose(existingPieces -> inventoryItemManager.getItemsByHoldingId(holdingId, locationContext)
                                     .map(existingItems-> {
                                       List<Piece> remainingPieces = skipPieceToProcess(piece, existingPieces);
                                       if (CollectionUtils.isEmpty(remainingPieces) && CollectionUtils.isEmpty(existingItems)) {
@@ -83,7 +85,7 @@ public class PieceUpdateInventoryService {
                   .compose(isUpdatePossibleVsHolding -> {
                     if (isUpdatePossibleVsHolding.getKey() && !isUpdatePossibleVsHolding.getValue().isEmpty()) {
                       String permanentLocationId = isUpdatePossibleVsHolding.getValue().getString(HOLDING_PERMANENT_LOCATION_ID);
-                      return inventoryHoldingManager.deleteHoldingById(holdingId, true, requestContext)
+                      return inventoryHoldingManager.deleteHoldingById(holdingId, true, locationContext)
                                               .map(v -> Pair.of(holdingId, permanentLocationId));
                     }
                     return Future.succeededFuture();

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -31,7 +31,7 @@ public class PieceCreateFlowInventoryManager {
   }
 
   public Future<Void> processInventory(CompositePoLine compPOL, Piece piece, boolean createItem, RequestContext requestContext) {
-    final var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
+    var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
     return updateInventoryForPoLine(compPOL, piece, locationContext, requestContext)
       .compose(instanceId -> handleHolding(compPOL, piece, instanceId, locationContext))
       .compose(holdingId -> handleItem(compPOL, createItem, piece, locationContext))

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -3,7 +3,6 @@ package org.folio.service.pieces.flows.create;
 import java.util.Optional;
 
 import org.folio.orders.utils.PoLineCommonUtil;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Location;
@@ -14,6 +13,8 @@ import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
 import org.folio.service.titles.TitlesService;
 
 import io.vertx.core.Future;
+
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 
 public class PieceCreateFlowInventoryManager {
 
@@ -30,7 +31,7 @@ public class PieceCreateFlowInventoryManager {
   }
 
   public Future<Void> processInventory(CompositePoLine compPOL, Piece piece, boolean createItem, RequestContext requestContext) {
-    var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
+    var locationContext = createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
     return updateInventoryInstanceForPoLine(compPOL, piece, locationContext, requestContext)
       .compose(instanceId -> handleHolding(compPOL, piece, instanceId, locationContext))
       .compose(holdingId -> handleItem(compPOL, createItem, piece, locationContext))

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -2,7 +2,6 @@ package org.folio.service.pieces.flows.create;
 
 import java.util.Optional;
 
-import org.apache.commons.lang3.BooleanUtils;
 import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
@@ -32,15 +31,15 @@ public class PieceCreateFlowInventoryManager {
 
   public Future<Void> processInventory(CompositePoLine compPOL, Piece piece, boolean createItem, RequestContext requestContext) {
     var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
-    return updateInventoryForPoLine(compPOL, piece, locationContext, requestContext)
+    return updateInventoryInstanceForPoLine(compPOL, piece, locationContext, requestContext)
       .compose(instanceId -> handleHolding(compPOL, piece, instanceId, locationContext))
       .compose(holdingId -> handleItem(compPOL, createItem, piece, locationContext))
       .map(itemId -> Optional.ofNullable(itemId).map(piece::withItemId))
       .mapEmpty();
   }
 
-  private Future<String> updateInventoryForPoLine(CompositePoLine compPOL, Piece piece, RequestContext locationContext, RequestContext requestContext) {
-    if (BooleanUtils.isNotTrue(compPOL.getIsPackage())) {
+  private Future<String> updateInventoryInstanceForPoLine(CompositePoLine compPOL, Piece piece, RequestContext locationContext, RequestContext requestContext) {
+    if (!Boolean.TRUE.equals(compPOL.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(compPOL))
         .orElseGet(() -> titlesService.updateTitleWithInstance(piece.getTitleId(), locationContext, requestContext))
         .map(instanceId -> compPOL.withInstanceId(instanceId).getInstanceId());

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -40,7 +40,7 @@ public class PieceCreateFlowInventoryManager {
   }
 
   private Future<String> updateInventoryInstanceForPoLine(CompositePoLine compPOL, Piece piece, RequestContext locationContext, RequestContext requestContext) {
-    if (!Boolean.TRUE.equals(compPOL.getIsPackage())) {
+    if (Boolean.FALSE.equals(compPOL.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(compPOL))
         .orElseGet(() -> titlesService.updateTitleWithInstance(piece.getTitleId(), locationContext, requestContext))
         .map(instanceId -> compPOL.withInstanceId(instanceId).getInstanceId());

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -2,12 +2,12 @@ package org.folio.service.pieces.flows.create;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Piece;
-import org.folio.rest.jaxrs.model.Title;
 import org.folio.service.inventory.InventoryHoldingManager;
 import org.folio.service.pieces.PieceUpdateInventoryService;
 import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
@@ -29,80 +29,53 @@ public class PieceCreateFlowInventoryManager {
     this.inventoryHoldingManager = inventoryHoldingManager;
   }
 
-  public Future<Void> processInventory(CompositePoLine compPOL,  Piece piece,  boolean createItem, RequestContext requestContext) {
-    if (Boolean.TRUE.equals(compPOL.getIsPackage())) {
-      return packagePoLineUpdateInventory(compPOL, piece, createItem, requestContext);
-    }
-    else
-    {
-       return nonPackagePoLineUpdateInventory(compPOL, piece, createItem, requestContext);
-    }
-  }
-
-  private Future<Void> nonPackagePoLineUpdateInventory(CompositePoLine compPOL, Piece piece, boolean createItem, RequestContext requestContext) {
-    return nonPackageUpdateTitleWithInstance(compPOL, piece.getTitleId(), requestContext)
+  public Future<Void> processInventory(CompositePoLine compPOL, Piece piece, boolean createItem, RequestContext requestContext) {
+    return updateInventoryForPoLine(compPOL, piece, requestContext)
       .compose(instanceId -> handleHolding(compPOL, piece, instanceId, requestContext))
       .compose(holdingId -> handleItem(compPOL, createItem, piece, requestContext))
-      .map(itemId -> {
-        Optional.ofNullable(itemId).ifPresent(piece::withItemId);
-        return null;
-      })
+      .map(itemId -> Optional.ofNullable(itemId).map(piece::withItemId))
       .mapEmpty();
   }
 
-  private Future<Void> packagePoLineUpdateInventory(CompositePoLine compPOL, Piece piece, boolean createItem, RequestContext requestContext) {
-    return titlesService.getTitleById(piece.getTitleId(), requestContext)
-      .compose(title -> packageUpdateTitleWithInstance(title, requestContext))
-      .compose(instanceId -> handleHolding(compPOL, piece, instanceId, requestContext))
-      .compose(holdingId -> handleItem(compPOL, createItem, piece, requestContext))
-      .map(itemId -> {
-        Optional.ofNullable(itemId).ifPresent(piece::withItemId);
-        return null;
-      })
-      .mapEmpty();
+  private Future<String> updateInventoryForPoLine(CompositePoLine compPOL, Piece piece, RequestContext requestContext) {
+    if (BooleanUtils.isTrue(compPOL.getIsPackage())) {
+      return Optional.ofNullable(getPoLineInstanceId(compPOL))
+        .orElse(titlesService.updateTitleWithInstance(piece.getTitleId(), requestContext))
+        .map(instanceId -> compPOL.withInstanceId(instanceId).getInstanceId());
+    }
+    return titlesService.updateTitleWithInstance(piece.getTitleId(), requestContext);
+  }
+
+  private Future<String> getPoLineInstanceId(CompositePoLine compPOL) {
+    return compPOL.getInstanceId() != null || PoLineCommonUtil.isInventoryUpdateNotRequired(compPOL)
+      ? Future.succeededFuture(compPOL.getInstanceId())
+      : null;
   }
 
   private Future<Location> handleHolding(CompositePoLine compPOL, Piece piece, String instanceId, RequestContext requestContext) {
     if (piece.getHoldingId() != null) {
       return Future.succeededFuture(new Location().withHoldingId(piece.getHoldingId()));
     }
-    if (instanceId != null && DefaultPieceFlowsValidator.isCreateHoldingForPiecePossible(piece, compPOL)) {
-      return inventoryHoldingManager.createHoldingAndReturnId(instanceId, piece.getLocationId(), requestContext)
-        .map(holdingId -> {
-          Location location = new Location().withLocationId(piece.getLocationId());
-          if(holdingId != null) {
-            piece.setLocationId(null);
-            piece.setHoldingId(holdingId);
-            location.setLocationId(null);
-            location.setHoldingId(holdingId);
-          }
-          return location;
-        });
+
+    var location = new Location().withLocationId(piece.getLocationId());
+    if (instanceId == null || !DefaultPieceFlowsValidator.isCreateHoldingForPiecePossible(piece, compPOL)) {
+      return Future.succeededFuture(location);
     }
-    return Future.succeededFuture(new Location().withLocationId(piece.getLocationId()));
+    return inventoryHoldingManager.createHoldingAndReturnId(instanceId, piece.getLocationId(), requestContext)
+      .map(holdingId -> {
+        if (holdingId != null) {
+          piece.withLocationId(null).setHoldingId(holdingId);
+          location.withLocationId(null).setHoldingId(holdingId);
+        }
+        return location;
+      });
   }
 
   private Future<String> handleItem(CompositePoLine compPOL, boolean createItem, Piece piece, RequestContext requestContext) {
-    if (piece.getItemId() != null) {
+    if (piece.getItemId() != null || !createItem || piece.getHoldingId() == null) {
       return Future.succeededFuture(piece.getItemId());
     }
-    if (createItem &&  piece.getHoldingId() != null) {
-        return pieceUpdateInventoryService.manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
-    }
-    return Future.succeededFuture();
+    return pieceUpdateInventoryService.manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }
 
-
-  private Future<String> nonPackageUpdateTitleWithInstance(CompositePoLine poLine, String titleId, RequestContext requestContext) {
-    if (poLine.getInstanceId() != null || PoLineCommonUtil.isInventoryUpdateNotRequired(poLine)) {
-      return Future.succeededFuture(poLine.getInstanceId());
-    }
-    return titlesService.getTitleById(titleId, requestContext)
-      .compose(title -> titlesService.updateTitleWithInstance(title, requestContext))
-      .map(instanceId -> poLine.withInstanceId(instanceId).getInstanceId());
-  }
-
-  private Future<String> packageUpdateTitleWithInstance(Title title, RequestContext requestContext) {
-    return titlesService.updateTitleWithInstance(title, requestContext);
-  }
 }

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -38,7 +38,7 @@ public class PieceCreateFlowInventoryManager {
   }
 
   private Future<String> updateInventoryForPoLine(CompositePoLine compPOL, Piece piece, RequestContext requestContext) {
-    if (BooleanUtils.isTrue(compPOL.getIsPackage())) {
+    if (BooleanUtils.isNotTrue(compPOL.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(compPOL))
         .orElse(titlesService.updateTitleWithInstance(piece.getTitleId(), requestContext))
         .map(instanceId -> compPOL.withInstanceId(instanceId).getInstanceId());
@@ -72,10 +72,9 @@ public class PieceCreateFlowInventoryManager {
   }
 
   private Future<String> handleItem(CompositePoLine compPOL, boolean createItem, Piece piece, RequestContext requestContext) {
-    if (piece.getItemId() != null || !createItem || piece.getHoldingId() == null) {
-      return Future.succeededFuture(piece.getItemId());
-    }
-    return pieceUpdateInventoryService.manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
+    return piece.getItemId() != null || !createItem || piece.getHoldingId() == null
+      ? Future.succeededFuture(piece.getItemId())
+      : pieceUpdateInventoryService.manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }
 
 }

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -40,7 +40,7 @@ public class PieceCreateFlowInventoryManager {
   }
 
   private Future<String> updateInventoryInstanceForPoLine(CompositePoLine compPOL, Piece piece, RequestContext locationContext, RequestContext requestContext) {
-    if (Boolean.FALSE.equals(compPOL.getIsPackage())) {
+    if (!Boolean.TRUE.equals(compPOL.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(compPOL))
         .orElseGet(() -> titlesService.updateTitleWithInstance(piece.getTitleId(), locationContext, requestContext))
         .map(instanceId -> compPOL.withInstanceId(instanceId).getInstanceId());

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -40,7 +40,7 @@ public class PieceCreateFlowInventoryManager {
   private Future<String> updateInventoryForPoLine(CompositePoLine compPOL, Piece piece, RequestContext requestContext) {
     if (BooleanUtils.isNotTrue(compPOL.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(compPOL))
-        .orElse(titlesService.updateTitleWithInstance(piece.getTitleId(), requestContext))
+        .orElseGet(() -> titlesService.updateTitleWithInstance(piece.getTitleId(), requestContext))
         .map(instanceId -> compPOL.withInstanceId(instanceId).getInstanceId());
     }
     return titlesService.updateTitleWithInstance(piece.getTitleId(), requestContext);

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
@@ -3,10 +3,11 @@ package org.folio.service.pieces.flows.delete;
 import io.vertx.core.Future;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.models.pieces.PieceDeletionHolder;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.service.pieces.PieceDeleteInventoryService;
 import org.folio.service.pieces.PieceUpdateInventoryService;
+
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 
 public class PieceDeleteFlowInventoryManager {
 
@@ -19,7 +20,7 @@ public class PieceDeleteFlowInventoryManager {
   }
 
   public Future<Pair<String, String>> processInventory(PieceDeletionHolder holder, RequestContext requestContext) {
-    var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, holder.getPieceToDelete().getReceivingTenantId());
+    var locationContext = createContextWithNewTenantId(requestContext, holder.getPieceToDelete().getReceivingTenantId());
     return pieceDeleteInventoryService.deleteItem(holder, locationContext)
       .compose(aVoid -> holder.isDeleteHolding()
           ? pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), locationContext)

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
@@ -1,61 +1,30 @@
 package org.folio.service.pieces.flows.delete;
 
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.folio.models.ItemStatus;
 import org.folio.models.pieces.PieceDeletionHolder;
 import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
-import org.folio.rest.jaxrs.model.Piece;
-import org.folio.service.inventory.InventoryItemManager;
+import org.folio.service.pieces.PieceDeleteInventoryService;
 import org.folio.service.pieces.PieceUpdateInventoryService;
-
-import java.util.Optional;
-
-import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS;
-import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS_NAME;
 
 public class PieceDeleteFlowInventoryManager {
 
-  private final InventoryItemManager inventoryItemManager;
+  private final PieceDeleteInventoryService pieceDeleteInventoryService;
   private final PieceUpdateInventoryService pieceUpdateInventoryService;
-  public PieceDeleteFlowInventoryManager(InventoryItemManager inventoryItemManager,
+  public PieceDeleteFlowInventoryManager(PieceDeleteInventoryService pieceDeleteInventoryService,
                                          PieceUpdateInventoryService pieceUpdateInventoryService) {
-    this.inventoryItemManager = inventoryItemManager;
+    this.pieceDeleteInventoryService = pieceDeleteInventoryService;
     this.pieceUpdateInventoryService = pieceUpdateInventoryService;
   }
 
   public Future<Pair<String, String>> processInventory(PieceDeletionHolder holder, RequestContext requestContext) {
     var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, holder.getPieceToDelete().getReceivingTenantId());
-    return deleteItem(holder, locationContext)
+    return pieceDeleteInventoryService.deleteItem(holder, locationContext)
       .compose(aVoid -> holder.isDeleteHolding()
           ? pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), locationContext)
           : Future.succeededFuture()
       );
-  }
-
-  private Future<Void> deleteItem(PieceDeletionHolder holder, RequestContext requestContext) {
-    var piece = holder.getPieceToDelete();
-    return getOnOrderItemForPiece(piece, requestContext)
-      .compose(item -> Optional.ofNullable(item)
-        .map(mItem -> inventoryItemManager.deleteItem(piece.getItemId(), true, requestContext))
-        .orElse(Future.succeededFuture()));
-  }
-
-  private Future<JsonObject> getOnOrderItemForPiece(Piece piece, RequestContext requestContext) {
-    return StringUtils.isEmpty(piece.getItemId())
-      ? Future.succeededFuture()
-      : inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
-          .map(item -> getItemWithStatus(item, ItemStatus.ON_ORDER.value()));
-  }
-
-  private JsonObject getItemWithStatus(JsonObject item, String status) {
-    return Optional.ofNullable(item)
-      .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
-      .filter(itemStatus -> status.equalsIgnoreCase(itemStatus.getString(ITEM_STATUS_NAME)))
-      .orElse(null);
   }
 
 }

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
@@ -48,14 +48,14 @@ public class PieceDeleteFlowInventoryManager {
     return StringUtils.isEmpty(piece.getItemId())
       ? Future.succeededFuture()
       : inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
-          .map(item -> isItemWithStatus(item, ItemStatus.ON_ORDER.value()) ? item : null);
+          .map(item -> getItemWithStatus(item, ItemStatus.ON_ORDER.value()));
   }
 
-  private boolean isItemWithStatus(JsonObject item, String status) {
+  private JsonObject getItemWithStatus(JsonObject item, String status) {
     return Optional.ofNullable(item)
       .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
       .filter(itemStatus -> status.equalsIgnoreCase(itemStatus.getString(ITEM_STATUS_NAME)))
-      .isPresent();
+      .orElse(null);
   }
 
 }

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
@@ -1,0 +1,59 @@
+package org.folio.service.pieces.flows.delete;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.models.ItemStatus;
+import org.folio.models.pieces.PieceDeletionHolder;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.service.inventory.InventoryItemManager;
+import org.folio.service.pieces.PieceUpdateInventoryService;
+
+import java.util.Optional;
+
+import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS;
+import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS_NAME;
+
+public class PieceDeleteFlowInventoryManager {
+
+  private final InventoryItemManager inventoryItemManager;
+  private final PieceUpdateInventoryService pieceUpdateInventoryService;
+  public PieceDeleteFlowInventoryManager(InventoryItemManager inventoryItemManager,
+                                         PieceUpdateInventoryService pieceUpdateInventoryService) {
+    this.inventoryItemManager = inventoryItemManager;
+    this.pieceUpdateInventoryService = pieceUpdateInventoryService;
+  }
+
+  public Future<Pair<String, String>> processInventory(PieceDeletionHolder holder, RequestContext requestContext) {
+    return deleteItem(holder, requestContext)
+      .compose(aVoid -> holder.isDeleteHolding()
+          ? pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), requestContext)
+          : Future.succeededFuture()
+      );
+  }
+
+  private Future<Void> deleteItem(PieceDeletionHolder holder, RequestContext requestContext) {
+    var piece = holder.getPieceToDelete();
+    return getOnOrderItemForPiece(piece, requestContext)
+      .compose(item -> Optional.ofNullable(item)
+        .map(mItem -> inventoryItemManager.deleteItem(piece.getItemId(), true, requestContext))
+        .orElse(Future.succeededFuture()));
+  }
+
+  private Future<JsonObject> getOnOrderItemForPiece(Piece piece, RequestContext requestContext) {
+    return StringUtils.isEmpty(piece.getItemId())
+      ? Future.succeededFuture()
+      : inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
+          .map(item -> isItemWithStatus(item, ItemStatus.ON_ORDER.value()) ? item : null);
+  }
+
+  private boolean isItemWithStatus(JsonObject item, String status) {
+    return Optional.ofNullable(item)
+      .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
+      .filter(itemStatus -> status.equalsIgnoreCase(itemStatus.getString(ITEM_STATUS_NAME)))
+      .isPresent();
+  }
+
+}

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowInventoryManager.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.models.ItemStatus;
 import org.folio.models.pieces.PieceDeletionHolder;
+import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.service.inventory.InventoryItemManager;
@@ -27,9 +28,10 @@ public class PieceDeleteFlowInventoryManager {
   }
 
   public Future<Pair<String, String>> processInventory(PieceDeletionHolder holder, RequestContext requestContext) {
-    return deleteItem(holder, requestContext)
+    var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, holder.getPieceToDelete().getReceivingTenantId());
+    return deleteItem(holder, locationContext)
       .compose(aVoid -> holder.isDeleteHolding()
-          ? pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), requestContext)
+          ? pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), locationContext)
           : Future.succeededFuture()
       );
   }

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -1,23 +1,15 @@
 package org.folio.service.pieces.flows.delete;
 
 import static org.folio.orders.utils.ProtectedOperationType.DELETE;
-import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS;
-import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS_NAME;
-
-import java.util.Optional;
 
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.models.ItemStatus;
 import org.folio.models.pieces.PieceDeletionHolder;
 import org.folio.rest.RestConstants;
 import org.folio.rest.core.exceptions.ErrorCodes;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
-import org.folio.rest.jaxrs.model.Piece;
 import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.ProtectionService;
 import org.folio.service.inventory.InventoryItemManager;
@@ -26,31 +18,27 @@ import org.folio.service.pieces.PieceUpdateInventoryService;
 import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
 
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 
 public class PieceDeleteFlowManager {
 
   private static final Logger logger = LogManager.getLogger(PieceDeleteFlowManager.class);
 
+  private final PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager;
   private final PieceStorageService pieceStorageService;
   private final ProtectionService protectionService;
-  private final InventoryItemManager inventoryItemManager;
-  private final PieceUpdateInventoryService pieceUpdateInventoryService;
   private final PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService;
   private final BasePieceFlowHolderBuilder basePieceFlowHolderBuilder;
   private final CirculationRequestsRetriever circulationRequestsRetriever;
 
-  public PieceDeleteFlowManager(PieceStorageService pieceStorageService,
+  public PieceDeleteFlowManager(PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager,
+                                PieceStorageService pieceStorageService,
                                 ProtectionService protectionService,
-                                InventoryItemManager inventoryItemManager,
-                                PieceUpdateInventoryService pieceUpdateInventoryService,
                                 PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService,
                                 BasePieceFlowHolderBuilder basePieceFlowHolderBuilder,
                                 CirculationRequestsRetriever circulationRequestsRetriever) {
+    this.pieceDeleteFlowInventoryManager = pieceDeleteFlowInventoryManager;
     this.pieceStorageService = pieceStorageService;
     this.protectionService = protectionService;
-    this.inventoryItemManager = inventoryItemManager;
-    this.pieceUpdateInventoryService = pieceUpdateInventoryService;
     this.pieceDeleteFlowPoLineService = pieceDeleteFlowPoLineService;
     this.basePieceFlowHolderBuilder = basePieceFlowHolderBuilder;
     this.circulationRequestsRetriever = circulationRequestsRetriever;
@@ -64,7 +52,7 @@ public class PieceDeleteFlowManager {
       .compose(aVoid -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .compose(aVoid -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), DELETE, requestContext))
       .compose(aVoid -> isDeletePieceRequestValid(holder, requestContext))
-      .compose(aVoid -> processInventory(holder, requestContext))
+      .compose(aVoid -> pieceDeleteFlowInventoryManager.processInventory(holder, requestContext))
       .compose(pair -> updatePoLine(holder, requestContext))
       .compose(aVoid -> pieceStorageService.deletePiece(holder.getPieceToDelete().getId(), true, requestContext));
   }
@@ -87,14 +75,6 @@ public class PieceDeleteFlowManager {
       .mapEmpty();
   }
 
-  private Future<Pair<String, String>> processInventory(PieceDeletionHolder holder, RequestContext requestContext) {
-    return deleteItem(holder, requestContext)
-      .compose(aVoid -> holder.isDeleteHolding()
-          ? pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), requestContext)
-          : Future.succeededFuture()
-      );
-  }
-
   protected Future<Void> updatePoLine(PieceDeletionHolder holder, RequestContext requestContext) {
     var comPOL = holder.getOriginPoLine();
     return BooleanUtils.isTrue(comPOL.getIsPackage()) || BooleanUtils.isTrue(comPOL.getCheckinItems())
@@ -102,25 +82,4 @@ public class PieceDeleteFlowManager {
       : pieceDeleteFlowPoLineService.updatePoLine(holder, requestContext);
   }
 
-  private Future<Void> deleteItem(PieceDeletionHolder holder, RequestContext requestContext) {
-    var piece = holder.getPieceToDelete();
-    return getOnOrderItemForPiece(piece, requestContext)
-      .compose(item -> Optional.ofNullable(item)
-        .map(mItem -> inventoryItemManager.deleteItem(piece.getItemId(), true, requestContext))
-        .orElse(Future.succeededFuture()));
-  }
-
-  private boolean isItemWithStatus(JsonObject item, String status) {
-    return Optional.ofNullable(item)
-      .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
-      .filter(itemStatus -> status.equalsIgnoreCase(itemStatus.getString(ITEM_STATUS_NAME)))
-      .isPresent();
-  }
-
-  private Future<JsonObject> getOnOrderItemForPiece(Piece piece, RequestContext requestContext) {
-    return StringUtils.isEmpty(piece.getItemId())
-      ? Future.succeededFuture()
-      : inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
-          .map(item -> isItemWithStatus(item, ItemStatus.ON_ORDER.value()) ? item : null);
-  }
 }

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -12,9 +12,7 @@ import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.ProtectionService;
-import org.folio.service.inventory.InventoryItemManager;
 import org.folio.service.pieces.PieceStorageService;
-import org.folio.service.pieces.PieceUpdateInventoryService;
 import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
 
 import io.vertx.core.Future;

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -2,7 +2,6 @@ package org.folio.service.pieces.flows.delete;
 
 import static org.folio.orders.utils.ProtectedOperationType.DELETE;
 
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.models.pieces.PieceDeletionHolder;
@@ -75,7 +74,7 @@ public class PieceDeleteFlowManager {
 
   protected Future<Void> updatePoLine(PieceDeletionHolder holder, RequestContext requestContext) {
     var comPOL = holder.getOriginPoLine();
-    return BooleanUtils.isTrue(comPOL.getIsPackage()) || BooleanUtils.isTrue(comPOL.getCheckinItems())
+    return Boolean.TRUE.equals(comPOL.getIsPackage()) || Boolean.TRUE.equals(comPOL.getCheckinItems())
       ? Future.succeededFuture()
       : pieceDeleteFlowPoLineService.updatePoLine(holder, requestContext);
   }

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -4,11 +4,9 @@ import static org.folio.orders.utils.ProtectedOperationType.DELETE;
 import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS;
 import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS_NAME;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -19,8 +17,6 @@ import org.folio.rest.RestConstants;
 import org.folio.rest.core.exceptions.ErrorCodes;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
-import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.ProtectionService;
@@ -33,6 +29,7 @@ import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
 public class PieceDeleteFlowManager {
+
   private static final Logger logger = LogManager.getLogger(PieceDeleteFlowManager.class);
 
   private final PieceStorageService pieceStorageService;
@@ -62,11 +59,9 @@ public class PieceDeleteFlowManager {
   public Future<Void> deletePiece(String pieceId, boolean deleteHolding, RequestContext requestContext) {
     PieceDeletionHolder holder = new PieceDeletionHolder().withDeleteHolding(deleteHolding);
     return pieceStorageService.getPieceById(pieceId, requestContext)
-      .map(pieceToDelete -> {
-        holder.withPieceToDelete(pieceToDelete); return null;
-      })
+      .map(holder::withPieceToDelete)
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext))
-      .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
+      .compose(aVoid -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .compose(aVoid -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), DELETE, requestContext))
       .compose(aVoid -> isDeletePieceRequestValid(holder, requestContext))
       .compose(aVoid -> processInventory(holder, requestContext))
@@ -75,76 +70,57 @@ public class PieceDeleteFlowManager {
   }
 
   private Future<Void> isDeletePieceRequestValid(PieceDeletionHolder holder, RequestContext requestContext) {
-    List<Error> combinedErrors = new ArrayList<>();
-    if (holder.getPieceToDelete().getItemId() != null) {
-      return circulationRequestsRetriever.getNumberOfRequestsByItemId(holder.getPieceToDelete().getItemId(), requestContext)
-        .map(numOfRequests -> {
-          if (numOfRequests != null && numOfRequests > 0) {
-            combinedErrors.add(ErrorCodes.REQUEST_FOUND.toError());
-          }
-          return null;
-        })
-        .map(v -> {
-          if (CollectionUtils.isNotEmpty(combinedErrors)) {
-            Errors errors = new Errors().withErrors(combinedErrors).withTotalRecords(combinedErrors.size());
-            logger.error("Validation error : " + JsonObject.mapFrom(errors).encodePrettily());
-            throw new HttpException(RestConstants.VALIDATION_ERROR, errors);
-          }
-          return null;
-        })
-      .mapEmpty();
+    var piece = holder.getPieceToDelete();
+    if (piece.getItemId() == null) {
+      return Future.succeededFuture();
     }
-    return Future.succeededFuture();
+
+    return circulationRequestsRetriever.getNumberOfRequestsByItemId(piece.getItemId(), requestContext)
+      .compose(totalRequests -> {
+        if (totalRequests != null && totalRequests > 0) {
+          logger.error("isDeletePieceRequestValid:: {} Request(s) were found for the given item {} when deleting piece {}",
+            totalRequests, piece.getItemId(), piece.getId());
+          throw new HttpException(RestConstants.VALIDATION_ERROR, ErrorCodes.REQUEST_FOUND.toError());
+        }
+        return Future.succeededFuture();
+      })
+      .mapEmpty();
   }
 
   private Future<Pair<String, String>> processInventory(PieceDeletionHolder holder, RequestContext requestContext) {
     return deleteItem(holder, requestContext)
-               .compose(aVoid -> {
-                 if (holder.isDeleteHolding()) {
-                   return pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), requestContext);
-                 }
-                 return Future.succeededFuture();
-               });
+      .compose(aVoid -> holder.isDeleteHolding()
+          ? pieceUpdateInventoryService.deleteHoldingConnectedToPiece(holder.getPieceToDelete(), requestContext)
+          : Future.succeededFuture()
+      );
   }
 
   protected Future<Void> updatePoLine(PieceDeletionHolder holder, RequestContext requestContext) {
-    if (!Boolean.TRUE.equals(holder.getOriginPoLine().getIsPackage()) && !Boolean.TRUE.equals(holder.getOriginPoLine().getCheckinItems())) {
-      return  pieceDeleteFlowPoLineService.updatePoLine(holder, requestContext);
-    }
-    return Future.succeededFuture();
+    var comPOL = holder.getOriginPoLine();
+    return BooleanUtils.isTrue(comPOL.getIsPackage()) || BooleanUtils.isTrue(comPOL.getCheckinItems())
+      ? Future.succeededFuture()
+      : pieceDeleteFlowPoLineService.updatePoLine(holder, requestContext);
   }
 
   private Future<Void> deleteItem(PieceDeletionHolder holder, RequestContext requestContext) {
-    Piece piece = holder.getPieceToDelete();
-    if (piece.getItemId() != null) {
-      return getOnOrderItemForPiece(piece, requestContext).compose(item -> {
-        if (item != null) {
-          return inventoryItemManager.deleteItem(piece.getItemId(), true, requestContext);
-        }
-        return Future.succeededFuture();
-      });
-    }
-    return Future.succeededFuture();
+    var piece = holder.getPieceToDelete();
+    return getOnOrderItemForPiece(piece, requestContext)
+      .compose(item -> Optional.ofNullable(item)
+        .map(mItem -> inventoryItemManager.deleteItem(piece.getItemId(), true, requestContext))
+        .orElse(Future.succeededFuture()));
   }
 
   private boolean isItemWithStatus(JsonObject item, String status) {
-    return Optional.ofNullable(item).map(itemP -> item.getJsonObject(ITEM_STATUS))
+    return Optional.ofNullable(item)
+      .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
       .filter(itemStatus -> status.equalsIgnoreCase(itemStatus.getString(ITEM_STATUS_NAME)))
       .isPresent();
   }
 
   private Future<JsonObject> getOnOrderItemForPiece(Piece piece, RequestContext requestContext) {
-    if (StringUtils.isNotEmpty(piece.getItemId())) {
-      return inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
-        .map(item -> {
-          boolean isOnOrderItem = isItemWithStatus(item, ItemStatus.ON_ORDER.value());
-          if (isOnOrderItem) {
-            return item;
-          }
-          return null;
-        });
-    } else {
-      return Future.succeededFuture();
-    }
+    return StringUtils.isEmpty(piece.getItemId())
+      ? Future.succeededFuture()
+      : inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
+          .map(item -> isItemWithStatus(item, ItemStatus.ON_ORDER.value()) ? item : null);
   }
 }

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -1,5 +1,6 @@
 package org.folio.service.pieces.flows.update;
 
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 import static org.folio.service.inventory.InventoryItemManager.ID;
 import static org.folio.service.inventory.InventoryItemManager.ITEM_HOLDINGS_RECORD_ID;
 import static org.folio.service.inventory.InventoryItemManager.ITEM_PURCHASE_ORDER_LINE_IDENTIFIER;
@@ -12,7 +13,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.models.pieces.PieceUpdateHolder;
 import org.folio.orders.utils.PoLineCommonUtil;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Location;
@@ -47,7 +47,7 @@ public class PieceUpdateFlowInventoryManager {
   }
 
   public Future<Void> processInventory(PieceUpdateHolder holder, RequestContext requestContext) {
-    final var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, holder.getPieceToUpdate().getReceivingTenantId());
+    final var locationContext = createContextWithNewTenantId(requestContext, holder.getPieceToUpdate().getReceivingTenantId());
     return inventoryItemManager.updateItemWithPieceFields(holder.getPieceToUpdate(), locationContext)
       .compose(v -> updateInventoryForPoLine(holder, locationContext, requestContext)
           .map(holder::withInstanceId)

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -63,7 +63,7 @@ public class PieceUpdateFlowInventoryManager {
     Piece pieceToUpdate = holder.getPieceToUpdate();
     if (BooleanUtils.isNotTrue(poLineToSave.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(poLineToSave))
-        .orElse(titlesService.updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext))
+        .orElseGet(() -> titlesService.updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext))
         .map(instanceId -> poLineToSave.withInstanceId(instanceId).getInstanceId());
     }
     return titlesService.updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -98,7 +98,7 @@ public class PieceUpdateFlowInventoryManager {
     return inventoryHoldingManager.createHoldingAndReturnId(instanceId, pieceToUpdate.getLocationId(), requestContext)
       .map(holdingId -> {
         if (holdingId != null) {
-          pieceToUpdate.withHoldingId(null).setHoldingId(holdingId);
+          pieceToUpdate.withLocationId(null).setHoldingId(holdingId);
           location.withLocationId(null).setHoldingId(holdingId);
         }
         return location;

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -7,7 +7,6 @@ import static org.folio.service.inventory.InventoryItemManager.ITEM_PURCHASE_ORD
 
 import java.util.Optional;
 
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,7 +62,7 @@ public class PieceUpdateFlowInventoryManager {
   private Future<String> updateInventoryForPoLine(PieceUpdateHolder holder, RequestContext locationContext, RequestContext requestContext) {
     CompositePoLine poLineToSave = holder.getPoLineToSave();
     Piece pieceToUpdate = holder.getPieceToUpdate();
-    if (BooleanUtils.isNotTrue(poLineToSave.getIsPackage())) {
+    if (!Boolean.TRUE.equals(poLineToSave.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(poLineToSave))
         .orElseGet(() -> titlesService.updateTitleWithInstance(pieceToUpdate.getTitleId(), locationContext, requestContext))
         .map(instanceId -> poLineToSave.withInstanceId(instanceId).getInstanceId());

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -62,7 +62,7 @@ public class PieceUpdateFlowInventoryManager {
   private Future<String> updateInventoryForPoLine(PieceUpdateHolder holder, RequestContext locationContext, RequestContext requestContext) {
     CompositePoLine poLineToSave = holder.getPoLineToSave();
     Piece pieceToUpdate = holder.getPieceToUpdate();
-    if (!Boolean.TRUE.equals(poLineToSave.getIsPackage())) {
+    if (Boolean.FALSE.equals(poLineToSave.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(poLineToSave))
         .orElseGet(() -> titlesService.updateTitleWithInstance(pieceToUpdate.getTitleId(), locationContext, requestContext))
         .map(instanceId -> poLineToSave.withInstanceId(instanceId).getInstanceId());

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -62,7 +62,7 @@ public class PieceUpdateFlowInventoryManager {
   private Future<String> updateInventoryForPoLine(PieceUpdateHolder holder, RequestContext locationContext, RequestContext requestContext) {
     CompositePoLine poLineToSave = holder.getPoLineToSave();
     Piece pieceToUpdate = holder.getPieceToUpdate();
-    if (Boolean.FALSE.equals(poLineToSave.getIsPackage())) {
+    if (!Boolean.TRUE.equals(poLineToSave.getIsPackage())) {
       return Optional.ofNullable(getPoLineInstanceId(poLineToSave))
         .orElseGet(() -> titlesService.updateTitleWithInstance(pieceToUpdate.getTitleId(), locationContext, requestContext))
         .map(instanceId -> poLineToSave.withInstanceId(instanceId).getInstanceId());

--- a/src/main/java/org/folio/service/titles/TitleInstanceService.java
+++ b/src/main/java/org/folio/service/titles/TitleInstanceService.java
@@ -33,7 +33,8 @@ public class TitleInstanceService {
   private Future<String> createInventoryInstance(String shadowInstId, Title title, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
     if (shadowInstId != null) {
       return Future.succeededFuture(shadowInstId);
-    } else if (title.getInstanceId() != null) {
+    }
+    if (title.getInstanceId() != null) {
       return Future.succeededFuture(title.getInstanceId());
     }
     return inventoryInstanceManager.getOrCreateInstanceRecord(title, isInstanceMatchingDisabled, requestContext);

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.orders.utils.ProtectedOperationType;
+import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
@@ -131,13 +132,13 @@ public class TitlesService {
     return compositePoLines.stream().filter(line -> !line.getIsPackage()).map(CompositePoLine::getId).collect(toList());
   }
 
-  public Future<String> updateTitleWithInstance(String titleId, RequestContext requestContext) {
+  public Future<String> updateTitleWithInstance(String titleId, RequestContext locationContext, RequestContext requestContext) {
     return getTitleById(titleId, requestContext)
-      .compose(title -> updateTitleWithInstance(title, false, requestContext));
+      .compose(title -> updateTitleWithInstance(title, false, locationContext, requestContext));
   }
 
-  public Future<String> updateTitleWithInstance(Title title, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
-    return titleInstanceService.getOrCreateInstance(title, isInstanceMatchingDisabled, requestContext)
+  public Future<String> updateTitleWithInstance(Title title, boolean isInstanceMatchingDisabled, RequestContext locationContext, RequestContext requestContext) {
+    return titleInstanceService.getOrCreateInstance(title, isInstanceMatchingDisabled, locationContext)
       .map(title::withInstanceId)
       .compose(entity -> saveTitle(entity, requestContext)
         .map(v -> entity.getInstanceId()));

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -136,10 +136,6 @@ public class TitlesService {
       .compose(title -> updateTitleWithInstance(title, false, requestContext));
   }
 
-  public Future<String> updateTitleWithInstance(Title title, RequestContext requestContext) {
-    return updateTitleWithInstance(title, false, requestContext);
-  }
-
   public Future<String> updateTitleWithInstance(Title title, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
     return titleInstanceService.getOrCreateInstance(title, isInstanceMatchingDisabled, requestContext)
       .map(title::withInstanceId)

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -131,6 +131,11 @@ public class TitlesService {
     return compositePoLines.stream().filter(line -> !line.getIsPackage()).map(CompositePoLine::getId).collect(toList());
   }
 
+  public Future<String> updateTitleWithInstance(String titleId, RequestContext requestContext) {
+    return getTitleById(titleId, requestContext)
+      .compose(title -> updateTitleWithInstance(title, false, requestContext));
+  }
+
   public Future<String> updateTitleWithInstance(Title title, RequestContext requestContext) {
     return updateTitleWithInstance(title, false, requestContext);
   }

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.orders.utils.ProtectedOperationType;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
@@ -126,7 +125,6 @@ public class TitlesService {
     List<String> lineIds = getNonPackageLineIds(compPO.getCompositePoLines());
     return getTitlesByPoLineIds(lineIds, requestContext);
   }
-
 
   private List<String> getNonPackageLineIds(List<CompositePoLine> compositePoLines) {
     return compositePoLines.stream().filter(line -> !line.getIsPackage()).map(CompositePoLine::getId).collect(toList());

--- a/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
@@ -205,7 +205,7 @@ public class OpenCompositeOrderPieceServiceTest {
     SharingInstance sharingInstance = new SharingInstance(UUID.randomUUID(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), anyBoolean(), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), anyBoolean(), eq(requestContext), eq(requestContext));
 
     doReturn(succeededFuture(sharingInstance))
       .when(inventoryInstanceManager).createShadowInstanceIfNeeded(eq(instanceId), any(String.class), eq(requestContext));
@@ -238,7 +238,7 @@ public class OpenCompositeOrderPieceServiceTest {
 
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
     doReturn(succeededFuture(itemId)).when(inventoryItemManager).openOrderCreateItemRecord(line, holdingId, requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), anyBoolean(), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), anyBoolean(), eq(requestContext), eq(requestContext));
 
     //When
     openCompositeOrderPieceService.openOrderUpdateInventory(line, piece, false, requestContext).result();

--- a/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManagerTest.java
@@ -115,7 +115,7 @@ public class PieceCreateFlowInventoryManagerTest {
     String instanceId = UUID.randomUUID().toString();
 
     Title title = new Title().withId(titleId).withPoLineId(lineId).withInstanceId(instanceId);
-    Piece piece = new Piece().withId(pieceId).withPoLineId(lineId).withHoldingId(holdingId).withFormat(Piece.Format.ELECTRONIC);
+    Piece piece = new Piece().withId(pieceId).withTitleId(titleId).withPoLineId(lineId).withHoldingId(holdingId).withFormat(Piece.Format.ELECTRONIC);
     Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1)
       .withListUnitPrice(1d).withExchangeRate(1d).withCurrency("USD")
@@ -129,7 +129,6 @@ public class PieceCreateFlowInventoryManagerTest {
 
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
     doReturn(succeededFuture(List.of(piece))).when(pieceStorageService).getPiecesByHoldingId(piece.getId(), requestContext);
-    doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
     doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(piece, requestContext);
@@ -143,7 +142,7 @@ public class PieceCreateFlowInventoryManagerTest {
 
     assertEquals(itemId, piece.getItemId());
     assertEquals(holdingId, piece.getHoldingId());
-    verify(titlesService).getTitleById(piece.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext);
 
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }
@@ -158,7 +157,7 @@ public class PieceCreateFlowInventoryManagerTest {
     String instanceId = UUID.randomUUID().toString();
 
     Title title = new Title().withId(titleId).withPoLineId(lineId).withInstanceId(instanceId);
-    Piece piece = new Piece().withId(pieceId).withPoLineId(lineId).withLocationId(locationId).withFormat(Piece.Format.ELECTRONIC);
+    Piece piece = new Piece().withId(pieceId).withTitleId(titleId).withPoLineId(lineId).withLocationId(locationId).withFormat(Piece.Format.ELECTRONIC);
     Location loc = new Location().withLocationId(locationId).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1)
       .withListUnitPrice(1d).withExchangeRate(1d).withCurrency("USD")
@@ -171,7 +170,6 @@ public class PieceCreateFlowInventoryManagerTest {
       .withLocations(List.of(loc)).withCost(cost);
     CompositePurchaseOrder compositePurchaseOrder = new CompositePurchaseOrder().withId(orderId).withCompositePoLines(List.of(compPOL));
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
-    doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
     doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(piece).withCreateItem(true);
@@ -184,7 +182,7 @@ public class PieceCreateFlowInventoryManagerTest {
     assertNull(piece.getItemId());
     assertNull(piece.getHoldingId());
     assertEquals(locationId, piece.getLocationId());
-    verify(titlesService).getTitleById(piece.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext);
 
     verify(pieceUpdateInventoryService, times(0)).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }
@@ -200,7 +198,7 @@ public class PieceCreateFlowInventoryManagerTest {
     String instanceId = UUID.randomUUID().toString();
 
     Title title = new Title().withId(titleId).withPoLineId(lineId).withInstanceId(instanceId);
-    Piece piece = new Piece().withId(pieceId).withPoLineId(lineId).withLocationId(locationId).withFormat(Piece.Format.ELECTRONIC);
+    Piece piece = new Piece().withId(pieceId).withTitleId(titleId).withPoLineId(lineId).withLocationId(locationId).withFormat(Piece.Format.ELECTRONIC);
     Location loc = new Location().withLocationId(locationId).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1)
       .withListUnitPrice(1d).withExchangeRate(1d).withCurrency("USD")
@@ -212,7 +210,6 @@ public class PieceCreateFlowInventoryManagerTest {
       .withLocations(List.of(loc)).withCost(cost);
     CompositePurchaseOrder compositePurchaseOrder = new CompositePurchaseOrder().withId(orderId).withCompositePoLines(List.of(compPOL));
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
-    doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
     doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(piece).withCreateItem(true);
@@ -225,7 +222,7 @@ public class PieceCreateFlowInventoryManagerTest {
     assertNull(piece.getItemId());
     assertNull(piece.getHoldingId());
     assertEquals(locationId, piece.getLocationId());
-    verify(titlesService).getTitleById(piece.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext);
 
     verify(pieceUpdateInventoryService, times(0)).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }

--- a/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManagerTest.java
@@ -130,7 +130,7 @@ public class PieceCreateFlowInventoryManagerTest {
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
     doReturn(succeededFuture(List.of(piece))).when(pieceStorageService).getPiecesByHoldingId(piece.getId(), requestContext);
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(piece, requestContext);
 
@@ -172,7 +172,7 @@ public class PieceCreateFlowInventoryManagerTest {
     CompositePurchaseOrder compositePurchaseOrder = new CompositePurchaseOrder().withId(orderId).withCompositePoLines(List.of(compPOL));
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(piece).withCreateItem(true);
     holder.withOrderInformation(compositePurchaseOrder);
@@ -213,7 +213,7 @@ public class PieceCreateFlowInventoryManagerTest {
     CompositePurchaseOrder compositePurchaseOrder = new CompositePurchaseOrder().withId(orderId).withCompositePoLines(List.of(compPOL));
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(piece.getTitleId(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(piece).withCreateItem(true);
     holder.withOrderInformation(compositePurchaseOrder);

--- a/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManagerTest.java
@@ -129,7 +129,7 @@ public class PieceCreateFlowInventoryManagerTest {
 
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
     doReturn(succeededFuture(List.of(piece))).when(pieceStorageService).getPiecesByHoldingId(piece.getId(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(piece, requestContext);
 
@@ -142,7 +142,7 @@ public class PieceCreateFlowInventoryManagerTest {
 
     assertEquals(itemId, piece.getItemId());
     assertEquals(holdingId, piece.getHoldingId());
-    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext, requestContext);
 
     verify(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }
@@ -170,7 +170,7 @@ public class PieceCreateFlowInventoryManagerTest {
       .withLocations(List.of(loc)).withCost(cost);
     CompositePurchaseOrder compositePurchaseOrder = new CompositePurchaseOrder().withId(orderId).withCompositePoLines(List.of(compPOL));
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(piece).withCreateItem(true);
     holder.withOrderInformation(compositePurchaseOrder);
@@ -182,7 +182,7 @@ public class PieceCreateFlowInventoryManagerTest {
     assertNull(piece.getItemId());
     assertNull(piece.getHoldingId());
     assertEquals(locationId, piece.getLocationId());
-    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext, requestContext);
 
     verify(pieceUpdateInventoryService, times(0)).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }
@@ -210,7 +210,7 @@ public class PieceCreateFlowInventoryManagerTest {
       .withLocations(List.of(loc)).withCost(cost);
     CompositePurchaseOrder compositePurchaseOrder = new CompositePurchaseOrder().withId(orderId).withCompositePoLines(List.of(compPOL));
     doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(pieceId, requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(piece).withCreateItem(true);
     holder.withOrderInformation(compositePurchaseOrder);
@@ -222,7 +222,7 @@ public class PieceCreateFlowInventoryManagerTest {
     assertNull(piece.getItemId());
     assertNull(piece.getHoldingId());
     assertEquals(locationId, piece.getLocationId());
-    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(piece.getTitleId(), requestContext, requestContext);
 
     verify(pieceUpdateInventoryService, times(0)).manualPieceFlowCreateItemRecord(piece, compPOL, requestContext);
   }

--- a/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
@@ -49,6 +49,7 @@ import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.ProtectionService;
 import org.folio.service.inventory.InventoryHoldingManager;
 import org.folio.service.inventory.InventoryItemManager;
+import org.folio.service.pieces.PieceDeleteInventoryService;
 import org.folio.service.pieces.PieceStorageService;
 import org.folio.service.pieces.PieceUpdateInventoryService;
 import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
@@ -409,9 +410,14 @@ public class PieceDeleteFlowManagerTest {
     }
 
     @Bean
-    PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager(InventoryItemManager inventoryItemManager,
+    PieceDeleteInventoryService pieceDeleteInventoryService(InventoryItemManager inventoryItemManager) {
+      return new PieceDeleteInventoryService(inventoryItemManager);
+    }
+
+    @Bean
+    PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager(PieceDeleteInventoryService pieceDeleteInventoryService,
                                                                     PieceUpdateInventoryService pieceUpdateInventoryService) {
-      return new PieceDeleteFlowInventoryManager(inventoryItemManager, pieceUpdateInventoryService);
+      return new PieceDeleteFlowInventoryManager(pieceDeleteInventoryService, pieceUpdateInventoryService);
     }
 
     @Bean PieceDeleteFlowManager pieceDeleteFlowManager(PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager,

--- a/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
@@ -408,15 +408,20 @@ public class PieceDeleteFlowManagerTest {
       return mock(CirculationRequestsRetriever.class);
     }
 
-    @Bean PieceDeleteFlowManager pieceDeleteFlowManager(PieceStorageService pieceStorageService,
+    @Bean
+    PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager(InventoryItemManager inventoryItemManager,
+                                                                    PieceUpdateInventoryService pieceUpdateInventoryService) {
+      return new PieceDeleteFlowInventoryManager(inventoryItemManager, pieceUpdateInventoryService);
+    }
+
+    @Bean PieceDeleteFlowManager pieceDeleteFlowManager(PieceDeleteFlowInventoryManager pieceDeleteFlowInventoryManager,
+                                                        PieceStorageService pieceStorageService,
                                                         ProtectionService protectionService,
-                                                        InventoryItemManager inventoryItemManager,
-                                                        PieceUpdateInventoryService pieceUpdateInventoryService,
                                                         PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService,
                                                         BasePieceFlowHolderBuilder basePieceFlowHolderBuilder,
                                                         CirculationRequestsRetriever circulationRequestsRetriever) {
-      return new PieceDeleteFlowManager(pieceStorageService, protectionService, inventoryItemManager,
-        pieceUpdateInventoryService, pieceDeleteFlowPoLineService, basePieceFlowHolderBuilder, circulationRequestsRetriever);
+      return new PieceDeleteFlowManager(pieceDeleteFlowInventoryManager, pieceStorageService, protectionService,
+        pieceDeleteFlowPoLineService, basePieceFlowHolderBuilder, circulationRequestsRetriever);
     }
 
   }

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManagerTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.ApiTestSuite;
 import org.folio.models.ItemStatus;
-import org.folio.models.consortium.SharingInstance;
 import org.folio.models.pieces.PieceUpdateHolder;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Cost;
@@ -152,11 +151,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -201,11 +200,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -251,11 +250,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -304,13 +303,13 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(holding)).when(inventoryHoldingManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
     assertEquals(holdingId, item.getString(ITEM_HOLDINGS_RECORD_ID));
     assertEquals(holder.getPoLineToSave().getId(), item.getString(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER));
-    verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -358,11 +357,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -407,11 +406,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -458,7 +457,7 @@ public class PieceUpdateFlowInventoryManagerTest {
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService, times(0)).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService, times(0)).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -511,7 +510,7 @@ public class PieceUpdateFlowInventoryManagerTest {
 
     assertEquals(holdingId, item.getString(ITEM_HOLDINGS_RECORD_ID));
     assertEquals(holder.getPoLineToSave().getId(), item.getString(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER));
-    verify(titlesService, times(0)).getTitleById(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService, times(0)).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManagerTest.java
@@ -151,11 +151,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -200,11 +200,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -250,11 +250,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -303,13 +303,13 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(holding)).when(inventoryHoldingManager).getHoldingById(holder.getPieceFromStorage().getHoldingId(), true, requestContext);
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
     assertEquals(holdingId, item.getString(ITEM_HOLDINGS_RECORD_ID));
     assertEquals(holder.getPoLineToSave().getId(), item.getString(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER));
-    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -357,11 +357,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -406,11 +406,11 @@ public class PieceUpdateFlowInventoryManagerTest {
     doReturn(succeededFuture(new ArrayList())).when(inventoryItemManager).getItemsByHoldingId(holder.getPieceFromStorage().getHoldingId(), requestContext);
     doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     doReturn(succeededFuture(itemId)).when(pieceUpdateInventoryService).manualPieceFlowCreateItemRecord(pieceToUpdate, holder.getPoLineToSave(), requestContext);
-    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext));
+    doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title.getId()), eq(requestContext), eq(requestContext));
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -457,7 +457,7 @@ public class PieceUpdateFlowInventoryManagerTest {
 
     pieceUpdateFlowInventoryManager.processInventory(holder, requestContext).result();
 
-    verify(titlesService, times(0)).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService, times(0)).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);
@@ -510,7 +510,7 @@ public class PieceUpdateFlowInventoryManagerTest {
 
     assertEquals(holdingId, item.getString(ITEM_HOLDINGS_RECORD_ID));
     assertEquals(holder.getPoLineToSave().getId(), item.getString(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER));
-    verify(titlesService, times(0)).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext);
+    verify(titlesService, times(0)).updateTitleWithInstance(pieceToUpdate.getTitleId(), requestContext, requestContext);
     verify(inventoryHoldingManager, times(0)).getOrCreateHoldingsRecord(eq(holder.getInstanceId()), any(Location.class), eq(requestContext));
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(holder.getPieceFromStorage(), requestContext);
     verify(inventoryItemManager).updateItemWithPieceFields(holder.getPieceToUpdate(), requestContext);


### PR DESCRIPTION
## Purpose
[[MODORDERS-1108] Update PiecesAPI CRUD methods  to process inventory in desired tenant](https://folio-org.atlassian.net/browse/MODORDERS-1108)

## Approach
* Refactor existing classes
* Check for piece receivingTenantId, wherever present, use it to work on inventory items located in a different tenant.
* Keep both tenant contexts in order to be able to work for titles, pieces in the original tenant and also inventory objects in a different one