### PR TITLE
[MODORDERS-1118] Optimize and refactor getting finance data structures

### DIFF
--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -112,7 +112,6 @@ public enum ErrorCodes {
   FORBIDDEN_DELETE_USED_VALUE("forbiddenDeleteUsedValue", "Deleting the value used is prohibited"),
   ERROR_REMOVING_INVOICE_LINE_ENCUMBRANCES("errorRemovingInvoiceLineEncumbrances", "Error removing invoice line encumbrance links after deleting the encumbrances: %s"),
   PO_LINE_HAS_RELATED_APPROVED_INVOICE_ERROR("poLineHasRelatedApprovedInvoice", "A related invoice has the APPROVED status, invoice line ids: %s"),
-  MULTIPLE_FISCAL_YEARS("multipleFiscalYears", "Order line fund distributions have active budgets in multiple fiscal years."),
   INSTANCE_INVALID_PRODUCT_ID_ERROR("instanceInvalidProductIdError", "Instance connection could not be changed, the chosen instance contains an invalid Product ID."),
   FUND_LOCATION_RESTRICTION_VIOLATION("fundLocationRestrictionViolation", "One of the locations is restricted to be used by all funds."),
   ENCUMBRANCES_FOR_RE_ENCUMBER_NOT_FOUND("encumbrancesForReEncumberNotFound", "The encumbrances were correctly created during the rollover or have already been updated."),
@@ -126,7 +125,8 @@ public enum ErrorCodes {
   ROUTING_LIST_UNIQUE_NAME_VIOLATION("routingListUniqueNameViolation", "Routing list with the same name already exists"),
   ORDER_FORMAT_INCORRECT_FOR_BINDARY_ACTIVE("orderFormatIncorrectForBindaryActive", "When PoLine is bindery active, its format must be 'P/E Mix' or 'Physical Resource'"),
   CREATE_INVENTORY_INCORRECT_FOR_BINDARY_ACTIVE("createInventoryIncorrectForBindaryActive", "When PoLine is bindery active, Create Inventory must be 'Instance, Holding, Item'"),
-  RECEIVING_WORKFLOW_INCORRECT_FOR_BINDARY_ACTIVE("receivingWorkflowIncorrectForBindaryActive", "When PoLine is bindery active, its receiving workflow must be set to 'Independent order and receipt quantity'");
+  RECEIVING_WORKFLOW_INCORRECT_FOR_BINDARY_ACTIVE("receivingWorkflowIncorrectForBindaryActive", "When PoLine is bindery active, its receiving workflow must be set to 'Independent order and receipt quantity'"),
+  BUDGET_NOT_FOUND_FOR_FISCAL_YEAR("budgetNotFoundForFiscalYear", "Could not find an active budget for a fund with the current fiscal year of another fund in the fund distribution");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
+++ b/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
@@ -1,0 +1,193 @@
+package org.folio.service.finance;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+import static org.folio.orders.utils.HelperUtils.convertFieldListToCqlQuery;
+import static org.folio.orders.utils.HelperUtils.getConversionQuery;
+import static org.folio.rest.core.exceptions.ErrorCodes.BUDGET_NOT_FOUND_FOR_FISCAL_YEAR;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.money.convert.ConversionQuery;
+import javax.money.convert.CurrencyConversion;
+import javax.money.convert.ExchangeRateProvider;
+
+import org.folio.models.EncumbranceRelationsHolder;
+import org.folio.rest.acq.model.finance.Budget;
+import org.folio.rest.acq.model.finance.FiscalYear;
+import org.folio.rest.acq.model.finance.Fund;
+import org.folio.rest.acq.model.finance.Ledger;
+import org.folio.rest.core.exceptions.HttpException;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePoLine;
+import org.folio.rest.jaxrs.model.Cost;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.service.exchange.ExchangeRateProviderResolver;
+import org.folio.service.finance.budget.BudgetService;
+
+import io.vertx.core.Future;
+
+public class FinanceHoldersBuilder {
+
+  private final FundService fundService;
+  private final FiscalYearService fiscalYearService;
+  protected final ExchangeRateProviderResolver exchangeRateProviderResolver;
+  private final BudgetService budgetService;
+  private final LedgerService ledgerService;
+
+  public FinanceHoldersBuilder(FundService fundService, FiscalYearService fiscalYearService,
+      ExchangeRateProviderResolver exchangeRateProviderResolver, BudgetService budgetService,
+      LedgerService ledgerService) {
+    this.fundService = fundService;
+    this.fiscalYearService = fiscalYearService;
+    this.exchangeRateProviderResolver = exchangeRateProviderResolver;
+    this.budgetService = budgetService;
+    this.ledgerService = ledgerService;
+  }
+
+  public Future<Void> withFinances(List<? extends EncumbranceRelationsHolder> encumbranceHolders,
+      RequestContext requestContext) {
+    if (encumbranceHolders.stream().noneMatch(h -> h.getFundId() != null)) {
+      return succeededFuture();
+    }
+    return getLedgerIds(encumbranceHolders, requestContext)
+      .compose(ledgerIds -> getLedgers(ledgerIds, encumbranceHolders, requestContext))
+      .compose(ledgers -> getFiscalYear(ledgers, encumbranceHolders, requestContext))
+      .compose(fiscalYear -> getBudgets(fiscalYear, encumbranceHolders, requestContext))
+      .compose(v -> withConversion(encumbranceHolders, requestContext));
+  }
+
+  public Future<List<String>> getLedgerIds(List<? extends EncumbranceRelationsHolder> encumbranceHolders,
+      RequestContext requestContext) {
+    List<String> fundIds = encumbranceHolders.stream()
+      .map(EncumbranceRelationsHolder::getFundId)
+      .filter(Objects::nonNull)
+      .distinct()
+      .toList();
+    if (fundIds.isEmpty()) {
+      return succeededFuture(List.of());
+    }
+    return fundService.getAllFunds(fundIds, requestContext)
+      .map(funds -> {
+        populateLedgerIds(funds, encumbranceHolders);
+        return funds.stream()
+          .map(Fund::getLedgerId)
+          .distinct()
+          .toList();
+      });
+  }
+
+  protected Future<Void> withConversion(List<? extends EncumbranceRelationsHolder> encumbranceHolders,
+    RequestContext requestContext) {
+    String fyCurrency = encumbranceHolders.stream()
+      .map(EncumbranceRelationsHolder::getCurrency)
+      .filter(Objects::nonNull)
+      .findFirst()
+      .orElse(null);
+    if (fyCurrency == null) {
+      return succeededFuture();
+    }
+    return requestContext.getContext().executeBlocking(() -> {
+        Map<String, List<EncumbranceRelationsHolder>> currencyHolderMap = encumbranceHolders.stream()
+          .filter(holder -> Objects.nonNull(holder.getPoLine()))
+          .collect(groupingBy(holder -> holder.getPoLine().getCost().getCurrency()));
+
+        currencyHolderMap.forEach((poLineCurrency, encumbranceRelationsHolders) -> {
+          Double exchangeRate = encumbranceRelationsHolders.stream()
+            .map(EncumbranceRelationsHolder::getPoLine)
+            .map(CompositePoLine::getCost)
+            .map(Cost::getExchangeRate)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+
+          ConversionQuery conversionQuery = getConversionQuery(exchangeRate, poLineCurrency, fyCurrency);
+          ExchangeRateProvider exchangeRateProvider = exchangeRateProviderResolver.resolve(conversionQuery, requestContext);
+          CurrencyConversion conversion = exchangeRateProvider.getCurrencyConversion(conversionQuery);
+          encumbranceRelationsHolders.forEach(holder -> holder.withPoLineToFyConversion(conversion));
+        });
+        return null;
+      })
+      .mapEmpty();
+  }
+
+  private void populateLedgerIds(List<Fund> funds, List<? extends EncumbranceRelationsHolder> encumbranceHolders) {
+    Map<String, String> idFundMap = funds.stream()
+      .collect(toMap(Fund::getId, Fund::getLedgerId));
+    encumbranceHolders.stream()
+      .filter(holder -> Objects.nonNull(holder.getFundId()))
+      .forEach(holder -> holder.withLedgerId(idFundMap.get(holder.getFundId())));
+  }
+
+  private Future<List<Ledger>> getLedgers(List<String> ledgerIds,
+      List<? extends EncumbranceRelationsHolder> encumbranceHolders, RequestContext requestContext) {
+    return ledgerService.getLedgersByIds(ledgerIds, requestContext)
+      .map(ledgers -> {
+        mapRestrictEncumbranceToHolders(ledgers, encumbranceHolders);
+        return ledgers;
+      });
+  }
+
+  private Future<FiscalYear> getFiscalYear(List<Ledger> ledgers,
+      List<? extends EncumbranceRelationsHolder> encumbranceHolders, RequestContext requestContext) {
+    return fiscalYearService.getCurrentFiscalYear(ledgers.get(0).getId(), requestContext)
+      .map(fiscalYear -> {
+        encumbranceHolders.forEach(holder -> holder.withCurrentFiscalYearId(fiscalYear.getId())
+          .withCurrency(fiscalYear.getCurrency()));
+        return fiscalYear;
+      });
+  }
+
+  private Future<Void> getBudgets(FiscalYear fiscalYear, List<? extends EncumbranceRelationsHolder> encumbranceHolders,
+      RequestContext requestContext) {
+    List<String> fundIds = encumbranceHolders.stream()
+      .map(EncumbranceRelationsHolder::getFundId)
+      .filter(Objects::nonNull)
+      .distinct()
+      .toList();
+    String query = convertFieldListToCqlQuery(fundIds, "fundId", true) +
+      String.format(" AND fiscalYearId == %s AND budgetStatus == Active", fiscalYear.getId());
+    return budgetService.getBudgetsByQuery(query, requestContext)
+      .map(budgets -> {
+        if (budgets.size() < fundIds.size()) {
+          List<String> idsOfFundsNotFound = fundIds.stream()
+            .filter(fundId -> budgets.stream().noneMatch(b -> fundId.equals(b.getFundId())))
+            .toList();
+          throw new HttpException(422, BUDGET_NOT_FOUND_FOR_FISCAL_YEAR.toError()
+            .withParameters(List.of(
+              new Parameter().withKey("fundId").withValue(idsOfFundsNotFound.get(0)),
+              new Parameter().withKey("fiscalYearId").withValue(fiscalYear.getId()),
+              new Parameter().withKey("fiscalYearCode").withValue(fiscalYear.getCode())
+            )));
+        }
+        mapHoldersToBudgets(budgets, encumbranceHolders);
+        return null;
+      });
+  }
+
+  private void mapRestrictEncumbranceToHolders(List<Ledger> ledgers,
+      List<? extends EncumbranceRelationsHolder> encumbranceHolders) {
+    Map<String, Ledger> idLedgerMap = ledgers.stream()
+      .collect(toMap(Ledger::getId, Function.identity()));
+    encumbranceHolders.stream()
+      .filter(holder -> Objects.nonNull(holder.getLedgerId()))
+      .forEach(holder -> {
+        Ledger ledger = idLedgerMap.get(holder.getLedgerId());
+        holder.withRestrictEncumbrances(Optional.ofNullable(ledger)
+          .map(Ledger::getRestrictEncumbrance)
+          .orElse(false));
+      });
+  }
+
+  private void mapHoldersToBudgets(List<Budget> budgets, List<? extends EncumbranceRelationsHolder> encumbranceHolders) {
+    Map<String, Budget> fundIdBudgetMap = budgets.stream()
+      .collect(toMap(Budget::getFundId, Function.identity()));
+    encumbranceHolders.forEach(holder -> holder.withBudget(fundIdBudgetMap.get(holder.getFundId())));
+  }
+
+}

--- a/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
+++ b/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
@@ -58,6 +58,10 @@ public class FinanceHoldersBuilder {
     this.ledgerService = ledgerService;
   }
 
+  /**
+   * Populate the encumbrance holders with the following data based on the fund ids in the holders:
+   * ledger ids, ledgers, fiscal year, budgets, currency conversion.
+   */
   public Future<Void> withFinances(List<? extends EncumbranceRelationsHolder> encumbranceHolders,
       RequestContext requestContext) {
     if (encumbranceHolders.stream().noneMatch(h -> h.getFundDistribution() != null && h.getFundId() != null)) {
@@ -72,6 +76,9 @@ public class FinanceHoldersBuilder {
       .onFailure(t -> logger.error("withFinances :: error retrieving finance data", t));
   }
 
+  /**
+   * Populate the ledger ids in the encumbrance holders based on the fund ids in the holders.
+   */
   public Future<List<String>> getLedgerIds(List<? extends EncumbranceRelationsHolder> encumbranceHolders,
       RequestContext requestContext) {
     List<String> fundIds = encumbranceHolders.stream()

--- a/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
+++ b/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
@@ -169,32 +169,32 @@ public class FinanceHoldersBuilder {
       .map(lists -> lists.stream().flatMap(Collection::stream).toList())
       .map(budgets -> {
         if (budgets.size() < fundIds.size()) {
-          List<? extends EncumbranceRelationsHolder> holdersOfFundsNotFound = encumbranceHolders.stream()
+          List<? extends EncumbranceRelationsHolder> holdersOfMissingBudgets = encumbranceHolders.stream()
             .filter(h -> budgets.stream().noneMatch(b -> h.getFundId().equals(b.getFundId())))
             .distinct()
             .toList();
-          List<String> idsOfFundsNotFound = holdersOfFundsNotFound.stream()
+          List<String> fundIdsOfMissingBudgets = holdersOfMissingBudgets.stream()
             .map(EncumbranceRelationsHolder::getFundId)
             .toList();
-          List<String> codesOfFundsNotFound = holdersOfFundsNotFound.stream()
+          List<String> fundCodesOfMissingBudgets = holdersOfMissingBudgets.stream()
             .map(h -> h.getFundDistribution().getCode())
             .distinct()
             .toList();
-          List<String> poLineIdsOfFundsNotFound = holdersOfFundsNotFound.stream()
+          List<String> poLineIdsOfMissingBudgets = holdersOfMissingBudgets.stream()
             .map(EncumbranceRelationsHolder::getPoLineId)
             .distinct()
             .toList();
-          List<String> poLineNumbersOfFundsNotFound = holdersOfFundsNotFound.stream()
+          List<String> poLineNumbersOfMissingBudgets = holdersOfMissingBudgets.stream()
             .map(h -> h.getPoLine().getPoLineNumber())
             .distinct()
             .filter(Objects::nonNull)
             .toList();
           throw new HttpException(422, BUDGET_NOT_FOUND_FOR_FISCAL_YEAR.toError()
             .withParameters(List.of(
-              new Parameter().withKey("fundIds").withValue(idsOfFundsNotFound.toString()),
-              new Parameter().withKey("fundCodes").withValue(codesOfFundsNotFound.toString()),
-              new Parameter().withKey("poLineIds").withValue(poLineIdsOfFundsNotFound.toString()),
-              new Parameter().withKey("poLineNumbers").withValue(poLineNumbersOfFundsNotFound.toString()),
+              new Parameter().withKey("fundIds").withValue(fundIdsOfMissingBudgets.toString()),
+              new Parameter().withKey("fundCodes").withValue(fundCodesOfMissingBudgets.toString()),
+              new Parameter().withKey("poLineIds").withValue(poLineIdsOfMissingBudgets.toString()),
+              new Parameter().withKey("poLineNumbers").withValue(poLineNumbersOfMissingBudgets.toString()),
               new Parameter().withKey("fiscalYearId").withValue(fiscalYear.getId()),
               new Parameter().withKey("fiscalYearCode").withValue(fiscalYear.getCode())
             )));

--- a/src/main/java/org/folio/service/finance/FiscalYearService.java
+++ b/src/main/java/org/folio/service/finance/FiscalYearService.java
@@ -18,7 +18,6 @@ import io.vertx.core.Future;
 
 public class FiscalYearService {
 
-  private static final String FISCAL_YEAR = "/finance/fiscal-years/{id}";
   private static final String CURRENT_FISCAL_YEAR = "/finance/ledgers/{id}/current-fiscal-year";
 
   private final RestClient restClient;
@@ -52,10 +51,5 @@ public class FiscalYearService {
 
   private boolean isFiscalYearNotFound(Throwable t) {
     return t instanceof HttpException && ((HttpException) t).getCode() == 404;
-  }
-
-  public Future<FiscalYear> getFiscalYearById(String fiscalYearId, RequestContext requestContext) {
-    RequestEntry requestEntry = new RequestEntry(FISCAL_YEAR).withId(fiscalYearId);
-    return restClient.get(requestEntry, FiscalYear.class, requestContext);
   }
 }

--- a/src/main/java/org/folio/service/finance/budget/BudgetService.java
+++ b/src/main/java/org/folio/service/finance/budget/BudgetService.java
@@ -1,67 +1,26 @@
 package org.folio.service.finance.budget;
 
-import static java.util.stream.Collectors.toList;
-import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
-import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ_15;
-import static org.folio.rest.core.exceptions.ErrorCodes.BUDGET_NOT_FOUND_FOR_TRANSACTION;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.acq.model.finance.Budget;
 import org.folio.rest.acq.model.finance.BudgetCollection;
 import org.folio.rest.core.RestClient;
-import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
-import org.folio.rest.jaxrs.model.Parameter;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import one.util.streamex.StreamEx;
 
 public class BudgetService {
   private static final Logger logger = LogManager.getLogger();
 
   private static final String BUDGETS_ENDPOINT = "/finance/budgets";
-  private static final String FUND_BUDGET_ENDPOINT = "/finance/funds/{id}/budget";
 
   private final RestClient restClient;
 
   public BudgetService(RestClient restClient) {
     this.restClient = restClient;
-  }
-
-  public Future<List<Budget>> fetchBudgetsByFundIds(List<String> fundIds, RequestContext requestContext) {
-    List<Future<Budget>> futures = fundIds.stream()
-      .distinct()
-      .map(fundId -> getActiveBudgetByFundId(fundId, requestContext))
-      .collect(toList());
-
-    return GenericCompositeFuture.join(futures)
-      .map(CompositeFuture::list);
-  }
-
-  public Future<Budget> getActiveBudgetByFundId(String fundId, RequestContext requestContext) {
-    RequestEntry requestEntry = new RequestEntry(FUND_BUDGET_ENDPOINT).withId(fundId).withQueryParameter("status", "Active");
-    return restClient.get(requestEntry, Budget.class, requestContext)
-       .recover(t -> {
-        Throwable cause = Objects.nonNull(t.getCause()) ? t.getCause() : t;
-        if (cause instanceof HttpException) {
-          throw new HttpException(404, BUDGET_NOT_FOUND_FOR_TRANSACTION.toError()
-            .withParameters(Collections.singletonList(new Parameter().withKey("fund")
-              .withValue(fundId))));
-        }
-        throw new CompletionException(cause);
-      });
   }
 
   public Future<List<Budget>> getBudgetsByQuery(String query, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/finance/transaction/ClosedToOpenEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/ClosedToOpenEncumbranceStrategy.java
@@ -57,28 +57,28 @@ public class ClosedToOpenEncumbranceStrategy implements EncumbranceWorkflowStrat
 
           // check encumbrance restrictions as in PendingToOpenEncumbranceStrategy
           // (except we use a different list of polines/transactions)
-          List<EncumbranceRelationsHolder> encumbranceRelationsHolders = encumbranceRelationsHoldersBuilder
+          List<EncumbranceRelationsHolder> holders = encumbranceRelationsHoldersBuilder
             .buildBaseHolders(compPO)
             // only keep holders with a missing encumbrance or a matching selected transaction
             .stream()
             .filter(h -> h.getFundDistribution().getEncumbrance() == null || transactions.stream()
               .anyMatch(t -> t.getEncumbrance().getSourcePoLineId().equals(h.getPoLineId())))
             .collect(Collectors.toList());
-          return encumbranceRelationsHoldersBuilder.withBudgets(encumbranceRelationsHolders, requestContext)
-            .compose(holders -> encumbranceRelationsHoldersBuilder.withLedgersData(holders, requestContext))
-            .compose(holders -> encumbranceRelationsHoldersBuilder.withFiscalYearData(holders, requestContext))
-            .compose(holders -> encumbranceRelationsHoldersBuilder.withConversion(holders, requestContext))
+          return encumbranceRelationsHoldersBuilder.withFinances(holders, requestContext)
             // use given transactions (withKnownTransactions) instead of retrieving them (withExistingTransactions)
-            .map(holders -> encumbranceRelationsHoldersBuilder.withKnownTransactions(holders, transactions))
+            .map(v -> {
+              encumbranceRelationsHoldersBuilder.withKnownTransactions(holders, transactions);
+              return holders;
+            })
             .map(fundsDistributionService::distributeFunds)
             .map(dataHolders -> {
               budgetRestrictionService.checkEncumbranceRestrictions(dataHolders);
               return null;
             })
-            .compose(aVoid -> {
+            .compose(v -> {
               // create missing encumbrances and unrelease existing ones
               EncumbrancesProcessingHolder holder = new EncumbrancesProcessingHolder();
-              List<EncumbranceRelationsHolder> toBeCreatedHolders = encumbranceRelationsHolders.stream()
+              List<EncumbranceRelationsHolder> toBeCreatedHolders = holders.stream()
                 .filter(h -> h.getOldEncumbrance() == null)
                 .collect(toList());
               holder.withEncumbrancesForCreate(toBeCreatedHolders);

--- a/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
@@ -47,13 +47,10 @@ public class ReceivingEncumbranceStrategy implements EncumbranceWorkflowStrategy
       .onSuccess(holders -> LOG.debug("End processing encumbrances for piece add/delete"));
   }
 
-  public Future<List<EncumbranceRelationsHolder>> prepareEncumbranceRelationsHolder(List<EncumbranceRelationsHolder> encumbranceRelationsHolders,
-                  CompositePurchaseOrder poFromStorage, RequestContext requestContext) {
-    return encumbranceRelationsHoldersBuilder.withBudgets(encumbranceRelationsHolders, requestContext)
-      .compose(holders -> encumbranceRelationsHoldersBuilder.withLedgersData(holders, requestContext))
-      .compose(holders -> encumbranceRelationsHoldersBuilder.withFiscalYearData(holders, requestContext))
-      .compose(holders -> encumbranceRelationsHoldersBuilder.withConversion(holders, requestContext))
-      .compose(holders -> encumbranceRelationsHoldersBuilder.withExistingTransactions(holders, poFromStorage, requestContext));
+  public Future<List<EncumbranceRelationsHolder>> prepareEncumbranceRelationsHolder(List<EncumbranceRelationsHolder> holders,
+      CompositePurchaseOrder poFromStorage, RequestContext requestContext) {
+    return encumbranceRelationsHoldersBuilder.withFinances(holders, requestContext)
+      .compose(v -> encumbranceRelationsHoldersBuilder.withExistingTransactions(holders, poFromStorage, requestContext));
   }
 
   @Override

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -51,6 +51,7 @@ import org.folio.service.consortium.ConsortiumConfigurationServiceTest;
 import org.folio.service.consortium.SharingInstanceServiceTest;
 import org.folio.service.exchange.ManualExchangeRateProviderTest;
 import org.folio.service.expenceclass.ExpenseClassValidationServiceTest;
+import org.folio.service.finance.FinanceHoldersBuilderTest;
 import org.folio.service.finance.FiscalYearServiceTest;
 import org.folio.service.finance.FundServiceTest;
 import org.folio.service.finance.budget.BudgetRestrictionServiceTest;
@@ -509,5 +510,9 @@ public class ApiTestSuite {
 
   @Nested
   class BaseApiTestNested extends BaseApiTest {
+  }
+
+  @Nested
+  class FinanceHoldersBuilderTestNested extends FinanceHoldersBuilderTest {
   }
 }

--- a/src/test/java/org/folio/service/finance/FinanceHoldersBuilderTest.java
+++ b/src/test/java/org/folio/service/finance/FinanceHoldersBuilderTest.java
@@ -10,6 +10,7 @@ import org.folio.rest.acq.model.finance.Budget;
 import org.folio.rest.acq.model.finance.FiscalYear;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.Ledger;
+import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
@@ -97,9 +98,22 @@ public class FinanceHoldersBuilderTest {
       .withCost(new Cost().withCurrency("EUR"))
       .withFundDistribution(Collections.singletonList(distribution3));
 
-    holder1 = new EncumbranceRelationsHolder().withPoLine(line1).withFundDistribution(distribution1);
-    holder2 = new EncumbranceRelationsHolder().withPoLine(line2).withFundDistribution(distribution2);
-    holder3 = new EncumbranceRelationsHolder().withPoLine(line3).withFundDistribution(distribution3);
+    Transaction newEncumbrance1 = new Transaction();
+    Transaction newEncumbrance2 = new Transaction();
+    Transaction newEncumbrance3 = new Transaction();
+
+    holder1 = new EncumbranceRelationsHolder()
+      .withPoLine(line1)
+      .withFundDistribution(distribution1)
+      .withNewEncumbrance(newEncumbrance1);
+    holder2 = new EncumbranceRelationsHolder()
+      .withPoLine(line2)
+      .withFundDistribution(distribution2)
+      .withNewEncumbrance(newEncumbrance2);
+    holder3 = new EncumbranceRelationsHolder()
+      .withPoLine(line3)
+      .withFundDistribution(distribution3)
+      .withNewEncumbrance(newEncumbrance3);
   }
 
   @AfterEach
@@ -194,8 +208,8 @@ public class FinanceHoldersBuilderTest {
 
   @Test
   void shouldNotFailIfHoldersHaveNoFund() {
-    EncumbranceRelationsHolder holder1 = new EncumbranceRelationsHolder();
-    EncumbranceRelationsHolder holder2 = new EncumbranceRelationsHolder();
+    EncumbranceRelationsHolder holder1 = new EncumbranceRelationsHolder().withFundDistribution(new FundDistribution());
+    EncumbranceRelationsHolder holder2 = new EncumbranceRelationsHolder().withFundDistribution(new FundDistribution());
     List<EncumbranceRelationsHolder> holders = List.of(holder1, holder2);
 
     Future<Void> f = financeHoldersBuilder.withFinances(holders, requestContext);

--- a/src/test/java/org/folio/service/finance/FinanceHoldersBuilderTest.java
+++ b/src/test/java/org/folio/service/finance/FinanceHoldersBuilderTest.java
@@ -80,15 +80,17 @@ public class FinanceHoldersBuilderTest {
   public void initMocks(){
     mockitoMocks = MockitoAnnotations.openMocks(this);
 
-    FundDistribution distribution1 = new FundDistribution().withFundId(UUID.randomUUID().toString());
+    FundDistribution distribution1 = new FundDistribution().withFundId(UUID.randomUUID().toString()).withCode("FUND1");
 
     CompositePoLine line1 = new CompositePoLine().withId(UUID.randomUUID().toString())
+      .withPoLineNumber("1")
       .withCost(new Cost().withCurrency("USD"))
       .withFundDistribution(Collections.singletonList(distribution1));
 
-    FundDistribution distribution2 = new FundDistribution().withFundId(UUID.randomUUID().toString());
+    FundDistribution distribution2 = new FundDistribution().withFundId(UUID.randomUUID().toString()).withCode("FUND2");
 
     CompositePoLine line2 = new CompositePoLine().withId(UUID.randomUUID().toString())
+      .withPoLineNumber("2")
       .withCost(new Cost().withCurrency("USD"))
       .withFundDistribution(Collections.singletonList(distribution2));
 
@@ -254,9 +256,12 @@ public class FinanceHoldersBuilderTest {
     assertEquals(422, httpException.getCode());
     Error error = httpException.getError();
     assertEquals(BUDGET_NOT_FOUND_FOR_FISCAL_YEAR.getCode(), error.getCode());
-    assertEquals(fund2.getId(), error.getParameters().get(0).getValue());
-    assertEquals(fiscalYear1.getId(), error.getParameters().get(1).getValue());
-    assertEquals(fiscalYear1.getCode(), error.getParameters().get(2).getValue());
+    assertEquals(List.of(fund2.getId()).toString(), error.getParameters().get(0).getValue());
+    assertEquals("[FUND2]", error.getParameters().get(1).getValue());
+    assertEquals(List.of(holder2.getPoLineId()).toString(), error.getParameters().get(2).getValue());
+    assertEquals("[2]", error.getParameters().get(3).getValue());
+    assertEquals(fiscalYear1.getId(), error.getParameters().get(4).getValue());
+    assertEquals(fiscalYear1.getCode(), error.getParameters().get(5).getValue());
   }
 
   @Test

--- a/src/test/java/org/folio/service/finance/FinanceHoldersBuilderTest.java
+++ b/src/test/java/org/folio/service/finance/FinanceHoldersBuilderTest.java
@@ -1,0 +1,258 @@
+package org.folio.service.finance;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.models.EncumbranceRelationsHolder;
+import org.folio.models.ReEncumbranceHolder;
+import org.folio.rest.acq.model.finance.Budget;
+import org.folio.rest.acq.model.finance.FiscalYear;
+import org.folio.rest.acq.model.finance.Fund;
+import org.folio.rest.acq.model.finance.Ledger;
+import org.folio.rest.core.exceptions.HttpException;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePoLine;
+import org.folio.rest.jaxrs.model.Cost;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.FundDistribution;
+import org.folio.service.exchange.ExchangeRateProviderResolver;
+import org.folio.service.exchange.ManualCurrencyConversion;
+import org.folio.service.exchange.ManualExchangeRateProvider;
+import org.folio.service.finance.budget.BudgetService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.money.convert.ConversionQuery;
+import javax.money.convert.ExchangeRateProvider;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.rest.core.exceptions.ErrorCodes.BUDGET_NOT_FOUND_FOR_FISCAL_YEAR;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class FinanceHoldersBuilderTest {
+  @InjectMocks
+  private FinanceHoldersBuilder financeHoldersBuilder;
+  @Mock
+  private BudgetService budgetService;
+  @Mock
+  private FundService fundService;
+  @Mock
+  private LedgerService ledgerService;
+  @Mock
+  private ExchangeRateProviderResolver exchangeRateProviderResolver;
+  @Mock
+  private FiscalYearService fiscalYearService;
+  @Mock
+  private RequestContext requestContext;
+
+  private AutoCloseable mockitoMocks;
+  private EncumbranceRelationsHolder holder1;
+  private EncumbranceRelationsHolder holder2;
+  private EncumbranceRelationsHolder holder3;
+
+  @BeforeEach
+  public void initMocks(){
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+
+    FundDistribution distribution1 = new FundDistribution().withFundId(UUID.randomUUID().toString());
+
+    CompositePoLine line1 = new CompositePoLine().withId(UUID.randomUUID().toString())
+      .withCost(new Cost().withCurrency("USD"))
+      .withFundDistribution(Collections.singletonList(distribution1));
+
+    FundDistribution distribution2 = new FundDistribution().withFundId(UUID.randomUUID().toString());
+
+    CompositePoLine line2 = new CompositePoLine().withId(UUID.randomUUID().toString())
+      .withCost(new Cost().withCurrency("USD"))
+      .withFundDistribution(Collections.singletonList(distribution2));
+
+    FundDistribution distribution3 = new FundDistribution().withFundId(UUID.randomUUID().toString());
+
+    CompositePoLine line3 = new CompositePoLine().withId(UUID.randomUUID().toString())
+      .withCost(new Cost().withCurrency("EUR"))
+      .withFundDistribution(Collections.singletonList(distribution3));
+
+    holder1 = new EncumbranceRelationsHolder().withPoLine(line1).withFundDistribution(distribution1);
+    holder2 = new EncumbranceRelationsHolder().withPoLine(line2).withFundDistribution(distribution2);
+    holder3 = new EncumbranceRelationsHolder().withPoLine(line3).withFundDistribution(distribution3);
+  }
+
+  @AfterEach
+  public void resetMocks() throws Exception {
+    mockitoMocks.close();
+  }
+
+  @Test
+  void shouldPopulateHoldersWithFinanceStructures(VertxTestContext vertxTestContext) {
+    // Given
+    Ledger ledger1 = new Ledger().withId(UUID.randomUUID().toString()).withRestrictEncumbrance(true);
+    Ledger ledger2 = new Ledger().withId(UUID.randomUUID().toString()).withRestrictEncumbrance(true);
+    Ledger ledger3 = new Ledger().withId(UUID.randomUUID().toString()).withRestrictEncumbrance(false);
+
+    Fund fund1 = new Fund().withId(holder1.getFundId()).withLedgerId(ledger1.getId());
+    Fund fund2 = new Fund().withId(holder2.getFundId()).withLedgerId(ledger2.getId());
+    Fund fund3 = new Fund().withId(holder3.getFundId()).withLedgerId(ledger3.getId());
+
+    Budget budget1 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder1.getFundId());
+    Budget budget2 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder2.getFundId());
+    Budget budget3 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder3.getFundId());
+
+    String fiscalYearId = UUID.randomUUID().toString();
+    FiscalYear fiscalYear = new FiscalYear().withId(fiscalYearId).withCurrency("RUB");
+
+    List<EncumbranceRelationsHolder> holders = List.of(holder1, holder2, holder3);
+
+    when(fundService.getAllFunds(anyCollection(), any()))
+      .thenReturn(Future.succeededFuture(List.of(fund1, fund2, fund3)));
+    when(ledgerService.getLedgersByIds(anyCollection(), any()))
+      .thenReturn(Future.succeededFuture(List.of(ledger2, ledger1, ledger3)));
+    when(fiscalYearService.getCurrentFiscalYear(anyString(), any()))
+      .thenReturn(Future.succeededFuture(fiscalYear));
+    when(budgetService.getBudgetsByQuery(anyString(), any()))
+      .thenReturn(Future.succeededFuture(List.of(budget1, budget2, budget3)));
+    ExchangeRateProvider exchangeRateProvider = mock(ManualExchangeRateProvider.class);
+    when(exchangeRateProviderResolver.resolve(any(), any()))
+      .thenReturn(exchangeRateProvider);
+    when(exchangeRateProvider.getCurrencyConversion(any(ConversionQuery.class)))
+      .thenAnswer(invocation -> {
+        ConversionQuery conversionQuery = invocation.getArgument(0);
+        return mock(ManualCurrencyConversion.class, conversionQuery.getBaseCurrency().getCurrencyCode());
+      });
+    when(requestContext.getContext())
+      .thenReturn(Vertx.vertx().getOrCreateContext());
+
+    // When
+    var future = financeHoldersBuilder.withFinances(holders, requestContext);
+
+    // Then
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        assertEquals(ledger1.getId(), holder1.getLedgerId());
+        assertEquals(ledger1.getRestrictEncumbrance(), holder1.getRestrictEncumbrance());
+        assertEquals(ledger2.getId(), holder2.getLedgerId());
+        assertEquals(ledger2.getRestrictEncumbrance(), holder2.getRestrictEncumbrance());
+        assertEquals(ledger3.getId(), holder3.getLedgerId());
+        assertEquals(ledger3.getRestrictEncumbrance(), holder3.getRestrictEncumbrance());
+
+        assertEquals(budget1, holder1.getBudget());
+        assertEquals(budget2, holder2.getBudget());
+        assertEquals(budget3, holder3.getBudget());
+
+        assertThat(holders, everyItem(hasProperty("newEncumbrance", allOf(
+          hasProperty("fiscalYearId", is(fiscalYear.getId())),
+          hasProperty("currency", is(fiscalYear.getCurrency()))
+        ))));
+
+        assertEquals("USD", holder1.getPoLineToFyConversion().toString());
+        assertEquals("USD", holder2.getPoLineToFyConversion().toString());
+        assertSame(holder1.getPoLineToFyConversion(), holder2.getPoLineToFyConversion());
+        assertEquals("EUR", holder3.getPoLineToFyConversion().toString());
+
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void shouldNotRetrieveAnythingIfHoldersAreEmpty() {
+    List<EncumbranceRelationsHolder> holders = Collections.emptyList();
+
+    Future<Void> f = financeHoldersBuilder.withFinances(holders, requestContext);
+
+    assertTrue(f.succeeded());
+    assertThat(holders, Matchers.is(empty()));
+    verify(fundService, never()).getAllFunds(anyCollection(), any());
+    verify(ledgerService, never()).getLedgersByIds(anyCollection(), any());
+    verify(fiscalYearService, never()).getCurrentFiscalYear(anyString(), any());
+    verify(budgetService, never()).getBudgetsByQuery(anyString(), any());
+    verify(exchangeRateProviderResolver, never()).resolve(any(), any());
+  }
+
+  @Test
+  void shouldNotFailIfHoldersHaveNoFund() {
+    EncumbranceRelationsHolder holder1 = new EncumbranceRelationsHolder();
+    EncumbranceRelationsHolder holder2 = new EncumbranceRelationsHolder();
+    List<EncumbranceRelationsHolder> holders = List.of(holder1, holder2);
+
+    Future<Void> f = financeHoldersBuilder.withFinances(holders, requestContext);
+
+    assertTrue(f.succeeded());
+  }
+
+  @Test
+  void shouldThrowExceptionWithMultipleFiscalYears() {
+    // Note: when the funds are using multiple fiscal years, some budgets will not be found using the first fiscal year
+    // The same error can also happen if a budget is missing or inactive.
+    // Given
+    FiscalYear fiscalYear1 = new FiscalYear().withId(UUID.randomUUID().toString()).withCode("FY1");
+
+    Ledger ledger1 = new Ledger().withId(UUID.randomUUID().toString()).withRestrictEncumbrance(true);
+    Ledger ledger2 = new Ledger().withId(UUID.randomUUID().toString()).withRestrictEncumbrance(true);
+
+    Fund fund1 = new Fund().withId(holder1.getFundId()).withLedgerId(ledger1.getId());
+    Fund fund2 = new Fund().withId(holder2.getFundId()).withLedgerId(ledger2.getId());
+
+    Budget budget1 = new Budget()
+      .withId(UUID.randomUUID().toString())
+      .withFundId(fund1.getId())
+      .withFiscalYearId(fiscalYear1.getId());
+
+    List<EncumbranceRelationsHolder> holders = List.of(holder1, holder2);
+
+    when(fundService.getAllFunds(anyCollection(), any()))
+      .thenReturn(Future.succeededFuture(List.of(fund1, fund2)));
+    when(ledgerService.getLedgersByIds(anyCollection(), any()))
+      .thenReturn(Future.succeededFuture(List.of(ledger1, ledger2)));
+    when(fiscalYearService.getCurrentFiscalYear(anyString(), any()))
+      .thenReturn(Future.succeededFuture(fiscalYear1));
+    when(budgetService.getBudgetsByQuery(anyString(), any()))
+      .thenReturn(Future.succeededFuture(List.of(budget1)));
+
+    // When
+    Future<Void> f = financeHoldersBuilder.withFinances(holders, requestContext);
+
+    // Then
+    HttpException httpException = (HttpException)f.cause();
+    assertEquals(422, httpException.getCode());
+    Error error = httpException.getError();
+    assertEquals(BUDGET_NOT_FOUND_FOR_FISCAL_YEAR.getCode(), error.getCode());
+    assertEquals(fund2.getId(), error.getParameters().get(0).getValue());
+    assertEquals(fiscalYear1.getId(), error.getParameters().get(1).getValue());
+    assertEquals(fiscalYear1.getCode(), error.getParameters().get(2).getValue());
+  }
+
+  @Test
+  void shouldNotRetrieveFundsIfReEncumbranceHoldersIsEmpty() {
+    List<ReEncumbranceHolder> holders = Collections.emptyList();
+
+    financeHoldersBuilder.getLedgerIds(holders, requestContext).result();
+
+    assertThat(holders, Matchers.is(empty()));
+    verify(fundService, never()).getFunds(anyCollection(), any());
+  }
+
+}

--- a/src/test/java/org/folio/service/finance/budget/BudgetServiceTest.java
+++ b/src/test/java/org/folio/service/finance/budget/BudgetServiceTest.java
@@ -2,8 +2,8 @@ package org.folio.service.finance.budget;
 
 import io.vertx.core.Future;
 import org.folio.rest.acq.model.finance.Budget;
+import org.folio.rest.acq.model.finance.BudgetCollection;
 import org.folio.rest.core.RestClient;
-import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
 import org.junit.jupiter.api.AfterEach;
@@ -14,9 +14,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.List;
-import java.util.UUID;
 
-import static org.folio.rest.core.exceptions.ErrorCodes.BUDGET_NOT_FOUND_FOR_TRANSACTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,22 +43,21 @@ public class BudgetServiceTest {
   }
 
   @Test
-  @DisplayName("Test getBudgets failure")
-  void testGetBudgetsFailure() {
+  @DisplayName("Test getBudgetsByQuery")
+  void testGetBudgetsByQuery() {
     // Given
-    doReturn(Future.failedFuture(new HttpException(404, "not found")))
-      .when(restClient).get(any(RequestEntry.class), eq(Budget.class), eq(requestContext));
-    String fundId = UUID.randomUUID().toString();
+    Budget budget = new Budget();
+    BudgetCollection budgetCollection = new BudgetCollection().withBudgets(List.of(budget));
+    doReturn(Future.succeededFuture(budgetCollection))
+      .when(restClient).get(any(RequestEntry.class), eq(BudgetCollection.class), eq(requestContext));
 
     // When
-    Future<List<Budget>> future = budgetService.getBudgets(List.of(fundId), requestContext);
+    Future<List<Budget>> future = budgetService.getBudgetsByQuery("", requestContext);
 
     // Then
-    assertTrue(future.failed());
-    HttpException ex = (HttpException)future.cause();
-    assertThat(ex.getErrors().getErrors(), hasSize(1));
-    assertEquals(BUDGET_NOT_FOUND_FOR_TRANSACTION.getCode(), ex.getError().getCode());
-    assertEquals(fundId, ex.getError().getParameters().get(0).getValue());
+    assertTrue(future.succeeded());
+    assertThat(future.result(), hasSize(1));
+    assertEquals(budget, future.result().get(0));
   }
 
 }

--- a/src/test/java/org/folio/service/finance/transaction/ClosedToOpenEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/ClosedToOpenEncumbranceStrategyTest.java
@@ -30,6 +30,7 @@ import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
 import org.folio.rest.jaxrs.model.FundDistribution;
 import org.folio.service.FundsDistributionService;
 import org.folio.service.finance.budget.BudgetRestrictionService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,10 +56,16 @@ public class ClosedToOpenEncumbranceStrategyTest {
   BudgetRestrictionService budgetRestrictionService;
   @Mock
   private RequestContext requestContext;
+  private AutoCloseable mockitoMocks;
 
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.openMocks(this);
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void resetMocks() throws Exception {
+    mockitoMocks.close();
   }
 
   @Test
@@ -79,12 +86,8 @@ public class ClosedToOpenEncumbranceStrategyTest {
     encumbranceRelationsHolders.add(new EncumbranceRelationsHolder()
       .withFundDistribution(new FundDistribution()));
     doReturn(encumbranceRelationsHolders).when(encumbranceRelationsHoldersBuilder).buildBaseHolders(any());
-    doReturn(succeededFuture(encumbranceRelationsHolders)).when(encumbranceRelationsHoldersBuilder).withBudgets(any(), any());
-    doReturn(succeededFuture(encumbranceRelationsHolders)).when(encumbranceRelationsHoldersBuilder).withLedgersData(any(),any());
-    doReturn(succeededFuture(encumbranceRelationsHolders)).when(encumbranceRelationsHoldersBuilder).withFiscalYearData(any(), any());
-    doReturn(succeededFuture(encumbranceRelationsHolders)).when(encumbranceRelationsHoldersBuilder).withConversion(any(), any());
+    doReturn(succeededFuture()).when(encumbranceRelationsHoldersBuilder).withFinances(any(), any());
 
-    doReturn(encumbranceRelationsHolders).when(encumbranceRelationsHoldersBuilder).withKnownTransactions(any(), any());
     doReturn(encumbranceRelationsHolders).when(fundsDistributionService).distributeFunds(any());
     doReturn(succeededFuture(null)).when(encumbranceService).createOrUpdateEncumbrances(any(), any());
 

--- a/src/test/java/org/folio/service/finance/transaction/EncumbranceRelationsHoldersBuilderTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/EncumbranceRelationsHoldersBuilderTest.java
@@ -6,7 +6,6 @@ import static org.folio.rest.acq.model.finance.Encumbrance.OrderStatus.OPEN;
 import static org.folio.rest.acq.model.finance.Encumbrance.OrderType.ONGOING;
 import static org.folio.rest.acq.model.finance.Encumbrance.Status.UNRELEASED;
 import static org.folio.rest.acq.model.finance.Transaction.Source.PO_LINE;
-import static org.folio.rest.core.exceptions.ErrorCodes.MULTIPLE_FISCAL_YEARS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
@@ -18,13 +17,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -32,32 +26,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import javax.money.convert.ConversionQuery;
-import javax.money.convert.ExchangeRateProvider;
-
 import org.folio.models.EncumbranceRelationsHolder;
-import org.folio.rest.acq.model.finance.Budget;
 import org.folio.rest.acq.model.finance.Encumbrance;
-import org.folio.rest.acq.model.finance.FiscalYear;
-import org.folio.rest.acq.model.finance.Fund;
-import org.folio.rest.acq.model.finance.Ledger;
 import org.folio.rest.acq.model.finance.Metadata;
 import org.folio.rest.acq.model.finance.Transaction;
-import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Cost;
-import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.FundDistribution;
 import org.folio.rest.jaxrs.model.Ongoing;
-import org.folio.service.exchange.ExchangeRateProviderResolver;
-import org.folio.service.exchange.ManualCurrencyConversion;
-import org.folio.service.exchange.ManualExchangeRateProvider;
-import org.folio.service.finance.FiscalYearService;
-import org.folio.service.finance.FundService;
-import org.folio.service.finance.LedgerService;
-import org.folio.service.finance.budget.BudgetService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,9 +45,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
 public class EncumbranceRelationsHoldersBuilderTest {
@@ -77,16 +53,6 @@ public class EncumbranceRelationsHoldersBuilderTest {
   @InjectMocks
   private EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder;
 
-  @Mock
-  private BudgetService budgetService;
-  @Mock
-  private FundService fundService;
-  @Mock
-  private LedgerService ledgerService;
-  @Mock
-  private ExchangeRateProviderResolver exchangeRateProviderResolver;
-  @Mock
-  private FiscalYearService fiscalYearService;
   @Mock
   private EncumbranceService encumbranceService;
   @Mock
@@ -362,148 +328,6 @@ public class EncumbranceRelationsHoldersBuilderTest {
 
     assertThat(resultHolders, hasItem( hasProperty("oldEncumbrance", is(encumbranceFromStorage1))));
     assertThat(resultHolders, hasItem( hasProperty("oldEncumbrance", is(encumbranceFromStorage2))));
-  }
-
-  @Test
-  void testShouldPopulateHoldersWithCorrespondingBudgets() {
-    //given
-    Budget budget1 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder1.getFundId());
-    Budget budget2 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder2.getFundId());
-    Budget budget3 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder3.getFundId());
-
-    List<EncumbranceRelationsHolder> holders = new ArrayList<>();
-    holders.add(holder1);
-    holders.add(holder2);
-    holders.add(holder3);
-
-    when(budgetService.getBudgets(anyCollection(), any()))
-        .thenReturn(Future.succeededFuture(List.of(budget1, budget2, budget3)));
-
-    //When
-    encumbranceRelationsHoldersBuilder.withBudgets(holders, requestContextMock).result();
-    //Then
-    assertEquals(budget1, holder1.getBudget());
-    assertEquals(budget2, holder2.getBudget());
-    assertEquals(budget3, holder3.getBudget());
-  }
-
-  @Test
-  void testShouldPopulateHoldersWithCorrespondingLedgerData() {
-    //given
-
-    Fund fund1 = new Fund().withId(holder1.getFundId()).withLedgerId(UUID.randomUUID().toString());
-    Fund fund2 = new Fund().withId(holder2.getFundId()).withLedgerId(UUID.randomUUID().toString());
-    Fund fund3 = new Fund().withId(holder3.getFundId()).withLedgerId(UUID.randomUUID().toString());
-
-    Ledger ledger1 = new Ledger().withId(fund1.getLedgerId()).withRestrictEncumbrance(true);
-    Ledger ledger2 = new Ledger().withId(fund2.getLedgerId()).withRestrictEncumbrance(true);
-    Ledger ledger3 = new Ledger().withId(fund3.getLedgerId()).withRestrictEncumbrance(false);
-
-    List<EncumbranceRelationsHolder> holders = new ArrayList<>();
-    holders.add(holder1);
-    holders.add(holder2);
-    holders.add(holder3);
-
-    when(fundService.getAllFunds(anyCollection(), any())).thenReturn(Future.succeededFuture(List.of(fund1, fund2, fund3)));
-    when(ledgerService.getLedgersByIds(anyCollection(), any())).thenReturn(Future.succeededFuture(List.of(ledger2, ledger1, ledger3)));
-
-    //When
-    encumbranceRelationsHoldersBuilder.withLedgersData(holders, requestContextMock).result();
-    //Then
-    assertEquals(ledger1.getId(), holder1.getLedgerId());
-    assertEquals(ledger1.getRestrictEncumbrance(), holder1.getRestrictEncumbrance());
-    assertEquals(ledger2.getId(), holder2.getLedgerId());
-    assertEquals(ledger2.getRestrictEncumbrance(), holder2.getRestrictEncumbrance());
-    assertEquals(ledger3.getId(), holder3.getLedgerId());
-    assertEquals(ledger3.getRestrictEncumbrance(), holder3.getRestrictEncumbrance());
-  }
-
-  @Test
-  void testShouldPopulateHoldersWithFiscalYearData() {
-    //given
-    String fiscalYearId = UUID.randomUUID().toString();
-    FiscalYear fiscalYear = new FiscalYear().withId(fiscalYearId).withCurrency("RUB");
-
-    Budget budget1 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder1.getFundId()).withFiscalYearId(fiscalYearId);
-    Budget budget2 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder2.getFundId()).withFiscalYearId(fiscalYearId);
-    Budget budget3 = new Budget().withId(UUID.randomUUID().toString()).withFundId(holder3.getFundId()).withFiscalYearId(fiscalYearId);
-
-    List<EncumbranceRelationsHolder> holders = new ArrayList<>();
-    holders.add(holder1.withBudget(budget1));
-    holders.add(holder2.withBudget(budget2));
-    holders.add(holder3.withBudget(budget3));
-   when(fiscalYearService.getFiscalYearById(anyString(), any())).thenReturn(Future.succeededFuture(fiscalYear));
-    //When
-    List<EncumbranceRelationsHolder> resultHolders = encumbranceRelationsHoldersBuilder.withFiscalYearData(holders, requestContextMock).result();
-    //Then
-    assertThat(resultHolders, everyItem(hasProperty("newEncumbrance", allOf(
-        hasProperty("fiscalYearId", is(fiscalYear.getId())),
-        hasProperty("currency", is(fiscalYear.getCurrency()))
-    ))));
-  }
-
-  @Test
-  void testShouldThrowExceptionWithMultipleFiscalYears() {
-    //Given
-    FiscalYear fiscalYear1 = new FiscalYear()
-      .withId(UUID.randomUUID().toString());
-    FiscalYear fiscalYear2 = new FiscalYear()
-      .withId(UUID.randomUUID().toString());
-
-    Budget budget1 = new Budget()
-      .withId(UUID.randomUUID().toString())
-      .withFundId(holder1.getFundId())
-      .withFiscalYearId(fiscalYear1.getId());
-    Budget budget2 = new Budget()
-      .withId(UUID.randomUUID().toString())
-      .withFundId(holder2.getFundId())
-      .withFiscalYearId(fiscalYear2.getId());
-
-    List<EncumbranceRelationsHolder> holders = new ArrayList<>();
-    holders.add(holder1.withBudget(budget1));
-    holders.add(holder2.withBudget(budget2));
-
-    //When
-    HttpException httpException = assertThrows(HttpException.class, () -> encumbranceRelationsHoldersBuilder
-      .withFiscalYearData(holders, requestContextMock).result());
-
-    //Then
-    assertEquals(422, httpException.getCode());
-    Error error = httpException.getError();
-    assertEquals(MULTIPLE_FISCAL_YEARS.getCode(), error.getCode());
-    assertEquals(List.of(fiscalYear1.getId(), fiscalYear2.getId()).toString(), error.getParameters().get(0).getValue());
-    assertEquals(order.getId(), error.getParameters().get(1).getValue());
-  }
-
-  @Test
-  void testShouldPopulatePoLineToFiscalYearCurrencyConversion(VertxTestContext vertxTestContext) {
-    //given
-    String currency = "RUB";
-
-    List<EncumbranceRelationsHolder> holders = new ArrayList<>();
-    holders.add(holder1.withCurrency(currency));
-    holders.add(holder2.withCurrency(currency));
-    holders.add(holder3.withCurrency(currency));
-    ExchangeRateProvider exchangeRateProvider = mock(ManualExchangeRateProvider.class);
-    when(exchangeRateProviderResolver.resolve(any(), any())).thenReturn(exchangeRateProvider);
-    when(exchangeRateProvider.getCurrencyConversion(any(ConversionQuery.class))).thenAnswer(invocation -> {
-      ConversionQuery conversionQuery = invocation.getArgument(0);
-      return mock(ManualCurrencyConversion.class, conversionQuery.getBaseCurrency().getCurrencyCode());
-    });
-    when(requestContextMock.getContext()).thenReturn(Vertx.vertx().getOrCreateContext());
-    //When
-    var future = encumbranceRelationsHoldersBuilder.withConversion(holders, requestContextMock);
-
-    vertxTestContext.assertComplete(future)
-      .onComplete(result -> {
-        //Then
-        assertEquals("USD", holder1.getPoLineToFyConversion().toString());
-        assertEquals("USD", holder2.getPoLineToFyConversion().toString());
-        assertSame(holder1.getPoLineToFyConversion(), holder2.getPoLineToFyConversion());
-        assertEquals("EUR", holder3.getPoLineToFyConversion().toString());
-        vertxTestContext.completeNow();
-      });
-
   }
 
 }

--- a/src/test/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategyTest.java
@@ -102,10 +102,7 @@ public class OpenToPendingEncumbranceStrategyTest {
         .withCurrentFiscalYearId(UUID.randomUUID().toString()));
 
       doReturn(new ArrayList<EncumbranceRelationsHolder>()).when(encumbranceRelationsHoldersBuilder).buildBaseHolders(any());
-      doReturn(succeededFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withBudgets(any(), any());
-      doReturn(succeededFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withLedgersData(any(),any());
-      doReturn(succeededFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withFiscalYearData(any(), any());
-      doReturn(succeededFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withConversion(any(), any());
+      doReturn(succeededFuture(new ArrayList<EncumbranceRelationsHolder>())).when(encumbranceRelationsHoldersBuilder).withFinances(any(), any());
       doReturn(succeededFuture(encumbranceRelationsHolders)).when(encumbranceRelationsHoldersBuilder).withExistingTransactions(any(), any(), any());
       doReturn(succeededFuture(encumbranceRelationsHolders)).when(encumbranceRelationsHoldersBuilder).prepareEncumbranceRelationsHolder(any(), any(), any());
 

--- a/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
@@ -14,6 +14,7 @@ package org.folio.service.finance.transaction;
   import static org.junit.jupiter.api.Assertions.assertNull;
   import static org.junit.jupiter.api.Assertions.assertTrue;
   import static org.mockito.ArgumentMatchers.any;
+  import static org.mockito.ArgumentMatchers.anyCollection;
   import static org.mockito.ArgumentMatchers.anyList;
   import static org.mockito.ArgumentMatchers.anyString;
   import static org.mockito.ArgumentMatchers.argThat;
@@ -22,6 +23,7 @@ package org.folio.service.finance.transaction;
   import static org.mockito.Mockito.doReturn;
   import static org.mockito.Mockito.times;
   import static org.mockito.Mockito.verify;
+  import static org.mockito.Mockito.when;
 
   import java.util.List;
   import java.util.UUID;
@@ -166,21 +168,19 @@ public class PendingToOpenEncumbranceStrategyTest {
     Budget budget2 = new Budget().withId(UUID.randomUUID().toString())
       .withFundId(fundId2)
       .withFiscalYearId(fiscalYearId);
-    doReturn(succeededFuture(List.of(budget1, budget2)))
-      .when(budgetService).getBudgets(anyList(), eq(requestContext));
-
     Fund fund1 = new Fund().withId(fundId1).withLedgerId(UUID.randomUUID().toString());
     Fund fund2 = new Fund().withId(fundId2).withLedgerId(UUID.randomUUID().toString());
-    doReturn(succeededFuture(List.of(fund1, fund2)))
-      .when(fundService).getAllFunds(anyList(), eq(requestContext));
-
     Ledger ledger = new Ledger().withId(fund1.getLedgerId()).withRestrictEncumbrance(true);
-    doReturn(succeededFuture(List.of(ledger)))
-      .when(ledgerService).getLedgersByIds(anyList(), eq(requestContext));
-
     FiscalYear fiscalYear = new FiscalYear().withId(fiscalYearId).withCurrency("USD");
-    doReturn(succeededFuture(fiscalYear))
-      .when(fiscalYearService).getFiscalYearById(anyString(), eq(requestContext));
+
+    doReturn(Future.succeededFuture(List.of(fund1, fund2)))
+      .when(fundService).getAllFunds(anyCollection(), any());
+    doReturn(Future.succeededFuture(List.of(ledger)))
+      .when(ledgerService).getLedgersByIds(anyCollection(), any());
+    doReturn(Future.succeededFuture(fiscalYear))
+      .when(fiscalYearService).getCurrentFiscalYear(anyString(), any());
+    doReturn(Future.succeededFuture(List.of(budget1, budget2)))
+      .when(budgetService).getBudgetsByQuery(anyString(), any());
 
     InvoiceLine invoiceLine = new InvoiceLine()
       .withId(invoiceLineId)

--- a/src/test/java/org/folio/service/orders/ReEncumbranceHoldersBuilderTest.java
+++ b/src/test/java/org/folio/service/orders/ReEncumbranceHoldersBuilderTest.java
@@ -2,7 +2,6 @@ package org.folio.service.orders;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
@@ -11,10 +10,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
@@ -36,11 +32,9 @@ import javax.money.convert.CurrencyConversion;
 import javax.money.convert.ExchangeRate;
 
 import org.folio.models.ReEncumbranceHolder;
-import org.folio.rest.acq.model.finance.Budget;
 import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.FiscalYear;
 import org.folio.rest.acq.model.finance.Fund;
-import org.folio.rest.acq.model.finance.Ledger;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
@@ -54,26 +48,23 @@ import org.folio.service.FundsDistributionService;
 import org.folio.service.exchange.ExchangeRateProviderResolver;
 import org.folio.service.exchange.ManualCurrencyConversion;
 import org.folio.service.exchange.ManualExchangeRateProvider;
-import org.folio.service.finance.FiscalYearService;
-import org.folio.service.finance.FundService;
-import org.folio.service.finance.LedgerService;
-import org.folio.service.finance.budget.BudgetService;
 import org.folio.service.finance.rollover.LedgerRolloverService;
 import org.folio.service.finance.transaction.TransactionService;
 import org.javamoney.moneta.Money;
 import org.javamoney.moneta.spi.DefaultNumberValue;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.mockito.Spy;
 
 
 @ExtendWith(VertxExtension.class)
@@ -83,32 +74,28 @@ public class ReEncumbranceHoldersBuilderTest {
   private ReEncumbranceHoldersBuilder reEncumbranceHoldersBuilder;
 
   @Mock
-  private FundService fundService;
-  @Mock
-  private LedgerService ledgerService;
-  @Mock
-  private FiscalYearService fiscalYearService;
-  @Mock
-  private BudgetService budgetService;
-  @Mock
   private LedgerRolloverService ledgerRolloverService;
   @Mock
   private ExchangeRateProviderResolver exchangeRateProviderResolver;
   @Mock
   private ManualExchangeRateProvider exchangeRateProvider;
   @Mock
-  private ManualCurrencyConversion currencyConversion;
-  @Mock
   private TransactionService transactionService;
   @Spy
   private FundsDistributionService fundsDistributionService;
+  private AutoCloseable mockitoMocks;
 
   @Mock
   private RequestContext requestContext;
 
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.openMocks(this);
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void resetMocks() throws Exception {
+    mockitoMocks.close();
   }
 
   @Test
@@ -128,217 +115,6 @@ public class ReEncumbranceHoldersBuilderTest {
       hasProperty("poLine", is(compositePoLine1)),
       hasProperty("fundDistribution", is(oneOf(fundDistribution1, fundDistribution2)))
     )));
-  }
-
-  @Test
-  void shouldPopulateEachReEncumbranceHolderWithCorrespondingLedgerIdIfAllFundsFound() {
-    FundDistribution fundDistribution1 = new FundDistribution().withFundId(UUID.randomUUID().toString());
-    FundDistribution fundDistribution2 = new FundDistribution().withFundId(UUID.randomUUID().toString());
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder().withFundDistribution(fundDistribution1);
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder().withFundDistribution(fundDistribution2);
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
-
-    Fund fund1 = new Fund().withId(fundDistribution1.getFundId()).withLedgerId(UUID.randomUUID().toString());
-    Fund fund2 = new Fund().withId(fundDistribution2.getFundId()).withLedgerId(UUID.randomUUID().toString());
-
-    when(fundService.getFunds(anyCollection(), any())).thenReturn(Future.succeededFuture(Arrays.asList(fund2, fund1)));
-
-
-    reEncumbranceHoldersBuilder.withFundsData(holders, requestContext).result();
-
-    assertEquals(fund1.getLedgerId(), holder1.getLedgerId());
-    assertEquals(fund2.getLedgerId(), holder2.getLedgerId());
-
-
-  }
-
-  @Test
-  void shouldPopulateReEncumbranceHolderFundWithNullIfCorrespondingFundsFound() {
-    FundDistribution fundDistribution1 = new FundDistribution().withFundId(UUID.randomUUID().toString());
-    FundDistribution fundDistribution2 = new FundDistribution().withFundId(UUID.randomUUID().toString());
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder().withFundDistribution(fundDistribution1);
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder().withFundDistribution(fundDistribution2);
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
-
-    Fund fund1 = new Fund().withId(fundDistribution1.getFundId()).withLedgerId(UUID.randomUUID().toString());
-
-    when(fundService.getFunds(anyCollection(), any())).thenReturn(Future.succeededFuture(Collections.singletonList(fund1)));
-
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withFundsData(holders, requestContext).result();
-
-    assertThat(resultHolders, hasItem(allOf(hasProperty("ledgerId", is(fund1.getLedgerId())), hasProperty("fundDistribution", is(fundDistribution1)))));
-    assertThat(resultHolders, hasItem(allOf(hasProperty("ledgerId", nullValue()), hasProperty("fundDistribution", is(fundDistribution2)))));
-
-
-  }
-
-  @Test
-  void shouldNotRetrieveFundsIfReEncumbranceHoldersIsEmpty() {
-
-    List<ReEncumbranceHolder> holders = Collections.emptyList();
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withFundsData(holders, requestContext).result();
-    assertThat(resultHolders, is(empty()));
-    verify(fundService, never()).getFunds(anyCollection(), any());
-
-  }
-
-  @Test
-  void shouldPopulateEachReEncumbranceHolderContainingFundWithCorrespondingLedgerData() {
-
-    String ledgerId1 = UUID.randomUUID().toString();
-    String ledgerId2 = UUID.randomUUID().toString();
-
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder().withLedgerId(ledgerId1);
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder().withLedgerId(ledgerId2);
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
-
-    Ledger ledger1 = new Ledger().withId(ledgerId1).withRestrictEncumbrance(true);
-    Ledger ledger2 = new Ledger().withId(ledgerId2).withRestrictEncumbrance(false);
-
-
-    when(ledgerService.getLedgersByIds(anyCollection(), any())).thenReturn(Future.succeededFuture(Arrays.asList(ledger1, ledger2)));
-
-
-   reEncumbranceHoldersBuilder.withLedgersData(holders, requestContext).result();
-
-    assertTrue(holder1.getRestrictEncumbrance());
-    assertFalse(holder2.getRestrictEncumbrance());
-
-  }
-
-  @Test
-  void shouldNotRetrieveLedgersIfReEncumbranceHoldersIsEmpty() {
-
-    List<ReEncumbranceHolder> holders = Collections.emptyList();
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withLedgersData(holders, requestContext).result();
-    assertThat(resultHolders, is(empty()));
-    verify(ledgerService, never()).getLedgersByIds(anyCollection(), any());
-
-  }
-
-  @Test
-  void shouldNotPopulateRestrictEncumbranceForReEncumbranceHoldersWithoutLedgerId() {
-    Fund fund1 = new Fund().withId(UUID.randomUUID().toString()).withLedgerId(UUID.randomUUID().toString());
-
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder().withLedgerId(fund1.getLedgerId());
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder();
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
-
-    Ledger ledger1 = new Ledger().withId(fund1.getLedgerId()).withRestrictEncumbrance(true);
-
-    when(ledgerService.getLedgersByIds(anyCollection(), any())).thenReturn(Future.succeededFuture(Collections.singletonList(ledger1)));
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withLedgersData(holders, requestContext).result();
-
-    assertThat(resultHolders, hasItem(hasProperty("restrictEncumbrance", is(false))));
-    assertThat(resultHolders, hasItem(hasProperty("restrictEncumbrance", is(true))));
-  }
-
-  @Test
-  void shouldPopulateEachReEncumbranceHolderWithFiscalYearIfFundExist() {
-
-    Fund fund1 = new Fund().withId(UUID.randomUUID().toString()).withLedgerId(UUID.randomUUID().toString());
-    Fund fund2 = new Fund().withId(UUID.randomUUID().toString()).withLedgerId(UUID.randomUUID().toString());
-
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder().withLedgerId(fund1.getLedgerId());
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder().withLedgerId(fund2.getLedgerId());
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2);
-
-    FiscalYear fiscalYear = new FiscalYear().withId(UUID.randomUUID().toString());
-
-    when(fiscalYearService.getCurrentFiscalYear(anyString(), any())).thenReturn(Future.succeededFuture(fiscalYear));
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withCurrentFiscalYearData(holders, requestContext).result();
-
-    assertThat(resultHolders, everyItem(hasProperty("currentFiscalYearId", is(fiscalYear.getId()))));
-    assertThat(resultHolders, everyItem(hasProperty("currency", is(fiscalYear.getCurrency()))));
-
-  }
-
-  @Test
-  void shouldNotRetrieveCurrentFiscalYearIfReEncumbranceHoldersIsEmpty() {
-
-    List<ReEncumbranceHolder> holders = Collections.emptyList();
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withCurrentFiscalYearData(holders, requestContext).result();
-    assertThat(resultHolders, is(empty()));
-    verify(fiscalYearService, never()).getCurrentFiscalYear(anyString(), any());
-
-  }
-
-  @Test
-  void shouldPopulateCurrentFiscalYearDataForReEncumbranceHoldersIfAnyHolderHasFund() {
-    Fund fund2 = new Fund().withId(UUID.randomUUID().toString()).withLedgerId(UUID.randomUUID().toString());
-    Fund fund3 = new Fund().withId(UUID.randomUUID().toString()).withLedgerId(UUID.randomUUID().toString());
-
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder();
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder().withLedgerId(fund2.getLedgerId());
-    ReEncumbranceHolder holder3 = new ReEncumbranceHolder().withLedgerId(fund3.getLedgerId());
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2, holder3);
-
-    FiscalYear fiscalYear = new FiscalYear().withId(UUID.randomUUID().toString());
-
-    when(fiscalYearService.getCurrentFiscalYear(anyString(), any())).thenReturn(Future.succeededFuture(fiscalYear));
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withCurrentFiscalYearData(holders, requestContext).result();
-
-    assertThat(resultHolders, everyItem(hasProperty("currentFiscalYearId", is(fiscalYear.getId()))));
-    assertThat(resultHolders, everyItem(hasProperty("currency", is(fiscalYear.getCurrency()))));
-  }
-
-  @Test
-  void shouldNotPopulateCurrentFiscalYearForReEncumbranceHoldersIfNoneHolderHasFund() {
-
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder();
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder();
-    ReEncumbranceHolder holder3 = new ReEncumbranceHolder();
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2, holder3);
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withCurrentFiscalYearData(holders, requestContext).result();
-
-    assertThat(resultHolders, everyItem(hasProperty("currentFiscalYearId", nullValue())));
-    assertThat(resultHolders, everyItem(hasProperty("currency", nullValue())));
-    verify(fiscalYearService, never()).getCurrentFiscalYear(anyString(), any());
-  }
-
-  @Test
-  void shouldPopulateReEncumbranceHoldersWithCorrespondingBudgetsForEveryHolderWithLedgerId() {
-    Fund fund1 = new Fund().withId(UUID.randomUUID().toString()).withLedgerId(UUID.randomUUID().toString());
-    Fund fund2 = new Fund().withId(UUID.randomUUID().toString()).withLedgerId(UUID.randomUUID().toString());
-
-    FundDistribution distribution1 = new FundDistribution().withFundId(fund1.getId());
-    FundDistribution distribution2 = new FundDistribution().withFundId(fund2.getId());
-    FundDistribution distribution3 = new FundDistribution().withFundId(UUID.randomUUID().toString());
-
-    ReEncumbranceHolder holder1 = new ReEncumbranceHolder().withLedgerId(fund1.getLedgerId()).withFundDistribution(distribution1);
-    ReEncumbranceHolder holder2 = new ReEncumbranceHolder().withLedgerId(fund2.getLedgerId()).withFundDistribution(distribution2);
-    ReEncumbranceHolder holder3 = new ReEncumbranceHolder().withFundDistribution(distribution3);
-    List<ReEncumbranceHolder> holders = Arrays.asList(holder1, holder2, holder3);
-
-    Budget budget1 = new Budget().withId(UUID.randomUUID().toString()).withFundId(fund1.getId());
-    Budget budget2 = new Budget().withId(UUID.randomUUID().toString()).withFundId(fund2.getId());
-
-    when(budgetService.fetchBudgetsByFundIds(anyList(), any())).thenReturn(Future.succeededFuture(Arrays.asList(budget1, budget2)));
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withBudgets(holders, requestContext).result();
-
-    assertThat(resultHolders, hasItem(allOf(hasProperty("budget", is(budget1)), hasProperty("ledgerId", is(fund1.getLedgerId())))));
-    assertThat(resultHolders, hasItem(allOf(hasProperty("budget", is(budget2)), hasProperty("ledgerId", is(fund2.getLedgerId())))));
-    assertThat(resultHolders, hasItem(allOf(hasProperty("budget", nullValue()), hasProperty("ledgerId", nullValue()))));
-  }
-
-  @Test
-  void shouldNotRetrieveActiveBudgetIfReEncumbranceHoldersIsEmpty() {
-
-    List<ReEncumbranceHolder> holders = Collections.emptyList();
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withBudgets(holders, requestContext).result();
-    assertThat(resultHolders, is(empty()));
-    verify(budgetService, never()).fetchBudgetsByFundIds(anyList(), any());
-
   }
 
   @Test
@@ -446,27 +222,15 @@ public class ReEncumbranceHoldersBuilderTest {
     when(poFyToPoLineConversion.getCurrency()).thenReturn(Monetary.getCurrency("USD"));
     when(requestContext.getContext()).thenReturn(Vertx.vertx().getOrCreateContext());
 
-    var future = reEncumbranceHoldersBuilder.withConversions(holders, requestContext);
+    var future = reEncumbranceHoldersBuilder.withConversion(holders, requestContext);
     vertxTestContext.assertComplete(future)
       .onComplete(result -> {
-        assertEquals(result.result().get(0).getPoLineToFyConversion().getCurrency(), poLineToFyConversion.getCurrency());
-        assertEquals(result.result().get(1).getPoLineToFyConversion().getCurrency(), poLineToFyConversion.getCurrency());
-        assertEquals(result.result().get(0).getFyToPoLineConversion().getCurrency(), poFyToPoLineConversion.getCurrency());
-        assertEquals(result.result().get(1).getFyToPoLineConversion().getCurrency(), poFyToPoLineConversion.getCurrency());
+        assertEquals(holders.get(0).getPoLineToFyConversion().getCurrency(), poLineToFyConversion.getCurrency());
+        assertEquals(holders.get(1).getPoLineToFyConversion().getCurrency(), poLineToFyConversion.getCurrency());
+        assertEquals(holders.get(0).getFyToPoLineConversion().getCurrency(), poFyToPoLineConversion.getCurrency());
+        assertEquals(holders.get(1).getFyToPoLineConversion().getCurrency(), poFyToPoLineConversion.getCurrency());
         vertxTestContext.completeNow();
       });
-
-  }
-
-  @Test
-  void shouldNotResolveExchangeRateProviderWhenReEncumbranceHoldersEmpty() {
-
-    List<ReEncumbranceHolder> holders = Collections.emptyList();
-
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withConversions(holders, requestContext).result();
-
-    assertThat(resultHolders, is(empty()));
-    verify(exchangeRateProviderResolver, never()).resolve(any(), any());
 
   }
 
@@ -475,16 +239,14 @@ public class ReEncumbranceHoldersBuilderTest {
 
     List<ReEncumbranceHolder> holders = Arrays.asList(new ReEncumbranceHolder(), new ReEncumbranceHolder());
 
-    List<ReEncumbranceHolder> resultHolders = reEncumbranceHoldersBuilder.withConversions(holders, requestContext).result();
+    reEncumbranceHoldersBuilder.withConversion(holders, requestContext).result();
 
-    assertEquals(resultHolders, holders);
     verify(exchangeRateProviderResolver, never()).resolve(any(), any());
 
   }
 
   @Test
   void shouldPopulateReEncumbranceHoldersWithOneTimeEncumbranceRolloverWhenOrderTypeOneTime() {
-
 
     EncumbranceRollover oneTimeEncumbranceRollover = new EncumbranceRollover()
             .withBasedOn(EncumbranceRollover.BasedOn.REMAINING)

--- a/src/test/resources/mockdata/funds/funds.json
+++ b/src/test/resources/mockdata/funds/funds.json
@@ -41,7 +41,13 @@
       "name": "One-time Gifts",
       "code": "GIFT-SUBN",
       "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
+    },
+    {
+      "id": "65032151-39a5-4cef-8810-5350eb316300",
+      "name": "US History",
+      "code": "USHIST",
+      "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
     }
   ],
-  "totalRecords": 7
+  "totalRecords": 8
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-1118](https://folio-org.atlassian.net/browse/MODORDERS-1118) - Fix and optimize getting finance data to process encumbrances

## Approach
- Optimized getting the finance data structures. Getting the current budget for all funds was generating a lot of calls that were not necessary for orders with many lines, this is now only done for a single fund.
- Refactored `ReEncumbranceHoldersBuilder` and `EncumbranceRelationsHoldersBuilder` to reduce code redundancy and make the process of getting finance data more consistent. Common code is now in `FinanceHoldersBuilder`.
- Updated unit tests. Redundant unit tests for `ReEncumbranceHoldersBuilder` and `EncumbranceRelationsHoldersBuilder` are moved to a new test: `FinanceHoldersBuilderTest`.

A side effect of the new implementation is that error messages will be a bit different. Because we don't retrieve the current fiscal year for all funds anymore, we can't give that specific error message when multiple fiscal years are used in a PO. The new error message for the same issue mentions that an active budget for the fund could not be found in the same fiscal year as the one used by another fund. The same error will be returned if the budget is missing or inactive.
Another minor side effect: when getting a composite order by id, the implementation will check that all funds are successfully retrieved (previously it was ignored when a fund was missing).

[Integration tests PR](https://github.com/folio-org/folio-integration-tests/pull/1366)

## TODO
Check the error message in the UI - we might need to update a UI module with the new code. Edit: created [UIOR-1281](https://folio-org.atlassian.net/browse/UIOR-1281).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
