### PR TITLE
MODORDERS-1122] Add logic to create item in any tenant for binding

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1102,7 +1102,11 @@
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get",
             "circulation.requests.collection.get",
-            "circulation.requests.item.move.post"
+            "circulation.requests.item.move.post",
+            "inventory-storage.holdings-sources.collection.get",
+            "inventory-storage.holdings.item.post",
+            "user-tenants.collection.get",
+            "consortia.sharing-instances.item.post"
           ]
         }
       ]

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -3,6 +3,7 @@ package org.folio.helper;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.models.ItemFields;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.orders.utils.PoLineCommonUtil;
@@ -204,7 +205,8 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
   private Future<String> createShadowInstanceAndHoldingIfNeeded(CompositePoLine compPOL, BindItem bindItem, String holdingId,
                                                                 RequestContext locationContext, RequestContext requestContext) {
     // No need to create inventory objects if BindItem tenantId is not different
-    if (Objects.equals(TenantTool.tenantId(requestContext.getHeaders()), bindItem.getTenantId())) {
+    var targetTenantId = bindItem.getTenantId();
+    if (StringUtils.isEmpty(targetTenantId) || targetTenantId.equals(TenantTool.tenantId(requestContext.getHeaders()))) {
       return Future.succeededFuture(holdingId);
     }
     var instanceId = compPOL.getInstanceId();

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -207,8 +207,9 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
     if (Objects.equals(TenantTool.tenantId(requestContext.getHeaders()), bindItem.getTenantId())) {
       return Future.succeededFuture(holdingId);
     }
-    return inventoryInstanceManager.createShadowInstanceIfNeeded(compPOL.getInstanceId(), locationContext)
-      .compose(inst -> inventoryHoldingManager.createHoldingAndReturnId(inst.instanceIdentifier().toString(), bindItem.getPermanentLocationId(), locationContext));
+    var instanceId = compPOL.getInstanceId();
+    return inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, locationContext)
+      .compose(s -> inventoryHoldingManager.createHoldingAndReturnId(instanceId, bindItem.getPermanentLocationId(), locationContext));
   }
 
   private Map<String, List<Piece>> updateTitleWithBindItems(Map<String, List<Piece>> piecesByPoLineIds,

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -6,12 +6,13 @@ import io.vertx.core.json.JsonObject;
 import org.folio.models.ItemFields;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.orders.utils.PoLineCommonUtil;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.RestConstants;
 import org.folio.rest.core.exceptions.ErrorCodes;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.BindItem;
 import org.folio.rest.jaxrs.model.BindPiecesCollection;
+import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.Piece;
@@ -20,6 +21,8 @@ import org.folio.rest.jaxrs.model.ReceivedItem;
 import org.folio.rest.jaxrs.model.ReceivingResult;
 import org.folio.rest.jaxrs.model.ReceivingResults;
 import org.folio.rest.jaxrs.model.Title;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.service.inventory.InventoryInstanceManager;
 import org.folio.service.inventory.InventoryItemRequestService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -32,6 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 import static org.folio.rest.jaxrs.model.BindPiecesCollection.RequestsAction.TRANSFER;
 
 
@@ -41,6 +45,9 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
 
   @Autowired
   private InventoryItemRequestService inventoryItemRequestService;
+
+  @Autowired
+  private InventoryInstanceManager inventoryInstanceManager;
 
   public BindHelper(BindPiecesCollection bindPiecesCollection,
                     Map<String, String> okapiHeaders, Context ctx) {
@@ -92,7 +99,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
     return GenericCompositeFuture.all(
       tenantToItem.entrySet().stream()
         .map(entry -> {
-        var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, entry.getKey());
+        var locationContext = createContextWithNewTenantId(requestContext, entry.getKey());
         return inventoryItemRequestService.getItemsWithActiveRequests(entry.getValue(), locationContext)
           .compose(items -> validateItemsForRequestTransfer(tenantToItem.keySet(), items, bindPiecesCollection));
         })
@@ -137,7 +144,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
     return GenericCompositeFuture.all(
       mapTenantIdsToItemIds(piecesGroupedByPoLine, requestContext).entrySet().stream()
         .map(entry -> {
-          var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, entry.getKey());
+          var locationContext = createContextWithNewTenantId(requestContext, entry.getKey());
           return inventoryItemManager.getItemRecordsByIds(entry.getValue(), locationContext)
             .compose(items -> {
               items.forEach(item -> {
@@ -162,10 +169,10 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
       .map(Piece::getHoldingId).distinct().toList();
     validateHoldingIds(holdingIds, bindPiecesCollection);
     logger.debug("createItemForPiece:: Trying to get poLine by id '{}'", poLineId);
+
     return purchaseOrderLineService.getOrderLineById(poLineId, requestContext)
       .map(PoLineCommonUtil::convertToCompositePoLine)
-      .compose(compPOL ->
-        inventoryItemManager.createBindItem(compPOL, holdingIds.get(0), bindPiecesCollection.getBindItem(), requestContext))
+      .compose(compPOL -> createInventoryObjects(compPOL, holdingIds.get(0), bindPiecesCollection.getBindItem(), requestContext))
       .map(newItemId -> {
         // Move requests if requestsAction is TRANSFER, otherwise do nothing
         if (TRANSFER.equals(bindPiecesCollection.getRequestsAction())) {
@@ -186,6 +193,22 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
         .withMessage("Holding Id must not be null or different for pieces");
       throw new HttpException(400, error);
     }
+  }
+
+  private Future<String> createInventoryObjects(CompositePoLine compPOL, String holdingId, BindItem bindItem, RequestContext requestContext) {
+    var locationContext = createContextWithNewTenantId(requestContext, bindItem.getTenantId());
+    return createShadowInstanceAndHoldingIfNeeded(compPOL, bindItem, holdingId, locationContext, requestContext)
+      .compose(targetHoldingId -> inventoryItemManager.createBindItem(compPOL, targetHoldingId, bindItem, locationContext));
+  }
+
+  private Future<String> createShadowInstanceAndHoldingIfNeeded(CompositePoLine compPOL, BindItem bindItem, String holdingId,
+                                                                RequestContext locationContext, RequestContext requestContext) {
+    // No need to create inventory objects if BindItem tenantId is not different
+    if (Objects.equals(TenantTool.tenantId(requestContext.getHeaders()), bindItem.getTenantId())) {
+      return Future.succeededFuture(holdingId);
+    }
+    return inventoryInstanceManager.createShadowInstanceIfNeeded(compPOL.getInstanceId(), locationContext)
+      .compose(inst -> inventoryHoldingManager.createHoldingAndReturnId(inst.instanceIdentifier().toString(), bindItem.getPermanentLocationId(), locationContext));
   }
 
   private Map<String, List<Piece>> updateTitleWithBindItems(Map<String, List<Piece>> piecesByPoLineIds,

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -31,6 +31,7 @@ import org.folio.rest.jaxrs.model.ProcessingStatus;
 import org.folio.rest.jaxrs.model.ReceivingItemResult;
 import org.folio.rest.jaxrs.model.ReceivingResult;
 import org.folio.rest.jaxrs.model.Title;
+import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.ProtectionService;
 import org.folio.service.inventory.InventoryHoldingManager;
 import org.folio.service.inventory.InventoryItemManager;
@@ -774,7 +775,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
     return extractAllPieces(piecesGroupedByPoLine)
       .filter(piece -> StringUtils.isNotEmpty(piece.getItemId()))
       .groupingBy(piece -> Optional.ofNullable(piece.getReceivingTenantId())
-          .orElse(RequestContextUtil.getContextTenantId(requestContext)),
+          .orElse(TenantTool.tenantId(requestContext.getHeaders())),
         mapping(Piece::getItemId, toList()));
   }
 

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -884,7 +884,7 @@ public class PurchaseOrderLineHelper {
     if (Boolean.TRUE.equals(compositePoLine.getIsPackage()) || Objects.isNull(instanceId)) {
       return Future.succeededFuture();
     }
-    return inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, TenantTool.tenantId(requestContext.getHeaders()), requestContext)
+    return inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, requestContext)
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -69,7 +69,6 @@ import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLineCollection;
 import org.folio.rest.jaxrs.model.ReportingCode;
 import org.folio.rest.jaxrs.model.Title;
-import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.ProtectionService;
 import org.folio.service.finance.expenceclass.ExpenseClassValidationService;
 import org.folio.service.finance.transaction.EncumbranceService;

--- a/src/main/java/org/folio/orders/utils/RequestContextUtil.java
+++ b/src/main/java/org/folio/orders/utils/RequestContextUtil.java
@@ -22,8 +22,4 @@ public class RequestContextUtil {
     return new RequestContext(requestContext.getContext(), modifiedHeaders);
   }
 
-  public static String getContextTenantId(RequestContext requestContext) {
-    return requestContext.getHeaders().get(XOkapiHeaders.TENANT);
-  }
-
 }

--- a/src/main/java/org/folio/service/consortium/SharingInstanceService.java
+++ b/src/main/java/org/folio/service/consortium/SharingInstanceService.java
@@ -7,13 +7,15 @@ import org.apache.logging.log4j.Logger;
 import org.folio.models.consortium.ConsortiumConfiguration;
 import org.folio.models.consortium.SharingInstance;
 import org.folio.models.consortium.SharingStatus;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.exceptions.ConsortiumException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.tools.utils.TenantTool;
 
 import java.util.UUID;
+
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 
 /**
  * The `SharingInstanceService` class manages the creation of shadow instances
@@ -41,13 +43,12 @@ public class SharingInstanceService {
    * @param requestContext          the request context
    * @return a Future that resolves with the created SharingInstance
    */
-  public Future<SharingInstance> createShadowInstance(String instanceId, String targetTenantId,
+  public Future<SharingInstance> createShadowInstance(String instanceId,
                                                       ConsortiumConfiguration consortiumConfiguration,
                                                       RequestContext requestContext) {
-    SharingInstance sharingInstance = new SharingInstance(UUID.fromString(instanceId),
-      consortiumConfiguration.centralTenantId(), targetTenantId);
-    RequestContext consortiaRequestContext = RequestContextUtil.createContextWithNewTenantId(requestContext,
-      consortiumConfiguration.centralTenantId());
+    var targetTenantId = TenantTool.tenantId(requestContext.getHeaders());
+    var sharingInstance = new SharingInstance(UUID.fromString(instanceId), consortiumConfiguration.centralTenantId(), targetTenantId);
+    var consortiaRequestContext = createContextWithNewTenantId(requestContext, consortiumConfiguration.centralTenantId());
     return shareInstance(consortiumConfiguration.consortiumId(), sharingInstance, consortiaRequestContext);
   }
 

--- a/src/main/java/org/folio/service/inventory/InventoryInstanceManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryInstanceManager.java
@@ -360,8 +360,9 @@ public class InventoryInstanceManager {
   private Future<String> shareInstanceAmongTenantsIfNeeded(String instanceId, ConsortiumConfiguration consortiumConfiguration,
                                                            List<Location> locations, RequestContext requestContext) {
     return findTenantsWithUnsharedInstance(instanceId, locations, requestContext)
-      .map(tenantIds -> tenantIds.stream().map(targetTenantId -> sharingInstanceService.createShadowInstance(instanceId,
-        targetTenantId, consortiumConfiguration, requestContext)).toList())
+      .map(tenantIds -> tenantIds.stream()
+        .map(targetTenantId -> sharingInstanceService.createShadowInstance(instanceId, consortiumConfiguration, requestContext))
+        .toList())
       .compose(HelperUtils::collectResultsOnSuccess)
       .map(sharingInstances -> instanceId);
   }
@@ -387,7 +388,7 @@ public class InventoryInstanceManager {
       .map(tenantIds -> tenantIds.stream().flatMap(Optional::stream).toList());
   }
 
-  public Future<SharingInstance> createShadowInstanceIfNeeded(String instanceId, String targetTenantId, RequestContext requestContext) {
+  public Future<SharingInstance> createShadowInstanceIfNeeded(String instanceId, RequestContext requestContext) {
     return consortiumConfigurationService.getConsortiumConfiguration(requestContext)
       .compose(consortiumConfiguration -> {
         if (consortiumConfiguration.isEmpty()) {
@@ -405,7 +406,7 @@ public class InventoryInstanceManager {
               return Future.succeededFuture();
             }
             logger.info("createShadowInstanceIfNeeded:: Creating shadow instance with instanceId: {}", instanceId);
-            return sharingInstanceService.createShadowInstance(instanceId, targetTenantId, consortiumConfiguration.get(), requestContext);
+            return sharingInstanceService.createShadowInstance(instanceId, consortiumConfiguration.get(), requestContext);
           });
       });
   }

--- a/src/main/java/org/folio/service/inventory/InventoryItemManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemManager.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.orders.utils.HelperUtils;
-import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.exceptions.InventoryException;
@@ -394,9 +393,7 @@ public class InventoryItemManager {
       });
   }
 
-  public Future<String> createBindItem(CompositePoLine compPOL, String holdingId,
-                                       BindItem bindItem,
-                                       RequestContext requestContext) {
+  public Future<String> createBindItem(CompositePoLine compPOL, String holdingId, BindItem bindItem, RequestContext locationContext) {
     JsonObject item = new JsonObject()
       .put(ITEM_HOLDINGS_RECORD_ID, holdingId)
       .put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ReceivedItem.ItemStatus.ON_ORDER.value()))
@@ -406,7 +403,6 @@ public class InventoryItemManager {
       .put(ITEM_MATERIAL_TYPE_ID, bindItem.getMaterialTypeId())
       .put(ITEM_PURCHASE_ORDER_LINE_IDENTIFIER, compPOL.getId());
     logger.debug("Creating item for PO Line with '{}' id", compPOL.getId());
-    var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, bindItem.getTenantId());
     return createItemInInventory(item, locationContext);
   }
 

--- a/src/main/java/org/folio/service/orders/lines/update/OrderLinePatchOperationService.java
+++ b/src/main/java/org/folio/service/orders/lines/update/OrderLinePatchOperationService.java
@@ -30,7 +30,6 @@ import org.folio.rest.jaxrs.model.Details;
 import org.folio.rest.jaxrs.model.PatchOrderLineRequest;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.ProductId;
-import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.caches.InventoryCache;
 import org.folio.service.inventory.InventoryInstanceManager;
 import org.folio.service.inventory.InventoryUtils;

--- a/src/main/java/org/folio/service/orders/lines/update/OrderLinePatchOperationService.java
+++ b/src/main/java/org/folio/service/orders/lines/update/OrderLinePatchOperationService.java
@@ -70,9 +70,8 @@ public class OrderLinePatchOperationService {
   }
 
   public Future<Void> patch(String lineId, PatchOrderLineRequest request, RequestContext requestContext) {
-    String targetTenantId = TenantTool.tenantId(requestContext.getHeaders());
     String newInstanceId = request.getReplaceInstanceRef().getNewInstanceId();
-    return inventoryInstanceManager.createShadowInstanceIfNeeded(newInstanceId, targetTenantId, requestContext)
+    return inventoryInstanceManager.createShadowInstanceIfNeeded(newInstanceId, requestContext)
       .compose(v -> patchOrderLine(request, lineId, requestContext))
       .compose(v -> updateInventoryInstanceInformation(request, lineId, requestContext));
   }

--- a/src/main/java/org/folio/service/titles/TitleInstanceService.java
+++ b/src/main/java/org/folio/service/titles/TitleInstanceService.java
@@ -2,7 +2,6 @@ package org.folio.service.titles;
 
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Title;
-import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.inventory.InventoryInstanceManager;
 
 import io.vertx.core.Future;
@@ -25,8 +24,7 @@ public class TitleInstanceService {
   }
 
   private Future<String> createShadowInstance(String instanceId, RequestContext requestContext) {
-    String targetTenantId = TenantTool.tenantId(requestContext.getHeaders());
-    return inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, targetTenantId, requestContext)
+    return inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, requestContext)
       .map(sharingInstance -> sharingInstance != null ? instanceId : null);
   }
 

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -1011,7 +1011,6 @@ public class CheckinReceivingApiTest {
     assertThat(response.as(ReceivingResults.class).getReceivingResults().get(0).getProcessedSuccessfully(), is(2));
 
     var pieceUpdates = getPieceUpdates();
-
     assertThat(pieceUpdates, notNullValue());
     assertThat(pieceUpdates, hasSize(bindPiecesCollection.getBindPieceIds().size()));
 
@@ -1020,8 +1019,11 @@ public class CheckinReceivingApiTest {
       String pieceId = piece.getId();
       return Objects.equals(bindingPiece1.getId(), pieceId) || Objects.equals(bindingPiece2.getId(), pieceId);
     }).toList();
-
     assertThat(pieceList.size(), is(2));
+
+    var createdHoldings = getCreatedHoldings();
+    assertThat(createdHoldings, nullValue());
+
   }
 
   @Test

--- a/src/test/java/org/folio/service/consortium/SharingInstanceServiceTest.java
+++ b/src/test/java/org/folio/service/consortium/SharingInstanceServiceTest.java
@@ -45,7 +45,7 @@ public class SharingInstanceServiceTest {
     Mockito.when(restClient.post(any(RequestEntry.class), any(), any(), any()))
       .thenReturn(Future.succeededFuture(new SharingInstance(UUID.randomUUID(), StringUtils.EMPTY, StringUtils.EMPTY)));
 
-    Future<SharingInstance> future = sharingInstanceService.createShadowInstance(instanceId, "testTenant", consortiumConfiguration, requestContext);
+    Future<SharingInstance> future = sharingInstanceService.createShadowInstance(instanceId, consortiumConfiguration, requestContext);
     vertxTestContext.assertComplete(future)
       .onComplete(ar -> {
         Assertions.assertTrue(ar.succeeded());
@@ -63,7 +63,7 @@ public class SharingInstanceServiceTest {
 
     Mockito.when(restClient.post(any(RequestEntry.class), any(), any(), any())).thenReturn(Future.succeededFuture(response));
 
-    Future<SharingInstance> future = service.createShadowInstance(instanceId, "testTenant", consortiumConfiguration, requestContext);
+    Future<SharingInstance> future = service.createShadowInstance(instanceId, consortiumConfiguration, requestContext);
     vertxTestContext.assertFailure(future)
       .onComplete(completionException -> {
         assertEquals(ConsortiumException.class, completionException.cause().getClass());

--- a/src/test/java/org/folio/service/inventory/InventoryManagerTest.java
+++ b/src/test/java/org/folio/service/inventory/InventoryManagerTest.java
@@ -867,7 +867,7 @@ public class InventoryManagerTest {
     doReturn(succeededFuture(configuration)).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
     doReturn(succeededFuture(JsonObject.mapFrom(new Instance()))).when(restClient).getAsJsonObject(any(RequestEntry.class), anyBoolean(), any(RequestContext.class));
 
-    inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, StringUtils.EMPTY, requestContext).result();
+    inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, requestContext).result();
 
     verifyNoInteractions(sharingInstanceService);
   }
@@ -878,7 +878,7 @@ public class InventoryManagerTest {
     doReturn(succeededFuture(configuration)).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
     doReturn(succeededFuture(JsonObject.mapFrom(new Instance()))).when(restClient).getAsJsonObject(any(RequestEntry.class), anyBoolean(), any(RequestContext.class));
 
-    inventoryInstanceManager.createShadowInstanceIfNeeded(null, StringUtils.EMPTY, requestContext).result();
+    inventoryInstanceManager.createShadowInstanceIfNeeded(null, requestContext).result();
 
     verifyNoInteractions(sharingInstanceService);
   }
@@ -888,7 +888,7 @@ public class InventoryManagerTest {
     String instanceId = UUID.randomUUID().toString();
     doReturn(succeededFuture(null)).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
 
-    inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, StringUtils.EMPTY, requestContext).result();
+    inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, requestContext).result();
 
     verifyNoInteractions(sharingInstanceService);
   }
@@ -900,9 +900,9 @@ public class InventoryManagerTest {
     doReturn(succeededFuture(configuration)).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
     doReturn(succeededFuture(null)).when(restClient).getAsJsonObject(any(RequestEntry.class), anyBoolean(), any(RequestContext.class));
 
-    inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, StringUtils.EMPTY, requestContext).result();
+    inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, requestContext).result();
 
-    verify(sharingInstanceService).createShadowInstance(instanceId, StringUtils.EMPTY, configuration.get(), requestContext);
+    verify(sharingInstanceService).createShadowInstance(instanceId, configuration.get(), requestContext);
   }
 
   @Test

--- a/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
@@ -208,7 +208,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), anyBoolean(), eq(requestContext), eq(requestContext));
 
     doReturn(succeededFuture(sharingInstance))
-      .when(inventoryInstanceManager).createShadowInstanceIfNeeded(eq(instanceId), any(String.class), eq(requestContext));
+      .when(inventoryInstanceManager).createShadowInstanceIfNeeded(eq(instanceId), eq(requestContext));
     doReturn(succeededFuture(holdingId))
       .when(inventoryHoldingManager).createHoldingAndReturnId(eq(title.getInstanceId()), eq(piece.getLocationId()), eq(requestContext));
     doReturn(succeededFuture(itemId)).when(inventoryItemManager).openOrderCreateItemRecord(any(CompositePoLine.class), eq(holdingId), eq(requestContext));


### PR DESCRIPTION
## Purpose
[[MODORDERS-1122] Add logic to create item in any tenant for binding](https://folio-org.atlassian.net/browse/MODORDERS-1122)

## Approach
* Create shadow instance and holding in another tenant if specified in bindItem.tenantId

## Screenshots
After manually calling bind endpoint:
![image](https://github.com/folio-org/mod-orders/assets/148070844/d661937f-1a32-4527-b7a4-d71d2c5ecac7)

Find item by barcode is created:
![image](https://github.com/folio-org/mod-orders/assets/148070844/2499ebd8-c7ae-4847-89dd-5a11f9744f20)

Find holding by Location and filter by creation date:
![image](https://github.com/folio-org/mod-orders/assets/148070844/43c074fa-9a91-4740-aede-fa825d8d89d4)