### PR TITLE
[MODORDERS-1131] Fix piece, item, title relationship in bind piece features

### DIFF
--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -116,7 +116,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
       tenantToItem.entrySet().stream()
         .map(entry -> {
         var locationContext = createContextWithNewTenantId(requestContext, entry.getKey());
-        return inventoryItemRequestService.getItemsWithActiveRequests(entry.getValue(), locationContext)
+        return inventoryItemRequestService.getItemIdsWithActiveRequests(entry.getValue(), locationContext)
           .compose(items -> validateItemsForRequestTransfer(tenantToItem.keySet(), items, holder.getBindPiecesCollection()));
         })
         .toList())
@@ -185,7 +185,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
         // Move requests if requestsAction is TRANSFER, otherwise do nothing
         if (TRANSFER.equals(bindPiecesCollection.getRequestsAction())) {
           var itemIds = holder.getPieces().map(Piece::getItemId).toList();
-          inventoryItemRequestService.transferItemsRequests(itemIds, newItemId, requestContext);
+          inventoryItemRequestService.transferItemRequests(itemIds, newItemId, requestContext);
         }
         // Set new item ids for pieces and holder
         holder.getPieces().forEach(piece -> piece.setItemId(newItemId));

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -239,7 +239,8 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
 
   @Override
   protected boolean isRevertToOnOrder(Piece piece) {
-    return false;
+    // Set to true for piece validation while fetching
+    return true;
   }
 
   @Override

--- a/src/main/java/org/folio/orders/utils/CommonFields.java
+++ b/src/main/java/org/folio/orders/utils/CommonFields.java
@@ -1,0 +1,18 @@
+package org.folio.orders.utils;
+
+public enum CommonFields {
+
+  METADATA("metadata"),
+  CREATED_DATE("createdDate");
+
+  private final String value;
+
+  CommonFields(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/src/main/java/org/folio/orders/utils/CommonFields.java
+++ b/src/main/java/org/folio/orders/utils/CommonFields.java
@@ -2,6 +2,7 @@ package org.folio.orders.utils;
 
 public enum CommonFields {
 
+  ID("id"),
   METADATA("metadata"),
   CREATED_DATE("createdDate");
 

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -542,6 +542,11 @@ public class HelperUtils {
     return json.getString(ID);
   }
 
+  public static String extractCreatedDate(JsonObject json) {
+    return json.getJsonObject(CommonFields.METADATA.getValue())
+      .getString(CommonFields.CREATED_DATE.getValue());
+  }
+
   public static CompositePurchaseOrder convertToCompositePurchaseOrder(PurchaseOrder purchaseOrder, List<PoLine> poLineList) {
     List<CompositePoLine> compositePoLines = new ArrayList<>(poLineList.size());
     if (CollectionUtils.isNotEmpty(poLineList)) {

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -85,6 +85,7 @@ public enum ErrorCodes {
   REQUEST_FOUND("thereAreRequestsOnItem", "There are requests on item"),
   REQUESTS_ACTION_REQUIRED("requestsActionRequired", "There are circulation requests on items and requestsAction should be populated"),
   PIECES_HAVE_DIFFERENT_RECEIVING_TENANT_IDS("piecesHaveDifferentReceivingTenantIds", "All pieces do not have the same receivingTenantId"),
+  PIECES_MUST_HAVE_RECEIVED_STATUS("piecesMustHaveReceivedStatus", "All pieces must have received status in order to be bound"),
   BUDGET_EXPENSE_CLASS_NOT_FOUND("budgetExpenseClassNotFound", "Budget expense class not found"),
   INACTIVE_EXPENSE_CLASS("inactiveExpenseClass", "Expense class is Inactive"),
   HOLDINGS_BY_INSTANCE_AND_LOCATION_NOT_FOUND("holdingsByInstanceAndLocationNotFoundError", "Holdings by instance id %s and location id %s not found"),

--- a/src/main/java/org/folio/service/inventory/InventoryItemManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemManager.java
@@ -135,7 +135,7 @@ public class InventoryItemManager {
   }
 
   public Future<Void> updateItemWithPieceFields(Piece piece, RequestContext requestContext) {
-    if (piece.getItemId() == null || piece.getPoLineId() == null) {
+    if (piece.getItemId() == null || piece.getPoLineId() == null || piece.getIsBound()) {
       return Future.succeededFuture();
     }
     String itemId = piece.getItemId();

--- a/src/main/java/org/folio/service/inventory/InventoryItemRequestService.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemRequestService.java
@@ -10,13 +10,19 @@ import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
 import org.folio.service.CirculationRequestsRetriever;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.folio.orders.utils.HelperUtils.extractCreatedDate;
+import static org.folio.orders.utils.HelperUtils.extractId;
 import static org.folio.service.inventory.InventoryUtils.INVENTORY_LOOKUP_ENDPOINTS;
 import static org.folio.service.inventory.InventoryUtils.REQUESTS;
-import static org.folio.service.inventory.util.RequestFields.DESTINATION_KEY;
+import static org.folio.service.inventory.util.RequestFields.DESTINATION_ITEM_ID;
+import static org.folio.service.inventory.util.RequestFields.STATUS;
 
 public class InventoryItemRequestService {
 
@@ -24,6 +30,7 @@ public class InventoryItemRequestService {
 
   private static final String REQUEST_ENDPOINT = INVENTORY_LOOKUP_ENDPOINTS.get(REQUESTS) + "/%s";
   private static final String REQUEST_MOVE_ENDPOINT = REQUEST_ENDPOINT + "/move";
+  private static final String REQUEST_CANCEL_STATUS = "Closed - Cancelled";
 
   private final CirculationRequestsRetriever circulationRequestsRetriever;
   private final RestClient restClient;
@@ -45,34 +52,62 @@ public class InventoryItemRequestService {
   }
 
   public Future<Void> cancelItemsRequests(List<String> itemIds, RequestContext requestContext) {
-    return handleItemsRequests(itemIds, requestContext, reqId -> cancelRequest(reqId, requestContext));
+    return circulationRequestsRetriever.getRequesterIdsToRequestsByItemIds(itemIds, requestContext)
+      .compose(requesterToRequestsMap -> {
+        var requestsToCancel = requesterToRequestsMap.values().stream()
+          .flatMap(Collection::stream)
+          .toList();
+        return handleItemsRequests(requestsToCancel, request -> cancelRequest(request, requestContext));
+      });
   }
 
   public Future<Void> transferItemsRequests(List<String> originItemIds, String destinationItemId, RequestContext requestContext) {
-    return handleItemsRequests(originItemIds, requestContext, reqId -> transferRequest(reqId, destinationItemId, requestContext));
+    return circulationRequestsRetriever.getRequesterIdsToRequestsByItemIds(originItemIds, requestContext)
+      .compose(requesterToRequestsMap -> {
+        var requestsToCancel = new ArrayList<JsonObject>();
+        var requestsToTransfer = new ArrayList<JsonObject>();
+        for (var requests : requesterToRequestsMap.values()) {
+          requestsToCancel.addAll(requests);
+          requests.stream().min(this::compareRequests).ifPresent(request -> {
+            requestsToTransfer.add(request);
+            requestsToCancel.remove(request);
+          });
+        }
+
+        return handleItemsRequests(requestsToTransfer, request -> transferRequest(request, destinationItemId, requestContext))
+          .compose(v -> handleItemsRequests(requestsToCancel, request -> cancelRequest(request, requestContext)));
+      });
   }
 
-  private Future<Void> handleItemsRequests(List<String> itemId, RequestContext requestContext, Function<String, Future<Void>> handler) {
-    return circulationRequestsRetriever.getRequestIdsByItemIds(itemId, requestContext)
-      .compose(reqIds -> {
-        var futures = reqIds.stream().map(handler).toList();
-        return GenericCompositeFuture.all(futures);
-      })
+  private Future<Void> handleItemsRequests(List<JsonObject> requests, Function<JsonObject, Future<Void>> handler) {
+    return GenericCompositeFuture.all(
+      requests.stream()
+        .map(handler)
+        .toList())
       .mapEmpty();
   }
 
-  private Future<Void> cancelRequest(String reqId, RequestContext requestContext) {
-    logger.info("cancelRequest:: Cancelling Request with id='{}'", reqId);
+  private Future<Void> cancelRequest(JsonObject request, RequestContext requestContext) {
+    String reqId = extractId(request);
+    request.put(STATUS.getValue(), REQUEST_CANCEL_STATUS);
     RequestEntry requestEntry = new RequestEntry(String.format(REQUEST_ENDPOINT, reqId));
-    return restClient.delete(requestEntry, requestContext);
+    logger.info("cancelRequest:: Cancelling Request with id='{}'", reqId);
+    return restClient.put(requestEntry, request, requestContext);
   }
 
-  private Future<Void> transferRequest(String reqId, String itemId, RequestContext requestContext) {
-      logger.info("transferRequest:: Moving Request with id='{}' to item with id='{}'", reqId, itemId);
-      JsonObject jsonObject =  JsonObject.of(DESTINATION_KEY.getValue(), itemId);
-      RequestEntry requestEntry = new RequestEntry(String.format(REQUEST_MOVE_ENDPOINT, reqId));
-      return restClient.postJsonObject(requestEntry, jsonObject, requestContext)
-        .mapEmpty();
+  private Future<Void> transferRequest(JsonObject request, String itemId, RequestContext requestContext) {
+    String reqId = extractId(request);
+    JsonObject jsonObject =  JsonObject.of(DESTINATION_ITEM_ID.getValue(), itemId);
+    RequestEntry requestEntry = new RequestEntry(String.format(REQUEST_MOVE_ENDPOINT, reqId));
+    logger.info("transferRequest:: Moving Request with id='{}' to item with id='{}'", reqId, itemId);
+    return restClient.postJsonObject(requestEntry, jsonObject, requestContext)
+      .mapEmpty();
+  }
+
+  private int compareRequests(JsonObject r1, JsonObject r2) {
+    Instant createdDate1 = Instant.parse(extractCreatedDate(r1));
+    Instant createdDate2 = Instant.parse(extractCreatedDate(r2));
+    return createdDate1.compareTo(createdDate2);
   }
 
 }

--- a/src/main/java/org/folio/service/inventory/InventoryItemRequestService.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemRequestService.java
@@ -40,7 +40,7 @@ public class InventoryItemRequestService {
     this.circulationRequestsRetriever = circulationRequestsRetriever;
   }
 
-  public Future<List<String>> getItemsWithActiveRequests(List<String> itemIds, RequestContext requestContext) {
+  public Future<List<String>> getItemIdsWithActiveRequests(List<String> itemIds, RequestContext requestContext) {
     if (logger.isDebugEnabled()) {
       logger.debug("getItemsWithActiveRequests:: Filtering itemIds with active requests: {}", itemIds);
     }
@@ -51,17 +51,17 @@ public class InventoryItemRequestService {
         .toList());
   }
 
-  public Future<Void> cancelItemsRequests(List<String> itemIds, RequestContext requestContext) {
+  public Future<Void> cancelItemRequests(List<String> itemIds, RequestContext requestContext) {
     return circulationRequestsRetriever.getRequesterIdsToRequestsByItemIds(itemIds, requestContext)
       .compose(requesterToRequestsMap -> {
         var requestsToCancel = requesterToRequestsMap.values().stream()
           .flatMap(Collection::stream)
           .toList();
-        return handleItemsRequests(requestsToCancel, request -> cancelRequest(request, requestContext));
+        return handleItemRequests(requestsToCancel, request -> cancelRequest(request, requestContext));
       });
   }
 
-  public Future<Void> transferItemsRequests(List<String> originItemIds, String destinationItemId, RequestContext requestContext) {
+  public Future<Void> transferItemRequests(List<String> originItemIds, String destinationItemId, RequestContext requestContext) {
     return circulationRequestsRetriever.getRequesterIdsToRequestsByItemIds(originItemIds, requestContext)
       .compose(requesterToRequestsMap -> {
         var requestsToCancel = new ArrayList<JsonObject>();
@@ -74,12 +74,12 @@ public class InventoryItemRequestService {
           });
         }
 
-        return handleItemsRequests(requestsToTransfer, request -> transferRequest(request, destinationItemId, requestContext))
-          .compose(v -> handleItemsRequests(requestsToCancel, request -> cancelRequest(request, requestContext)));
+        return handleItemRequests(requestsToTransfer, request -> transferRequest(request, destinationItemId, requestContext))
+          .compose(v -> handleItemRequests(requestsToCancel, request -> cancelRequest(request, requestContext)));
       });
   }
 
-  private Future<Void> handleItemsRequests(List<JsonObject> requests, Function<JsonObject, Future<Void>> handler) {
+  private Future<Void> handleItemRequests(List<JsonObject> requests, Function<JsonObject, Future<Void>> handler) {
     return GenericCompositeFuture.all(
       requests.stream()
         .map(handler)

--- a/src/main/java/org/folio/service/inventory/util/RequestFields.java
+++ b/src/main/java/org/folio/service/inventory/util/RequestFields.java
@@ -2,13 +2,14 @@ package org.folio.service.inventory.util;
 
 public enum RequestFields {
 
-  ID_KEY("id"),
-  ITEM_ID_KEY("itemId"),
-  DESTINATION_KEY("destinationItemId"),
+  ITEM_ID("itemId"),
+  REQUESTER_ID("itemId"),
+  STATUS("status"),
+  DESTINATION_ITEM_ID("destinationItemId"),
   COLLECTION_RECORDS("requests"),
   COLLECTION_TOTAL("totalRecords");
 
-  private String value;
+  private final String value;
 
   RequestFields(String value) {
     this.value = value;

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowInventoryManager.java
@@ -107,7 +107,7 @@ public class PieceUpdateFlowInventoryManager {
   private Future<String> handleItem(PieceUpdateHolder holder, RequestContext requestContext) {
     CompositePoLine poLineToSave = holder.getPoLineToSave();
     Piece pieceToUpdate = holder.getPieceToUpdate();
-    if (!DefaultPieceFlowsValidator.isCreateItemForPiecePossible(pieceToUpdate, poLineToSave)) {
+    if (!DefaultPieceFlowsValidator.isCreateItemForPiecePossible(pieceToUpdate, poLineToSave) || pieceToUpdate.getIsBound()) {
         return Future.succeededFuture();
     }
     return inventoryItemManager.getItemRecordById(pieceToUpdate.getItemId(), true, requestContext)

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiTest.java
@@ -87,6 +87,7 @@ import static org.folio.rest.core.exceptions.ErrorCodes.ITEM_UPDATE_FAILED;
 import static org.folio.rest.core.exceptions.ErrorCodes.LOC_NOT_PROVIDED;
 import static org.folio.rest.core.exceptions.ErrorCodes.MULTIPLE_NONPACKAGE_TITLES;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECES_HAVE_DIFFERENT_RECEIVING_TENANT_IDS;
+import static org.folio.rest.core.exceptions.ErrorCodes.PIECES_MUST_HAVE_RECEIVED_STATUS;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_ALREADY_RECEIVED;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_NOT_FOUND;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_NOT_RETRIEVED;
@@ -1196,6 +1197,40 @@ public class CheckinReceivingApiTest {
       .toList();
 
     assertThat(pieceList.size(), is(1));
+  }
+
+  @Test
+  void testBindExpectedPieces() {
+    logger.info("=== Test POST Bind to Title with Expected Piece ");
+
+    var order = getMinimalContentCompositePurchaseOrder()
+      .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
+    var poLine = getMinimalContentCompositePoLine(order.getId())
+      .withLocations(List.of(new Location().withHoldingId(UUID.randomUUID().toString())
+        .withQuantityPhysical(1).withQuantity(1)));
+    var bindingPiece = getMinimalContentPiece(poLine.getId())
+      .withItemId("522a501a-56b5-48d9-b28a-3a8f02482d98") // Present in mockdata/itemRequests/itemRequests.json
+      .withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+      .withFormat(org.folio.rest.jaxrs.model.Piece.Format.ELECTRONIC);
+    var bindPiecesCollection = new BindPiecesCollection()
+      .withPoLineId(poLine.getId())
+      .withBindItem(getMinimalContentBindItem()
+        .withLocationId(null)
+        .withHoldingId(UUID.randomUUID().toString()))
+      .withBindPieceIds(List.of(bindingPiece.getId()))
+      .withRequestsAction(BindPiecesCollection.RequestsAction.TRANSFER);
+
+    addMockEntry(PURCHASE_ORDER_STORAGE, order);
+    addMockEntry(PO_LINES_STORAGE, poLine);
+    addMockEntry(PIECES_STORAGE, bindingPiece);
+    addMockEntry(TITLES, getTitle(poLine));
+
+    var errors = verifyPostResponse(ORDERS_BIND_ENDPOINT, JsonObject.mapFrom(bindPiecesCollection).encode(),
+      prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10), APPLICATION_JSON, VALIDATION_ERROR)
+      .as(Errors.class)
+      .getErrors();
+
+    assertThat(errors.get(0).getMessage(), equalTo(PIECES_MUST_HAVE_RECEIVED_STATUS.getDescription()));
   }
 
   @Test

--- a/src/test/java/org/folio/service/CirculationRequestsRetrieverTest.java
+++ b/src/test/java/org/folio/service/CirculationRequestsRetrieverTest.java
@@ -19,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -153,11 +154,13 @@ public class CirculationRequestsRetrieverTest {
 
     doReturn(Future.succeededFuture(mockData)).when(restClient).getAsJsonObject(any(RequestEntry.class), eq(requestContext));
 
-    Future<List<String>> future = circulationRequestsRetriever.getRequestIdsByItemIds(MOCK_ITEM_IDS, requestContext);
+    Future<Map<String, List<JsonObject>>> future = circulationRequestsRetriever.getRequesterIdsToRequestsByItemIds(MOCK_ITEM_IDS, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
-      assertEquals(7, f.result().size());
+      var reqMap = f.result();
+      assertEquals(2, reqMap.size());
+      assertEquals(7, reqMap.values().stream().mapToInt(Collection::size).sum());
       verify(restClient, times(1)).getAsJsonObject(any(RequestEntry.class), eq(requestContext));
       vertxTestContext.completeNow();
     });

--- a/src/test/java/org/folio/service/inventory/InventoryItemRequestServiceTest.java
+++ b/src/test/java/org/folio/service/inventory/InventoryItemRequestServiceTest.java
@@ -125,7 +125,7 @@ public class InventoryItemRequestServiceTest {
 
     doReturn(Future.succeededFuture(itemReqMap)).when(circulationRequestsRetriever).getNumbersOfRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<List<String>> future = inventoryItemRequestService.getItemsWithActiveRequests(itemIds, requestContext);
+    Future<List<String>> future = inventoryItemRequestService.getItemIdsWithActiveRequests(itemIds, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
@@ -144,7 +144,7 @@ public class InventoryItemRequestServiceTest {
 
     doReturn(Future.succeededFuture(itemReqMap)).when(circulationRequestsRetriever).getNumbersOfRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<List<String>> future = inventoryItemRequestService.getItemsWithActiveRequests(itemIds, requestContext);
+    Future<List<String>> future = inventoryItemRequestService.getItemIdsWithActiveRequests(itemIds, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
@@ -163,7 +163,7 @@ public class InventoryItemRequestServiceTest {
     doReturn(Future.succeededFuture()).when(restClient).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
     doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<Void> future = inventoryItemRequestService.cancelItemsRequests(itemIds, requestContext);
+    Future<Void> future = inventoryItemRequestService.cancelItemRequests(itemIds, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
@@ -180,7 +180,7 @@ public class InventoryItemRequestServiceTest {
     doReturn(Future.succeededFuture()).when(restClient).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
     doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<Void> future = inventoryItemRequestService.cancelItemsRequests(itemIds, requestContext);
+    Future<Void> future = inventoryItemRequestService.cancelItemRequests(itemIds, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
@@ -199,7 +199,7 @@ public class InventoryItemRequestServiceTest {
     doReturn(Future.succeededFuture()).when(restClient).postJsonObject(any(RequestEntry.class), eq(jsonObject), eq(requestContext));
     doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<Void> future = inventoryItemRequestService.transferItemsRequests(itemIds, destItemId, requestContext);
+    Future<Void> future = inventoryItemRequestService.transferItemRequests(itemIds, destItemId, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
@@ -219,7 +219,7 @@ public class InventoryItemRequestServiceTest {
     doReturn(Future.succeededFuture()).when(restClient).postJsonObject(any(RequestEntry.class), eq(jsonObject), eq(requestContext));
     doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<Void> future = inventoryItemRequestService.transferItemsRequests(itemIds, destItemId, requestContext);
+    Future<Void> future = inventoryItemRequestService.transferItemRequests(itemIds, destItemId, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
@@ -251,7 +251,7 @@ public class InventoryItemRequestServiceTest {
     doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
     // One requester will now have two requests, old one will be cancelled
-    Future<Void> future = inventoryItemRequestService.transferItemsRequests(itemIds, destItemId, requestContext);
+    Future<Void> future = inventoryItemRequestService.transferItemRequests(itemIds, destItemId, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());

--- a/src/test/java/org/folio/service/inventory/InventoryItemRequestServiceTest.java
+++ b/src/test/java/org/folio/service/inventory/InventoryItemRequestServiceTest.java
@@ -20,6 +20,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,9 +41,15 @@ import static org.folio.TestConfig.isVerticleNotDeployed;
 import static org.folio.TestConfig.mockPort;
 import static org.folio.TestConstants.X_OKAPI_TOKEN;
 import static org.folio.TestConstants.X_OKAPI_USER_ID;
+import static org.folio.orders.utils.CommonFields.CREATED_DATE;
+import static org.folio.orders.utils.CommonFields.ID;
+import static org.folio.orders.utils.CommonFields.METADATA;
 import static org.folio.rest.RestConstants.OKAPI_URL;
 import static org.folio.rest.impl.PurchaseOrdersApiTest.X_OKAPI_TENANT;
-import static org.folio.service.inventory.util.RequestFields.DESTINATION_KEY;
+import static org.folio.service.inventory.util.RequestFields.DESTINATION_ITEM_ID;
+import static org.folio.service.inventory.util.RequestFields.ITEM_ID;
+import static org.folio.service.inventory.util.RequestFields.REQUESTER_ID;
+import static org.folio.service.inventory.util.RequestFields.STATUS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,6 +63,8 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(VertxExtension.class)
 public class InventoryItemRequestServiceTest {
+
+  private final JsonObject sampleMetadata = JsonObject.of(CREATED_DATE.getValue(), Instant.now().toString());
 
   @Autowired
   RestClient restClient;
@@ -147,49 +157,49 @@ public class InventoryItemRequestServiceTest {
 
   @Test
   void cancelSingleItemRequest(VertxTestContext vertxTestContext) {
-    String itemId = UUID.randomUUID().toString();
-    String reqId = UUID.randomUUID().toString();
+    var itemIds = generateUUIDs(1);
+    var reqMap = generateRequests(itemIds);
 
-    doReturn(Future.succeededFuture()).when(restClient).delete(any(RequestEntry.class), eq(requestContext));
-    doReturn(Future.succeededFuture(List.of(reqId))).when(circulationRequestsRetriever).getRequestIdsByItemIds(anyList(), eq(requestContext));
+    doReturn(Future.succeededFuture()).when(restClient).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
+    doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<Void> future = inventoryItemRequestService.cancelItemsRequests(List.of(itemId), requestContext);
+    Future<Void> future = inventoryItemRequestService.cancelItemsRequests(itemIds, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
-      verify(restClient, times(1)).delete(any(RequestEntry.class), any(RequestContext.class));
+      verify(restClient, times(1)).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
       vertxTestContext.completeNow();
     });
   }
 
   @Test
   void cancelManyItemRequests(VertxTestContext vertxTestContext) {
-    List<String> itemIds = generateUUIDs(10);
-    List<String> reqIds = generateUUIDs(10);
+    var itemIds = generateUUIDs(10);
+    var reqMap = generateRequests(itemIds);
 
-    doReturn(Future.succeededFuture()).when(restClient).delete(any(RequestEntry.class), eq(requestContext));
-    doReturn(Future.succeededFuture(reqIds)).when(circulationRequestsRetriever).getRequestIdsByItemIds(anyList(), eq(requestContext));
+    doReturn(Future.succeededFuture()).when(restClient).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
+    doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
     Future<Void> future = inventoryItemRequestService.cancelItemsRequests(itemIds, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
-      verify(restClient, times(10)).delete(any(RequestEntry.class), eq(requestContext));
+      verify(restClient, times(10)).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
       vertxTestContext.completeNow();
     });
   }
 
   @Test
   void transferSingleItemRequest(VertxTestContext vertxTestContext) {
-    String itemId = UUID.randomUUID().toString();
-    String reqId = UUID.randomUUID().toString();
+    var itemIds = generateUUIDs(1);
+    var reqMap = generateRequests(itemIds);
     String destItemId = UUID.randomUUID().toString();
-    JsonObject jsonObject =  JsonObject.of(DESTINATION_KEY.getValue(), destItemId);
+    JsonObject jsonObject =  JsonObject.of(DESTINATION_ITEM_ID.getValue(), destItemId);
 
     doReturn(Future.succeededFuture()).when(restClient).postJsonObject(any(RequestEntry.class), eq(jsonObject), eq(requestContext));
-    doReturn(Future.succeededFuture(List.of(reqId))).when(circulationRequestsRetriever).getRequestIdsByItemIds(anyList(), eq(requestContext));
+    doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
-    Future<Void> future = inventoryItemRequestService.transferItemsRequests(List.of(itemId), destItemId, requestContext);
+    Future<Void> future = inventoryItemRequestService.transferItemsRequests(itemIds, destItemId, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
@@ -200,19 +210,54 @@ public class InventoryItemRequestServiceTest {
 
   @Test
   void transferManyItemRequests(VertxTestContext vertxTestContext) {
-    List<String> itemIds = generateUUIDs(10);
-    List<String> reqIds = generateUUIDs(10);
+    var itemIds = generateUUIDs(10);
+    var reqMap = generateRequests(itemIds);
+
     String destItemId = UUID.randomUUID().toString();
-    JsonObject jsonObject =  JsonObject.of(DESTINATION_KEY.getValue(), destItemId);
+    JsonObject jsonObject =  JsonObject.of(DESTINATION_ITEM_ID.getValue(), destItemId);
 
     doReturn(Future.succeededFuture()).when(restClient).postJsonObject(any(RequestEntry.class), eq(jsonObject), eq(requestContext));
-    doReturn(Future.succeededFuture(reqIds)).when(circulationRequestsRetriever).getRequestIdsByItemIds(anyList(), eq(requestContext));
+    doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
 
     Future<Void> future = inventoryItemRequestService.transferItemsRequests(itemIds, destItemId, requestContext);
 
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
       verify(restClient, times(10)).postJsonObject(any(RequestEntry.class), eq(jsonObject), eq(requestContext));
+      vertxTestContext.completeNow();
+    });
+  }
+
+  @Test
+  void transferManyItemRequestsAndCancelOne(VertxTestContext vertxTestContext) {
+    var itemIds = generateUUIDs(10);
+    var reqMap = generateRequests(itemIds);
+
+    // Add request for a different item with same requester
+    var entries = reqMap.entrySet().stream().toList();
+    var reqEntry = entries.get(0);
+    var newRequest = new JsonObject()
+      .put(ID.getValue(), UUID.randomUUID().toString())
+      .put(ITEM_ID.getValue(), UUID.randomUUID().toString())
+      .put(METADATA.getValue(), JsonObject.of(CREATED_DATE.getValue(), Instant.now().plus(1, ChronoUnit.DAYS).toString()))
+      .put(REQUESTER_ID.getValue(), reqEntry.getKey());
+    reqEntry.getValue().add(newRequest);
+
+    String destItemId = UUID.randomUUID().toString();
+    JsonObject jsonObject =  JsonObject.of(DESTINATION_ITEM_ID.getValue(), destItemId);
+
+    doReturn(Future.succeededFuture()).when(restClient).postJsonObject(any(RequestEntry.class), eq(jsonObject), eq(requestContext));
+    doReturn(Future.succeededFuture()).when(restClient).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
+    doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
+
+    // One requester will now have two requests, old one will be cancelled
+    Future<Void> future = inventoryItemRequestService.transferItemsRequests(itemIds, destItemId, requestContext);
+
+    vertxTestContext.assertComplete(future).onComplete(f -> {
+      assertTrue(f.succeeded());
+      newRequest.put(STATUS.getValue(), "Closed - Cancelled");
+      verify(restClient, times(10)).postJsonObject(any(RequestEntry.class), eq(jsonObject), eq(requestContext));
+      verify(restClient, times(1)).put(any(RequestEntry.class), eq(newRequest), eq(requestContext));
       vertxTestContext.completeNow();
     });
   }
@@ -225,6 +270,20 @@ public class InventoryItemRequestServiceTest {
     return ids;
   }
 
+  private Map<String, List<JsonObject>> generateRequests(List<String> itemIds) {
+    Map<String, List<JsonObject>> reqMap = new HashMap<>();
+    for (var itemId : itemIds) {
+      var requesterId = UUID.randomUUID().toString();
+      var requests = new ArrayList<JsonObject>();
+      requests.add(new JsonObject()
+        .put(ID.getValue(), UUID.randomUUID().toString())
+        .put(ITEM_ID.getValue(), itemId)
+        .put(METADATA.getValue(), sampleMetadata)
+        .put(REQUESTER_ID.getValue(), requesterId));
+      reqMap.put(UUID.randomUUID().toString(), requests);
+    }
+    return reqMap;
+  }
 
   /**
    * Define unit test specific beans to override actual ones

--- a/src/test/resources/mockdata/requests/requests.json
+++ b/src/test/resources/mockdata/requests/requests.json
@@ -1,12 +1,12 @@
 {
   "requests": [
-    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a00", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
-    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a01", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
-    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a02", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
-    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a03", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
-    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a04", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
-    {"id":  "33d3d7f4-a937-4d16-af05-6eefde43c962", "itemId": "e477dd71-3144-48ee-9972-d93f726ce0d8"},
-    {"id":  "33d3d7f4-a937-4d16-af05-6eefde43c963", "itemId": "e477dd71-3144-48ee-9972-d93f726ce0d8"}
+    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a00", "requesterId": "ac17d541-7c28-43c3-b9f2-9289a9988a44", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
+    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a01", "requesterId": "ac17d541-7c28-43c3-b9f2-9289a9988a45", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
+    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a02", "requesterId": "ac17d541-7c28-43c3-b9f2-9289a9988a46", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
+    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a03", "requesterId": "ac17d541-7c28-43c3-b9f2-9289a9988a47", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
+    {"id":  "ab18897b-0e40-4f31-896b-9c9adc979a04", "requesterId": "ac17d541-7c28-43c3-b9f2-9289a9988a48", "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"},
+    {"id":  "33d3d7f4-a937-4d16-af05-6eefde43c962", "requesterId": "ac17d541-7c28-43c3-b9f2-9289a9988a44", "itemId": "e477dd71-3144-48ee-9972-d93f726ce0d8"},
+    {"id":  "33d3d7f4-a937-4d16-af05-6eefde43c963", "requesterId": "ac17d541-7c28-43c3-b9f2-9289a9988a45", "itemId": "e477dd71-3144-48ee-9972-d93f726ce0d8"}
   ],
   "totalRecords": 7
 }


### PR DESCRIPTION
## Purpose
[[MODORDERS-1131] Fix piece, item, title relationship in bind piece features](https://folio-org.atlassian.net/browse/MODORDERS-1131)

## Approach
- [x] Bound piece feature should support different locations in pieces when they are binding
- [x] BindItemIds array shouldn’t empty when new piece is being created in title
- [x] Pieces shouldn’t update new Item details, after they are bound.
- [x] Bind endpoint payload should now accept instanceId in case of package POL
- [x] After successful binding the pieces isBound flag is set to true and bound piece IDs are returned in response payload
- [x] Modify transfer logic to handle transferring several requests
- [x] Update necessary unit tests
