### PR TITLE
[MODORDERS-1124] API upgrade to new holdings storage version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1186,7 +1186,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "4.2 5.0 6.0"
+      "version": "4.2 5.0 6.0 7.0"
     },
     {
       "id": "orders-storage.po-number",
@@ -1992,6 +1992,7 @@
         "inventory-storage.items.collection.get",
         "inventory-storage.items.item.post",
         "inventory-storage.items.item.delete",
+        "inventory-storage.locations.collection.get",
         "inventory.items.item.put",
         "inventory-storage.loan-types.collection.get",
         "inventory-storage.contributor-name-types.collection.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1992,7 +1992,6 @@
         "inventory-storage.items.collection.get",
         "inventory-storage.items.item.post",
         "inventory-storage.items.item.delete",
-        "inventory-storage.locations.collection.get",
         "inventory.items.item.put",
         "inventory-storage.loan-types.collection.get",
         "inventory-storage.contributor-name-types.collection.get",


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDERS-1124
PR with breaking change: https://github.com/folio-org/mod-inventory-storage/pull/1024/files
So field sourceId become required field.
No any modification in mod-orders is needed because we already populate sourceId when creating holding:
https://github.com/folio-org/mod-orders/blob/master/src/main/java/org/folio/service/inventory/InventoryHoldingManager.java#L215