### PR TITLE
[MODORDERS-1098] Converting API unit tests - part 3

### DIFF
--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -24,6 +24,7 @@ import org.folio.rest.core.ResponseUtilTest;
 import org.folio.rest.core.RestClientTest;
 import org.folio.rest.core.exceptions.ExceptionUtilTest;
 import org.folio.rest.impl.AcquisitionMethodAPITest;
+import org.folio.rest.impl.BaseApiTest;
 import org.folio.rest.impl.CheckinReceivingApiTest;
 import org.folio.rest.impl.ExportHistoryImplTest;
 import org.folio.rest.impl.HoldingsSummaryAPITest;
@@ -506,4 +507,7 @@ public class ApiTestSuite {
   class CirculationRequestsRetrieverTestNested extends CirculationRequestsRetrieverTest {
   }
 
+  @Nested
+  class BaseApiTestNested extends BaseApiTest {
+  }
 }

--- a/src/test/java/org/folio/orders/utils/PoLineCommonUtilTest.java
+++ b/src/test/java/org/folio/orders/utils/PoLineCommonUtilTest.java
@@ -8,6 +8,8 @@ import io.vertx.core.json.JsonObject;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.jaxrs.model.*;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.List;
 import java.util.UUID;
@@ -123,5 +125,37 @@ public class PoLineCommonUtilTest {
     String errorMessage = "{\"message\":\"Protected fields can't be modified\",\"code\":\"protectedFieldChanging\",\"parameters\":[],\"protectedAndModifiedFields\":[\"details.productIds\"]}";
     assertEquals(400, exception.getCode());
     assertEquals(errorMessage, exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {"false:true:Other::Instance:true",
+    "true:false:Other:None::true",
+    "true:false:Other:Instance::false",
+    "true:false:Physical Resource:None::true",
+    "true:false:Physical Resource:Instance::false",
+    "false:true:Electronic Resource::None:true",
+    "false:true:Electronic Resource::Instance:false",
+    "true:true:P/E Mix:None:None:true",
+    "true:true:P/E Mix:Instance:None:false",
+    "true:true:P/E Mix:None:Instance:false"
+  }, delimiter = ':')
+  void testIsInventoryUpdateNotRequired(Boolean withPhysical, Boolean withEResource, String orderFormat,
+      String physicalCreateInventory, String eresourceCreateInventory, Boolean updateNotRequired) {
+    CompositePoLine poLine = new CompositePoLine();
+    if (withPhysical) {
+      poLine.setPhysical(new Physical());
+    }
+    if (withEResource) {
+      poLine.setEresource(new Eresource());
+    }
+    poLine.setOrderFormat(CompositePoLine.OrderFormat.fromValue(orderFormat));
+    if (physicalCreateInventory != null) {
+      poLine.getPhysical().setCreateInventory(Physical.CreateInventory.fromValue(physicalCreateInventory));
+    }
+    if (eresourceCreateInventory != null) {
+      poLine.getEresource().setCreateInventory(Eresource.CreateInventory.fromValue(eresourceCreateInventory));
+    }
+    boolean result = PoLineCommonUtil.isInventoryUpdateNotRequired(poLine);
+    assertEquals(result, updateNotRequired);
   }
 }

--- a/src/test/java/org/folio/rest/impl/BaseApiTest.java
+++ b/src/test/java/org/folio/rest/impl/BaseApiTest.java
@@ -1,0 +1,63 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import org.folio.rest.core.exceptions.HttpException;
+import org.folio.rest.jaxrs.model.Errors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class BaseApiTest {
+  private AutoCloseable mockitoMocks;
+  private BaseApi baseApi;
+  @Mock
+  Handler<AsyncResult<Response>> asyncResultHandler;
+  @Captor
+  private ArgumentCaptor<Future<Response>> asyncResultCaptor;
+
+  @BeforeEach
+  void beforeEach() {
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+    baseApi = new BaseApi();
+  }
+
+  @AfterEach
+  void resetMocks() throws Exception {
+    mockitoMocks.close();
+  }
+
+  @Test
+  @DisplayName("Test handleErrorResponse")
+  void testHandleErrorResponse() {
+    // Given
+    Throwable t = new HttpException(123, "test");
+    doNothing()
+      .when(asyncResultHandler).handle(any());
+
+    // When
+    baseApi.handleErrorResponse(asyncResultHandler, t);
+
+    // Then
+    verify(asyncResultHandler, times(1)).handle(asyncResultCaptor.capture());
+    Response response = asyncResultCaptor.getAllValues().get(0).result();
+    assertThat(response.getStatus(), equalTo(123));
+    Errors errors = (Errors)response.getEntity();
+    assertThat(errors.getErrors().get(0).getMessage(), equalTo("test"));
+  }
+}

--- a/src/test/java/org/folio/service/finance/budget/BudgetServiceTest.java
+++ b/src/test/java/org/folio/service/finance/budget/BudgetServiceTest.java
@@ -1,21 +1,66 @@
 package org.folio.service.finance.budget;
 
-public class BudgetServiceTest {
+import io.vertx.core.Future;
+import org.folio.rest.acq.model.finance.Budget;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.exceptions.HttpException;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
-//    @Test
-//    public void testShouldReturnActiveBudgetForFund() {
-//        EncumbranceService encumbranceService = new EncumbranceService(transactionService, transactionSummariesService, exchangeRateProviderResolver, fundService, ledgerService, budgetService, fiscalYearService, configurationEntriesService);
-//        Budget budget = encumbranceService.getActiveBudgetByFundId(ACTIVE_BUDGET).result();
-//        assertNotNull(budget);
-//    }
-//
-//    @Test
-//    public void testShouldThrowExceptionIfActiveBudgetForFund() {
-//        assertThrows(CompletionException.class, () -> {
-//            EncumbranceService encumbranceService = new EncumbranceService(transactionService, transactionSummariesService, exchangeRateProviderResolver, fundService, ledgerService, budgetService, fiscalYearService, configurationEntriesService);
-//            Budget budget = encumbranceService.getActiveBudgetByFundId(UUID.randomUUID().toString())
-//                    .result();
-//            assertNotNull(budget);
-//        });
-//    }
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.rest.core.exceptions.ErrorCodes.BUDGET_NOT_FOUND_FOR_TRANSACTION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+public class BudgetServiceTest {
+  private AutoCloseable mockitoMocks;
+  private BudgetService budgetService;
+  @Mock
+  private RequestContext requestContext;
+  @Mock
+  private RestClient restClient;
+
+  @BeforeEach
+  void beforeEach() {
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+    budgetService = new BudgetService(restClient);
+  }
+
+  @AfterEach
+  void resetMocks() throws Exception {
+    mockitoMocks.close();
+  }
+
+  @Test
+  @DisplayName("Test getBudgets failure")
+  void testGetBudgetsFailure() {
+    // Given
+    doReturn(Future.failedFuture(new HttpException(404, "not found")))
+      .when(restClient).get(any(RequestEntry.class), eq(Budget.class), eq(requestContext));
+    String fundId = UUID.randomUUID().toString();
+
+    // When
+    Future<List<Budget>> future = budgetService.getBudgets(List.of(fundId), requestContext);
+
+    // Then
+    assertTrue(future.failed());
+    HttpException ex = (HttpException)future.cause();
+    assertThat(ex.getErrors().getErrors(), hasSize(1));
+    assertEquals(BUDGET_NOT_FOUND_FOR_TRANSACTION.getCode(), ex.getError().getCode());
+    assertEquals(fundId, ex.getError().getParameters().get(0).getValue());
+  }
+
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-1098](https://folio-org.atlassian.net/browse/MODORDERS-1098) - Rewrite PurchaseOrdersApiTest tests without using MockServer

## Approach
- `testOrderWithPoLinesWithoutSource()`
-> `PurchaseOrderHelperTest.testSourceValidationInLine()`
(relates to [MODORDERS-1119](https://folio-org.atlassian.net/browse/MODORDERS-1119))

- `testDateOrderedIsNotSetForPendingOrder()`  (currently disabled)
-> removed, this is equivalent to checking that `OpenCompositeOrderManager` is not used for pending orders

- `testPostOpenOrderInventoryUpdateWithOrderFormatOther()` (currently disabled)
-> `PoLineCommonUtilTest.testIsInventoryUpdateNotRequired()`
(See also integration tests `open-order-without-holdings.feature` and `piece-operations-for-order-flows-mixed-order-line.feature` and [FAT-1106](https://folio-org.atlassian.net/browse/FAT-1106))

- `testPostOpenOrderInventoryUpdateOnlyForFirstPOL()`
-> removed (also based on `isInventoryUpdateNotRequired()`, same tests as previous)

- `testPutOrdersByIdPEMixFormat()` (disabled)
There are problems with this test; it opens an order, but uses different data for the PUT than MockServer returns with a GET. So this is like opening the order, changing the line and adding another line in a single operation. Also, the test currently fails (it is disabled).
-> removed, redundant with `MODORDERS-538-piece-against-non-package-mixed-pol-manual-piece-creation-is-false.feature`

- `testPutOrdersByIdFundsNotFound()`
-> `BudgetServiceTest.testGetBudgetsFailure()`
(note: I am not adding many tests in `BudgetServiceTest` because the implementation will be changed a lot with [MODORDERS-1118](https://folio-org.atlassian.net/browse/MODORDERS-1118))

- `testPutOrdersByIdCurrentActiveBudgetNotFound()`
-> removed, it is similar to the previous one and not clear about the difference

- `testPutOrdersByIdCurrentFiscalYearServerError()`
-> `BaseApiTest.testHandleErrorResponse()` (this is just checking error propagation)

- `testPutOrdersByIdEmptyFundDistributions()`
-> tried to update `delete-fund-distribution.feature`, merge scenarios and add a new scenario removing the fundDistribution in a compositeOrder and PUTting that order instead of the line
Problem: scenario fails because of [MODORDERS-564](https://folio-org.atlassian.net/browse/MODORDERS-564) -> added the new feature to the ticket

- `testPutOrdersByIdTotalPiecesEqualsTotalQuantityWhenCreateInventoryIsFalse()` (disabled)
There are problems with this test too...
-> removed, redundant with `should-decrease-quantity-when-delete-piece-with-no-location.feature`


#### TODOS and Open Questions
TODO: it is hard sometimes to find the karate test matching a particular feature. We should better organize them.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
