### PR TITLE
added missing permission for changing status of circulation request and making improvements

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1103,6 +1103,7 @@
             "acquisitions-units-storage.memberships.collection.get",
             "circulation.requests.collection.get",
             "circulation.requests.item.move.post",
+            "circulation.requests.item.put",
             "inventory-storage.holdings-sources.collection.get",
             "inventory-storage.holdings.item.post",
             "user-tenants.collection.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1103,7 +1103,6 @@
             "acquisitions-units-storage.memberships.collection.get",
             "circulation.requests.collection.get",
             "circulation.requests.item.move.post",
-            "circulation.requests.item.put",
             "inventory-storage.holdings-sources.collection.get",
             "inventory-storage.holdings.item.post",
             "user-tenants.collection.get",

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -183,10 +183,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
       .compose(compPOL -> createInventoryObjects(compPOL, bindPiecesCollection.getInstanceId(), bindPiecesCollection.getBindItem(), requestContext))
       .map(newItemId -> {
         // Move requests if requestsAction is TRANSFER, otherwise do nothing
-        if (TRANSFER.equals(bindPiecesCollection.getRequestsAction())) {
-          var itemIds = holder.getPieces().map(Piece::getItemId).toList();
-          inventoryItemRequestService.transferItemRequests(itemIds, newItemId, requestContext);
-        }
+        transferRequestsIfNeed(holder, newItemId, requestContext);
         // Set new item ids for pieces and holder
         holder.getPieces().forEach(piece -> piece.setItemId(newItemId));
         return holder.withBindItemId(newItemId);
@@ -217,6 +214,17 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
       return Future.succeededFuture(bindItem.getHoldingId());
     }
     return inventoryHoldingManager.createHoldingAndReturnId(instanceId, bindItem.getLocationId(), locationContext);
+  }
+
+  private void transferRequestsIfNeed(BindPiecesHolder bindPiecesHolder, String newItemId, RequestContext requestContext) {
+    if (TRANSFER.equals(bindPiecesHolder.getBindPiecesCollection().getRequestsAction())) {
+      var itemIds = bindPiecesHolder.getPieces().map(Piece::getItemId).toList();
+      inventoryItemRequestService.transferItemRequests(itemIds, newItemId, requestContext)
+        .onFailure(throwable -> {
+          logger.error("Failed to transfer item requests", throwable);
+          throw new RuntimeException("Failed to transfer item requests", throwable);
+        });
+    }
   }
 
   private Future<BindPiecesHolder> storeUpdatedPieces(BindPiecesHolder holder, RequestContext requestContext) {

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -222,7 +222,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
       inventoryItemRequestService.transferItemRequests(itemIds, newItemId, requestContext)
         .onFailure(throwable -> {
           logger.error("Failed to transfer item requests", throwable);
-          throw new RuntimeException("Failed to transfer item requests", throwable);
+          throw new IllegalStateException("Failed to transfer item requests", throwable);
         });
     }
   }

--- a/src/main/java/org/folio/service/inventory/InventoryItemRequestService.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemRequestService.java
@@ -12,7 +12,6 @@ import org.folio.service.CirculationRequestsRetriever;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -49,16 +48,6 @@ public class InventoryItemRequestService {
         .filter(e -> e.getValue() > 0)
         .map(Map.Entry::getKey)
         .toList());
-  }
-
-  public Future<Void> cancelItemRequests(List<String> itemIds, RequestContext requestContext) {
-    return circulationRequestsRetriever.getRequesterIdsToRequestsByItemIds(itemIds, requestContext)
-      .compose(requesterToRequestsMap -> {
-        var requestsToCancel = requesterToRequestsMap.values().stream()
-          .flatMap(Collection::stream)
-          .toList();
-        return handleItemRequests(requestsToCancel, request -> cancelRequest(request, requestContext));
-      });
   }
 
   public Future<Void> transferItemRequests(List<String> originItemIds, String destinationItemId, RequestContext requestContext) {

--- a/src/test/java/org/folio/service/inventory/InventoryItemRequestServiceTest.java
+++ b/src/test/java/org/folio/service/inventory/InventoryItemRequestServiceTest.java
@@ -156,40 +156,6 @@ public class InventoryItemRequestServiceTest {
   }
 
   @Test
-  void cancelSingleItemRequest(VertxTestContext vertxTestContext) {
-    var itemIds = generateUUIDs(1);
-    var reqMap = generateRequests(itemIds);
-
-    doReturn(Future.succeededFuture()).when(restClient).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
-    doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
-
-    Future<Void> future = inventoryItemRequestService.cancelItemRequests(itemIds, requestContext);
-
-    vertxTestContext.assertComplete(future).onComplete(f -> {
-      assertTrue(f.succeeded());
-      verify(restClient, times(1)).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
-      vertxTestContext.completeNow();
-    });
-  }
-
-  @Test
-  void cancelManyItemRequests(VertxTestContext vertxTestContext) {
-    var itemIds = generateUUIDs(10);
-    var reqMap = generateRequests(itemIds);
-
-    doReturn(Future.succeededFuture()).when(restClient).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
-    doReturn(Future.succeededFuture(reqMap)).when(circulationRequestsRetriever).getRequesterIdsToRequestsByItemIds(anyList(), eq(requestContext));
-
-    Future<Void> future = inventoryItemRequestService.cancelItemRequests(itemIds, requestContext);
-
-    vertxTestContext.assertComplete(future).onComplete(f -> {
-      assertTrue(f.succeeded());
-      verify(restClient, times(10)).put(any(RequestEntry.class), any(JsonObject.class), eq(requestContext));
-      vertxTestContext.completeNow();
-    });
-  }
-
-  @Test
   void transferSingleItemRequest(VertxTestContext vertxTestContext) {
     var itemIds = generateUUIDs(1);
     var reqMap = generateRequests(itemIds);


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/FAT-14355
there is issue with permission and exception handling
```
ERROR FutureImpl$2         org.folio.rest.core.exceptions.HttpException: Access for user 'test-user' (00000000-1111-5555-9999-999999999992) requires permission: circulation.requests.item.put
```
## Approach
adding permission to change circulation request status for transfer action and adding exception handling to notify user about error. 

Removing unsed method. This will be stored in version control system, if it need in the future