### PR TITLE
MODORDERS-1102 - Order lines search results do not display fund code for orders created by data import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 ### Bug Fixes
 
 * [MODORDERS-1090](https://folio-org.atlassian.net/browse/MODORDERS-1090) - Quantity = 0 for electronic format orders
+* [MODORDERS-1102](https://folio-org.atlassian.net/browse/MODORDERS-1102) - Order lines search results do not display fund code for orders created by data import
 
 ## 12.8.0 - Released (Quesnelia R1 2024)
 This release focused on fixing several bugs as well as implement new features and upgrading dependent libraries

--- a/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
@@ -192,7 +192,6 @@ public class CreateOrderEventHandler implements EventHandler {
           future.completeExceptionally(result.cause());
         } else {
           Optional<Integer> poLinesLimitOptional = extractPoLinesLimit(dataImportEventPayload);
-          MappingManager.map(dataImportEventPayload, new MappingContext());
 
           RequestContext requestContext = new RequestContext(Vertx.currentContext(), okapiHeaders);
           Future<JsonObject> tenantConfigFuture = configurationEntriesCache.loadConfiguration(ORDER_CONFIG_MODULE_NAME, requestContext);

--- a/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
@@ -549,8 +549,7 @@ public class CreateOrderEventHandler implements EventHandler {
       poLineJson.getJsonArray(POL_FUND_DISTRIBUTION_FIELD).stream()
         .map(JsonObject.class::cast)
         .filter(fundDistributionJson -> isNotEmpty(fundDistributionJson.getString(POL_FUND_ID_FIELD)))
-        .forEach(fundDistribution ->
-          fundDistribution.getMap().put(POL_FUND_CODE_FIELD, determineFundCode(fundDistribution, idToFundName)));
+        .forEach(fundDistribution -> fundDistribution.put(POL_FUND_CODE_FIELD, determineFundCode(fundDistribution, idToFundName)));
     }
   }
 

--- a/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/CreateOrderEventHandler.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.ActionProfile.Action.CREATE;
 import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
 import static org.folio.ActionProfile.FolioRecord.INSTANCE;
@@ -32,6 +33,7 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +47,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -110,6 +113,9 @@ public class CreateOrderEventHandler implements EventHandler {
   private static final String POL_ERESOURCE_FIELD = "eresource";
   private static final String POL_PHYSICAL_FIELD = "physical";
   private static final String POL_CREATE_INVENTORY_FIELD = "createInventory";
+  private static final String POL_FUND_DISTRIBUTION_FIELD = "fundDistribution";
+  private static final String POL_FUND_CODE_FIELD = "code";
+  private static final String POL_FUND_ID_FIELD = "fundId";
   private static final String PO_LINE_KEY = "PO_LINE";
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String JOB_PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
@@ -119,6 +125,8 @@ public class CreateOrderEventHandler implements EventHandler {
   private static final String WORKFLOW_STATUS_PATH = "order.po.workflowStatus";
   private static final String PO_LINE_ORDER_ID_KEY = "purchaseOrderId";
   private static final String DEFAULT_PO_LINES_LIMIT = "1";
+  private static final char LEFT_BRACKET = '(';
+  private static final char RIGHT_BRACKET = ')';
 
   private final PurchaseOrderHelper purchaseOrderHelper;
   private final PurchaseOrderLineHelper poLineHelper;
@@ -508,6 +516,7 @@ public class CreateOrderEventHandler implements EventHandler {
     JsonObject orderJson = mappingResult.getJsonObject(MAPPING_RESULT_FIELD).getJsonObject(ORDER_FIELD);
     JsonObject poLineJson = mappingResult.getJsonObject(MAPPING_RESULT_FIELD).getJsonObject(PO_LINES_FIELD);
     calculateActivationDue(poLineJson);
+    ensureFundCode(poLineJson, dataImportEventPayload);
     dataImportEventPayload.getContext().put(ORDER.value(), orderJson.encode());
 
     if (WorkflowStatus.OPEN.value().equals(orderJson.getString(ORDER_STATUS_FIELD))) {
@@ -531,6 +540,36 @@ public class CreateOrderEventHandler implements EventHandler {
         : 1;
       poLineJson.getJsonObject(POL_ERESOURCE_FIELD).put(POL_ACTIVATION_DUE_FIELD, activationDue);
     }
+  }
+
+  private void ensureFundCode(JsonObject poLineJson, DataImportEventPayload dataImportEventPayload) {
+    if (!IterableUtils.isEmpty(poLineJson.getJsonArray(POL_FUND_DISTRIBUTION_FIELD))) {
+      Map<String, String> idToFundName = extractFundsData(dataImportEventPayload);
+
+      poLineJson.getJsonArray(POL_FUND_DISTRIBUTION_FIELD).stream()
+        .map(JsonObject.class::cast)
+        .filter(fundDistributionJson -> isNotEmpty(fundDistributionJson.getString(POL_FUND_ID_FIELD)))
+        .forEach(fundDistribution ->
+          fundDistribution.getMap().put(POL_FUND_CODE_FIELD, determineFundCode(fundDistribution, idToFundName)));
+    }
+  }
+
+  private Map<String, String> extractFundsData(DataImportEventPayload dataImportEventPayload) {
+    ProfileSnapshotWrapper mappingProfileWrapper = dataImportEventPayload.getCurrentNode();
+    MappingProfile mappingProfile = ObjectMapperTool.getMapper().convertValue(mappingProfileWrapper.getContent(), MappingProfile.class);
+
+    return mappingProfile.getMappingDetails().getMappingFields().stream()
+      .filter(mappingRule -> POL_FUND_DISTRIBUTION_FIELD.equals(mappingRule.getName()) && !mappingRule.getSubfields().isEmpty())
+      .flatMap(mappingRule -> mappingRule.getSubfields().get(0).getFields().stream())
+      .filter(mappingRule -> POL_FUND_ID_FIELD.equals(mappingRule.getName()))
+      .map(mappingRule -> ((Map<String, String>) mappingRule.getAcceptedValues()))
+      .findAny()
+      .orElse(Collections.emptyMap());
+  }
+
+  private String determineFundCode(JsonObject fundDistribution, Map<String, String> idToFundName) {
+    String fundName = idToFundName.get(fundDistribution.getString(POL_FUND_ID_FIELD));
+    return fundName.substring(fundName.lastIndexOf(LEFT_BRACKET) + 1, fundName.lastIndexOf(RIGHT_BRACKET));
   }
 
   private Future<Void> overrideCreateInventoryField(JsonObject poLineJson, DataImportEventPayload dataImportEventPayload) {


### PR DESCRIPTION
## Purpose
to ensure fund code in imported order lines

## Approach
* set po line fund code based on fundId populated during order line mapping
* add test


## Learning
[MODORDERS-1102](https://issues.folio.org/browse/MODORDERS-1102)