### PR TITLE
[MODORDERS-1112] Sync bind pieces state with newly created item in correct tenant

### DIFF
--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -216,15 +216,12 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
    * @return map passed as a parameter
    */
   protected Future<Map<String, List<Piece>>> storeUpdatedPieceRecords(Map<String, List<Piece>> piecesGroupedByPoLine, RequestContext requestContext) {
-    List<Future<Void>> futures = StreamEx
-      .ofValues(piecesGroupedByPoLine)
-      .flatMap(List::stream)
-      .filter(this::isSuccessfullyProcessedPiece)
-      .map(piece -> piece.withStatusUpdatedDate(new Date()))
-      .map(piece -> storeUpdatedPieceRecord(piece, requestContext))
-      .toList();
-
-    return GenericCompositeFuture.join(futures)
+    return GenericCompositeFuture.join(
+      extractAllPieces(piecesGroupedByPoLine)
+        .filter(this::isSuccessfullyProcessedPiece)
+        .map(piece -> piece.withStatusUpdatedDate(new Date()))
+        .map(piece -> storeUpdatedPieceRecord(piece, requestContext))
+        .toList())
       .map(v -> piecesGroupedByPoLine);
   }
 


### PR DESCRIPTION
## Purpose
[[MODORDERS-1112] Sync bind pieces state with newly created item in correct tenant](https://folio-org.atlassian.net/browse/MODORDERS-1112)

## Approach
After item is created during binding, do following:
* Clear these fields as piece can have these fields populated from previous item: displaySummary, enumeration, copyNumber, chronology, accessionNumber, discoverySuppress
* Populate these fields from bindItem: barcode, callNumber, locationId

## Screenshots
### Pieces before binding:
Display Summary and Barcode are set
![Pasted image 20240523142639](https://github.com/folio-org/mod-orders/assets/148070844/236ddc42-93c9-496c-a49a-7510529f063f)

### Binding call
![Pasted image 20240523142712](https://github.com/folio-org/mod-orders/assets/148070844/4f9c8eb1-7c1f-4d26-9eef-df99bb337adc)

### Pieces after binding:
Display Summary is gone, and Barcode is updated
![Pasted image 20240523143141](https://github.com/folio-org/mod-orders/assets/148070844/7a39f622-9b34-40ea-afd1-a8e11b0fc643)
