### PR TITLE
[MODORDERS-1131] Fix misspelled field name

### DIFF
--- a/src/main/java/org/folio/service/inventory/util/RequestFields.java
+++ b/src/main/java/org/folio/service/inventory/util/RequestFields.java
@@ -3,7 +3,7 @@ package org.folio.service.inventory.util;
 public enum RequestFields {
 
   ITEM_ID("itemId"),
-  REQUESTER_ID("itemId"),
+  REQUESTER_ID("requesterId"),
   STATUS("status"),
   DESTINATION_ITEM_ID("destinationItemId"),
   COLLECTION_RECORDS("requests"),

--- a/src/test/java/org/folio/service/CirculationRequestsRetrieverTest.java
+++ b/src/test/java/org/folio/service/CirculationRequestsRetrieverTest.java
@@ -149,7 +149,7 @@ public class CirculationRequestsRetrieverTest {
   }
 
   @Test
-  void getRequestsByItemIdsTest(VertxTestContext vertxTestContext) {
+  void getRequesterIdsToRequestsByItemIdsTest(VertxTestContext vertxTestContext) {
     JsonObject mockData = getMockAsJson(REQUESTS_PATH, REQUESTS_MOCK);
 
     doReturn(Future.succeededFuture(mockData)).when(restClient).getAsJsonObject(any(RequestEntry.class), eq(requestContext));
@@ -159,7 +159,7 @@ public class CirculationRequestsRetrieverTest {
     vertxTestContext.assertComplete(future).onComplete(f -> {
       assertTrue(f.succeeded());
       var reqMap = f.result();
-      assertEquals(2, reqMap.size());
+      assertEquals(5, reqMap.size());
       assertEquals(7, reqMap.values().stream().mapToInt(Collection::size).sum());
       verify(restClient, times(1)).getAsJsonObject(any(RequestEntry.class), eq(requestContext));
       vertxTestContext.completeNow();


### PR DESCRIPTION
## Purpose
[[MODORDERS-1131] Fix piece, item, title relationship in bind piece features](https://folio-org.atlassian.net/browse/MODORDERS-1131)

## Approach
- Rename REQUESTER_ID field from itemId to requesterId
- Update corresponding unit test