### PR TITLE
Fix NPE when order format is P/E Mix

### DIFF
--- a/src/main/java/org/folio/service/routinglists/validators/RoutingListValidatorUtil.java
+++ b/src/main/java/org/folio/service/routinglists/validators/RoutingListValidatorUtil.java
@@ -2,10 +2,10 @@ package org.folio.service.routinglists.validators;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.folio.rest.core.exceptions.ErrorCodes;
 import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.RoutingList;
 import org.folio.rest.jaxrs.model.RoutingListCollection;
@@ -36,7 +36,10 @@ public class RoutingListValidatorUtil {
   }
 
   private static int getQuantityPhysicalTotal(PoLine poLine) {
-    return poLine.getLocations().stream().mapToInt(Location::getQuantityPhysical).sum();
+    return poLine.getLocations()
+      .stream()
+      .mapToInt(loc -> Optional.ofNullable(loc.getQuantityPhysical()).orElse(0))
+      .sum();
   }
 
   private static List<RoutingList> extractDifferentRoutingLists(RoutingList routingList, RoutingListCollection routingListCollection) {

--- a/src/test/java/org/folio/TestUtils.java
+++ b/src/test/java/org/folio/TestUtils.java
@@ -238,7 +238,6 @@ public final class TestUtils {
   public static List<Location> getLocationPhysicalCopies(int n) {
     return List.of(new Location()
       .withLocationId(UUID.randomUUID().toString())
-      .withQuantityElectronic(0)
       .withQuantityPhysical(n)
       .withQuantity(n));
   }

--- a/src/test/java/org/folio/service/routinglists/validators/RoutingListValidatorTest.java
+++ b/src/test/java/org/folio/service/routinglists/validators/RoutingListValidatorTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.RoutingList;
 import org.folio.rest.jaxrs.model.RoutingListCollection;
@@ -56,6 +57,18 @@ public class RoutingListValidatorTest {
   @Test
   void testValidateRoutingListWithPOLineInvalidOrderFormat() {
     samplePoLine.setOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE);
+    RoutingListCollection collection = getRoutingListCollection(1);
+    List<Error> errors = RoutingListValidatorUtil.validateRoutingList(sampleRoutingList, collection, samplePoLine);
+    assertEquals(errors.size(), 1);
+    assertEquals(errors.get(0).getMessage(), INVALID_ROUTING_LIST_FOR_PO_LINE_FORMAT.getDescription());
+  }
+
+  @Test
+  void testValidateRoutingListWithPOLinePEMixOrderFormat() {
+    var locations = new ArrayList<>(samplePoLine.getLocations());
+    locations.add(new Location().withLocationId(UUID.randomUUID().toString()).withQuantityElectronic(1).withQuantity(1));
+    samplePoLine.withOrderFormat(PoLine.OrderFormat.P_E_MIX).withLocations(locations);
+
     RoutingListCollection collection = getRoutingListCollection(1);
     List<Error> errors = RoutingListValidatorUtil.validateRoutingList(sampleRoutingList, collection, samplePoLine);
     assertEquals(errors.size(), 1);

--- a/src/test/java/org/folio/service/routinglists/validators/RoutingListValidatorTest.java
+++ b/src/test/java/org/folio/service/routinglists/validators/RoutingListValidatorTest.java
@@ -70,9 +70,8 @@ public class RoutingListValidatorTest {
     samplePoLine.withOrderFormat(PoLine.OrderFormat.P_E_MIX).withLocations(locations);
 
     RoutingListCollection collection = getRoutingListCollection(1);
-    List<Error> errors = RoutingListValidatorUtil.validateRoutingList(sampleRoutingList, collection, samplePoLine);
-    assertEquals(errors.size(), 1);
-    assertEquals(errors.get(0).getMessage(), INVALID_ROUTING_LIST_FOR_PO_LINE_FORMAT.getDescription());
+    List<Error> errorList = RoutingListValidatorUtil.validateRoutingList(sampleRoutingList, collection, samplePoLine);
+    assertEquals(errorList.size(), 0);
   }
 
   private RoutingListCollection getRoutingListCollection(int n) {


### PR DESCRIPTION
## Purpose
NullPointerException is thrown when the P/E Mix order format is used in PO Line and a routing list is added to it.

## Approach
Add a null check when summing up PO Line location's physical quantities to determine if the routing list can be added or not
