### PR TITLE
MODORDERS-1122] Add logic to create item in any tenant for binding

### DIFF
--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -28,6 +28,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.folio.rest.jaxrs.model.BindPiecesCollection.RequestsAction.TRANSFER;
@@ -88,32 +90,39 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
                                                                       RequestContext requestContext) {
     var tenantToItem = mapTenantIdsToItemIds(piecesGroupedByPoLine, requestContext);
     return GenericCompositeFuture.all(
-        tenantToItem.entrySet().stream()
-          .map(entry -> {
-          var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, entry.getKey());
-          return inventoryItemRequestService.getItemsWithActiveRequests(entry.getValue(), locationContext)
-            .compose(items -> {
-              if (items.isEmpty()) {
-                return Future.succeededFuture();
-              }
-
-              // requestsAction is required to handle outstanding requests
-              if (Objects.isNull(bindPiecesCollection.getRequestsAction())) {
-                logger.warn("checkRequestsForPieceItems:: Found outstanding requests on items with ids: {}", items);
-                throw new HttpException(RestConstants.VALIDATION_ERROR, ErrorCodes.REQUESTS_ACTION_REQUIRED);
-              }
-
-              // When requests are to be transferred check if pieces contain different receivingTenantIds
-              // Transferring requests between tenants is not a requirement for R
-              if (bindPiecesCollection.getRequestsAction().equals(TRANSFER) && !tenantToItem.keySet().isEmpty()) {
-                logger.warn("checkRequestsForPieceItems:: All pieces do not have the same receivingTenantId: {}", tenantToItem.keySet());
-                throw new HttpException(RestConstants.VALIDATION_ERROR, ErrorCodes.PIECES_HAVE_DIFFERENT_RECEIVING_TENANT_IDS);
-              }
-              return Future.succeededFuture();
-            });
-          })
-          .toList())
+      tenantToItem.entrySet().stream()
+        .map(entry -> {
+        var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, entry.getKey());
+        return inventoryItemRequestService.getItemsWithActiveRequests(entry.getValue(), locationContext)
+          .compose(items -> validateItemsForRequestTransfer(tenantToItem.keySet(), items, bindPiecesCollection));
+        })
+        .toList())
       .map(f -> piecesGroupedByPoLine);
+  }
+
+  private Future<Void> validateItemsForRequestTransfer(Set<String> tenants,
+                                                       List<String> items,
+                                                       BindPiecesCollection bindPiecesCollection) {
+    if (items.isEmpty()) {
+      return Future.succeededFuture();
+    }
+
+    // requestsAction is required to handle outstanding requests
+    if (Objects.isNull(bindPiecesCollection.getRequestsAction())) {
+      logger.warn("validateItemsForRequestTransfer:: Found outstanding requests on items with ids: {}", items);
+      throw new HttpException(RestConstants.VALIDATION_ERROR, ErrorCodes.REQUESTS_ACTION_REQUIRED);
+    }
+
+    var bindItemTenantId = bindPiecesCollection.getBindItem().getTenantId();
+    var itemsInSameTenant = Optional.ofNullable(bindItemTenantId)
+      .map(tenants::contains).orElse(true) && tenants.size() == 1;
+    // Transferring requests between tenants is not a requirement for R
+    // All items should be in same tenant as the bind item tenantId for requests to be transferred
+    if (TRANSFER.equals(bindPiecesCollection.getRequestsAction()) && !itemsInSameTenant) {
+      logger.warn("validateItemsForRequestTransfer:: All piece items and bindItem must be in same tenant. Pieces: {}, BindItem: {}", tenants, bindItemTenantId);
+      throw new HttpException(RestConstants.VALIDATION_ERROR, ErrorCodes.PIECES_HAVE_DIFFERENT_RECEIVING_TENANT_IDS);
+    }
+    return Future.succeededFuture();
   }
 
   private Map<String, List<Piece>> updatePieceRecords(Map<String, List<Piece>> piecesGroupedByPoLine) {

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -69,7 +69,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
   private Future<ReceivingResults> processBindPieces(BindPiecesCollection bindPiecesCollection, RequestContext requestContext) {
     //   1. Get piece records from storage
     return retrievePieceRecords(requestContext)
-      // 2. Check if there are any "outstanding" requests for items
+      // 2. Check if there are any open requests for items
       .compose(piecesGroupedByPoLine -> checkRequestsForPieceItems(piecesGroupedByPoLine, bindPiecesCollection, requestContext))
       // 3. Update piece isBound flag
       .map(this::updatePieceRecords)
@@ -107,9 +107,9 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
       return Future.succeededFuture();
     }
 
-    // requestsAction is required to handle "outstanding" requests
+    // requestsAction is required to handle open requests
     if (Objects.isNull(bindPiecesCollection.getRequestsAction())) {
-      logger.warn("validateItemsForRequestTransfer:: Found 'outstanding' requests on items with ids: {}", items);
+      logger.warn("validateItemsForRequestTransfer:: Found open requests on items with ids: {}", items);
       throw new HttpException(RestConstants.VALIDATION_ERROR, ErrorCodes.REQUESTS_ACTION_REQUIRED);
     }
 

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -216,15 +216,12 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
    * @return map passed as a parameter
    */
   protected Future<Map<String, List<Piece>>> storeUpdatedPieceRecords(Map<String, List<Piece>> piecesGroupedByPoLine, RequestContext requestContext) {
-    List<Future<Void>> futures = StreamEx
-      .ofValues(piecesGroupedByPoLine)
-      .flatMap(List::stream)
-      .filter(this::isSuccessfullyProcessedPiece)
-      .map(piece -> piece.withStatusUpdatedDate(new Date()))
-      .map(piece -> storeUpdatedPieceRecord(piece, requestContext))
-      .toList();
-
-    return GenericCompositeFuture.join(futures)
+    return GenericCompositeFuture.join(
+        extractAllPieces(piecesGroupedByPoLine)
+          .filter(this::isSuccessfullyProcessedPiece)
+          .map(piece -> piece.withStatusUpdatedDate(new Date()))
+          .map(piece -> storeUpdatedPieceRecord(piece, requestContext))
+          .toList())
       .map(v -> piecesGroupedByPoLine);
   }
 

--- a/src/main/java/org/folio/service/inventory/InventoryItemManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemManager.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.orders.utils.HelperUtils;
+import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.exceptions.InventoryException;
@@ -405,7 +406,8 @@ public class InventoryItemManager {
       .put(ITEM_MATERIAL_TYPE_ID, bindItem.getMaterialTypeId())
       .put(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER, compPOL.getId());
     logger.debug("Creating item for PO Line with '{}' id", compPOL.getId());
-    return createItemInInventory(item, requestContext);
+    var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, bindItem.getTenantId());
+    return createItemInInventory(item, locationContext);
   }
 
   private Future<List<String>> createItemRecords(JsonObject itemRecord, int expectedCount, RequestContext requestContext) {

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -137,7 +137,7 @@ public class CheckinReceivingApiTest {
   private static final String ITEM_STATUS = "status";
   private static final String COMPOSITE_POLINE_ONGOING_ID = "6e2b169a-ebeb-4c3c-a2f2-6233ff9c59ae";
   private static final String COMPOSITE_POLINE_CANCELED_ID = "1196fcd9-7607-447d-ae85-6e91883d7e4f";
-  private static final String OUTSTANDING_REQUEST_ITEM_ID = "f972fa0e-5e84-4a47-a27b-137724a73fee";
+  private static final String OPEN_REQUEST_ITEM_ID = "f972fa0e-5e84-4a47-a27b-137724a73fee";
 
   private static boolean runningOnOwn;
 
@@ -1073,7 +1073,7 @@ public class CheckinReceivingApiTest {
       .withLocations(List.of(new Location().withHoldingId(UUID.randomUUID().toString())
         .withQuantityPhysical(1).withQuantity(1)));
     var bindingPiece = getMinimalContentPiece(poLine.getId())
-      .withItemId(OUTSTANDING_REQUEST_ITEM_ID)
+      .withItemId(OPEN_REQUEST_ITEM_ID)
       .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
     var bindPiecesCollection = new BindPiecesCollection()
@@ -1104,7 +1104,7 @@ public class CheckinReceivingApiTest {
       .withLocations(List.of(new Location().withHoldingId(UUID.randomUUID().toString())
         .withQuantityPhysical(1).withQuantity(1)));
     var bindingPiece = getMinimalContentPiece(poLine.getId())
-      .withItemId(OUTSTANDING_REQUEST_ITEM_ID)
+      .withItemId(OPEN_REQUEST_ITEM_ID)
       .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
     var bindPiecesCollection = new BindPiecesCollection()

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -433,7 +433,7 @@ public class CheckinReceivingApiTest {
 
   @Test
   void testPostCheckInLocationId() {
-   logger.info("=== Test POST Checkin - locationId checking ===");
+    logger.info("=== Test POST Checkin - locationId checking ===");
 
     String poLineId = "fe47e95d-24e9-4a9a-9dc0-bcba64b51f56";
     String pieceId = UUID.randomUUID().toString();
@@ -954,9 +954,9 @@ public class CheckinReceivingApiTest {
         .getReceivedItems()) {
         if (receivedItem.getPieceId()
           .equals(piece.getId())
-            && !receivedItem.getLocationId()
-              .equals(piece.getLocationId())
-            && isHoldingsUpdateRequired(piece, compPOL)) {
+          && !receivedItem.getLocationId()
+          .equals(piece.getLocationId())
+          && isHoldingsUpdateRequired(piece, compPOL)) {
           expectedHoldings.add(getInstanceId(poline) + receivedItem.getLocationId());
         }
       }
@@ -966,7 +966,7 @@ public class CheckinReceivingApiTest {
 
   private boolean isHoldingsUpdateRequired(org.folio.rest.acq.model.Piece piece, CompositePoLine compPOL) {
     if (piece.getFormat() == org.folio.rest.acq.model.Piece.PieceFormat.ELECTRONIC) {
-     return isHoldingUpdateRequiredForEresource(compPOL);
+      return isHoldingUpdateRequiredForEresource(compPOL);
     } else {
       return isHoldingUpdateRequiredForPhysical(compPOL);
     }
@@ -976,24 +976,24 @@ public class CheckinReceivingApiTest {
   void testBindPiecesToTitleWithItem() {
     logger.info("=== Test POST Bind to Title With Item");
 
-    var order = getMinimalContentCompositePurchaseOrder()
-      .withId(UUID.randomUUID().toString());
-    var poLine = getMinimalContentCompositePoLine(order.getId())
-      .withId(UUID.randomUUID().toString());
+    var holdingId = "849241fa-4a14-4df5-b951-846dcd6cfc4d";
+    var receivingStatus = Piece.ReceivingStatus.UNRECEIVABLE;
+    var format = Piece.Format.ELECTRONIC;
 
+    var order = getMinimalContentCompositePurchaseOrder()
+      .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    var poLine = getMinimalContentCompositePoLine(order.getId());
     var bindingPiece1 = getMinimalContentPiece(poLine.getId())
-      .withId(UUID.randomUUID().toString())
-      .withHoldingId("849241fa-4a14-4df5-b951-846dcd6cfc4d")
-      .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
-      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
+      .withHoldingId(holdingId)
+      .withReceivingStatus(receivingStatus)
+      .withFormat(format);
     var bindingPiece2 = getMinimalContentPiece(poLine.getId())
       .withId(UUID.randomUUID().toString())
-      .withHoldingId("849241fa-4a14-4df5-b951-846dcd6cfc4d")
-      .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
-      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
-    var bindItem = getMinimalContentBindItem();
+      .withHoldingId(holdingId)
+      .withReceivingStatus(receivingStatus)
+      .withFormat(format);
 
-    addMockEntry(PURCHASE_ORDER_STORAGE, order.withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN));
+    addMockEntry(PURCHASE_ORDER_STORAGE, order);
     addMockEntry(PO_LINES_STORAGE, poLine);
     addMockEntry(PIECES_STORAGE, bindingPiece1);
     addMockEntry(PIECES_STORAGE, bindingPiece2);
@@ -1001,8 +1001,8 @@ public class CheckinReceivingApiTest {
 
     var bindPiecesCollection = new BindPiecesCollection()
       .withPoLineId(poLine.getId())
-        .withBindItem(bindItem)
-        .withBindPieceIds(List.of(bindingPiece1.getId(), bindingPiece2.getId()));
+      .withBindItem(getMinimalContentBindItem())
+      .withBindPieceIds(List.of(bindingPiece1.getId(), bindingPiece2.getId()));
 
     var response = verifyPostResponse(ORDERS_BIND_ENDPOINT, JsonObject.mapFrom(bindPiecesCollection).encode(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, HttpStatus.HTTP_OK.toInt());
@@ -1011,7 +1011,7 @@ public class CheckinReceivingApiTest {
 
     var pieceUpdates = getPieceUpdates();
 
-    assertThat(pieceUpdates, not(nullValue()));
+    assertThat(pieceUpdates, notNullValue());
     assertThat(pieceUpdates, hasSize(bindPiecesCollection.getBindPieceIds().size()));
 
     var pieceList = pieceUpdates.stream().filter(pol -> {
@@ -1027,24 +1027,24 @@ public class CheckinReceivingApiTest {
   void testBindPiecesWithDifferentHoldingIdAndThrowError() {
     logger.info("=== Test POST Bind with different holdingId to Title With and throw error");
 
-    var order = getMinimalContentCompositePurchaseOrder()
-      .withId(UUID.randomUUID().toString());
-    var poLine = getMinimalContentCompositePoLine(order.getId())
-      .withId(UUID.randomUUID().toString());
+    var holdingId = "849241fa-4a14-4df5-b951-846dcd6cfc4d";
+    var receivingStatus = Piece.ReceivingStatus.UNRECEIVABLE;
+    var format = Piece.Format.ELECTRONIC;
 
+    var order = getMinimalContentCompositePurchaseOrder()
+      .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    var poLine = getMinimalContentCompositePoLine(order.getId());
     var bindingPiece1 = getMinimalContentPiece(poLine.getId())
-      .withId(UUID.randomUUID().toString())
-      .withHoldingId("849241fa-4a14-4df5-b951-846dcd6cfc4d")
-      .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
-      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
+      .withHoldingId(holdingId)
+      .withReceivingStatus(receivingStatus)
+      .withFormat(format);
     var bindingPiece2 = getMinimalContentPiece(poLine.getId())
       .withId(UUID.randomUUID().toString())
       .withHoldingId("64ee33f2-b2b5-4912-942a-50ddea063663")
-      .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
-      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
-    var bindItem = getMinimalContentBindItem();
+      .withReceivingStatus(receivingStatus)
+      .withFormat(format);
 
-    addMockEntry(PURCHASE_ORDER_STORAGE, order.withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN));
+    addMockEntry(PURCHASE_ORDER_STORAGE, order);
     addMockEntry(PO_LINES_STORAGE, poLine);
     addMockEntry(PIECES_STORAGE, bindingPiece1);
     addMockEntry(PIECES_STORAGE, bindingPiece2);
@@ -1052,7 +1052,7 @@ public class CheckinReceivingApiTest {
 
     var bindPiecesCollection = new BindPiecesCollection()
       .withPoLineId(poLine.getId())
-      .withBindItem(bindItem)
+      .withBindItem(getMinimalContentBindItem())
       .withBindPieceIds(List.of(bindingPiece1.getId(), bindingPiece2.getId()));
 
     var errors = verifyPostResponse(ORDERS_BIND_ENDPOINT, JsonObject.mapFrom(bindPiecesCollection).encode(),
@@ -1067,28 +1067,23 @@ public class CheckinReceivingApiTest {
     logger.info("=== Test POST Bind to Title with Item with Outstanding Request");
 
     var order = getMinimalContentCompositePurchaseOrder()
-      .withId(UUID.randomUUID().toString())
       .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     var poLine = getMinimalContentCompositePoLine(order.getId())
-      .withId(UUID.randomUUID().toString())
       .withLocations(List.of(new Location().withHoldingId(UUID.randomUUID().toString())
-      .withQuantityPhysical(1).withQuantity(1)));
-    var title = getTitle(poLine);
+        .withQuantityPhysical(1).withQuantity(1)));
     var bindingPiece = getMinimalContentPiece(poLine.getId())
-      .withId(UUID.randomUUID().toString())
       .withItemId(OUTSTANDING_REQUEST_ITEM_ID)
       .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
       .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
-    var bindItem = getMinimalContentBindItem();
     var bindPiecesCollection = new BindPiecesCollection()
       .withPoLineId(poLine.getId())
-      .withBindItem(bindItem)
+      .withBindItem(getMinimalContentBindItem())
       .withBindPieceIds(List.of(bindingPiece.getId()));
 
     addMockEntry(PURCHASE_ORDER_STORAGE, order);
     addMockEntry(PO_LINES_STORAGE, poLine);
     addMockEntry(PIECES_STORAGE, bindingPiece);
-    addMockEntry(TITLES, title);
+    addMockEntry(TITLES, getTitle(poLine));
 
     var errors = verifyPostResponse(ORDERS_BIND_ENDPOINT, JsonObject.mapFrom(bindPiecesCollection).encode(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, VALIDATION_ERROR)

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -185,7 +185,7 @@ public class CheckinReceivingApiTest {
 
     assertThat(pieceSearches, not(nullValue()));
     assertThat(pieceUpdates, not(nullValue()));
-    assertThat(getItemsSearches(),is(nullValue()));
+    assertThat(getItemsSearches(), is(nullValue()));
     assertThat(getItemUpdates(), is(nullValue()));
     assertThat(polSearches, not(nullValue()));
     assertThat(polUpdates, not(nullValue()));
@@ -1368,9 +1368,9 @@ public class CheckinReceivingApiTest {
 
 
     List<ReceivingItemResult> results = response.getReceivingItemResults();
-    for(ReceivingItemResult r : results) {
+    for (ReceivingItemResult r : results) {
       Error error = r.getProcessingStatus().getError();
-      if(error != null) {
+      if (error != null) {
         assertThat(r.getProcessingStatus().getError().getCode(), equalTo(LOC_NOT_PROVIDED.getCode()));
         assertThat(r.getProcessingStatus().getError().getMessage(), equalTo(LOC_NOT_PROVIDED.getDescription()));
         assertThat(r.getPieceId(), is(in(pieceIds)));

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -85,6 +85,7 @@ import static org.folio.rest.core.exceptions.ErrorCodes.ITEM_NOT_RETRIEVED;
 import static org.folio.rest.core.exceptions.ErrorCodes.ITEM_UPDATE_FAILED;
 import static org.folio.rest.core.exceptions.ErrorCodes.LOC_NOT_PROVIDED;
 import static org.folio.rest.core.exceptions.ErrorCodes.MULTIPLE_NONPACKAGE_TITLES;
+import static org.folio.rest.core.exceptions.ErrorCodes.PIECES_HAVE_DIFFERENT_RECEIVING_TENANT_IDS;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_ALREADY_RECEIVED;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_NOT_FOUND;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_NOT_RETRIEVED;
@@ -1091,6 +1092,39 @@ public class CheckinReceivingApiTest {
       .getErrors();
 
     assertThat(errors.get(0).getMessage(), equalTo(REQUESTS_ACTION_REQUIRED.getDescription()));
+  }
+
+  @Test
+  void testBindPiecesToTitleWithBindItemWithDifferentTenantId() {
+    logger.info("=== Test POST Bind to Title with Item with Outstanding Request");
+
+    var order = getMinimalContentCompositePurchaseOrder()
+      .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    var poLine = getMinimalContentCompositePoLine(order.getId())
+      .withLocations(List.of(new Location().withHoldingId(UUID.randomUUID().toString())
+        .withQuantityPhysical(1).withQuantity(1)));
+    var bindingPiece = getMinimalContentPiece(poLine.getId())
+      .withItemId(OUTSTANDING_REQUEST_ITEM_ID)
+      .withReceivingStatus(Piece.ReceivingStatus.UNRECEIVABLE)
+      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
+    var bindPiecesCollection = new BindPiecesCollection()
+      .withPoLineId(poLine.getId())
+      .withBindItem(getMinimalContentBindItem()
+        .withTenantId("differentTenantId"))
+      .withBindPieceIds(List.of(bindingPiece.getId()))
+      .withRequestsAction(BindPiecesCollection.RequestsAction.TRANSFER);
+
+    addMockEntry(PURCHASE_ORDER_STORAGE, order);
+    addMockEntry(PO_LINES_STORAGE, poLine);
+    addMockEntry(PIECES_STORAGE, bindingPiece);
+    addMockEntry(TITLES, getTitle(poLine));
+
+    var errors = verifyPostResponse(ORDERS_BIND_ENDPOINT, JsonObject.mapFrom(bindPiecesCollection).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, VALIDATION_ERROR)
+      .as(Errors.class)
+      .getErrors();
+
+    assertThat(errors.get(0).getMessage(), equalTo(PIECES_HAVE_DIFFERENT_RECEIVING_TENANT_IDS.getDescription()));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[[MODORDERS-1122] Add logic to create item in any tenant for binding](https://folio-org.atlassian.net/browse/MODORDERS-1122)

## Approach
* Add tenantId to BindItem schema
* If tenantId is present while binding, create item in the specified tenant