### PR TITLE
[MODORDERS-1138] Implement endpoint to fetch Circulation requests for pieces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -615,6 +615,15 @@
             "invoice.invoice-lines.collection.get",
             "invoice.invoice-lines.item.put"
           ]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/orders/pieces/circulation-requests",
+          "permissionsRequired": ["orders.pieces.collection.get"],
+          "modulePermissions": [
+            "orders-storage.pieces.collection.get",
+            "circulation.requests.collection.get"
+          ]
         }
       ]
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -618,7 +618,7 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/orders/pieces/circulation-requests",
+          "pathPattern": "/orders/pieces-requests",
           "permissionsRequired": ["orders.pieces.collection.get"],
           "modulePermissions": [
             "orders-storage.pieces.collection.get",

--- a/ramls/pieces-requests.raml
+++ b/ramls/pieces-requests.raml
@@ -1,0 +1,33 @@
+#%RAML 1.0
+title: Pieces Requests
+baseUri: https://github.com/folio-org/mod-orders
+version: v1
+protocols: [ HTTP, HTTPS ]
+
+documentation:
+  - title: Endpoint for fetching Circulation Requests for Pieces
+    content: <b>Endpoint for fetching Circulation Requests for Pieces</b>
+
+types:
+  requests-collection: !include acq-models/mod-orders/schemas/circulationRequestsCollection.json
+  errors: !include raml-util/schemas/errors.schema
+  UUID:
+    type: string
+    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
+
+/orders/pieces-requests:
+  get:
+    description: Return a collection of circulation requests by Piece IDs
+    queryParameters:
+      pieceIds:
+        displayName: IDs of the pieces associated with the requests
+        type: string[]
+        description: IDs of the pieces associated with the requests
+        example: [ 7e74f1f1-f19e-482e-a02a-669fd632c5e0, afd0c802-2d9c-49ed-be89-770b7ef564b5 ]
+        required: true
+      status:
+        displayName: Status by which the requests should be filtered
+        type: string
+        description: Status by which the requests should be filtered
+        example: Open - In transit
+        required: true

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -11,6 +11,7 @@ documentation:
 types:
   piece: !include acq-models/mod-orders-storage/schemas/piece.json
   piece-collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
+  requests-collection: !include acq-models/mod-orders/schemas/circulationRequestsCollection.json
   errors: !include raml-util/schemas/errors.schema
   UUID:
     type: string
@@ -142,3 +143,20 @@ resourceTypes:
                 value: !include examples/errors_500.sample
             text/plain:
               example: "unable to delete Piece -- Internal server error, e.g. due to misconfiguration"
+  /circulation-requests:
+    get:
+      description: Return a collection of circulation requests by Piece IDs
+      queryParameters:
+        pieceIds:
+          displayName: IDs of the pieces associated with the requests
+          type: string[]
+          description: IDs of the pieces associated with the requests
+          example: [7e74f1f1-f19e-482e-a02a-669fd632c5e0, afd0c802-2d9c-49ed-be89-770b7ef564b5]
+          required: true
+        status:
+          displayName: Status by which the requests should be filtered
+          type: string
+          description: Status by which the requests should be filtered
+          example: Open - In transit
+          required: true
+

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -11,7 +11,6 @@ documentation:
 types:
   piece: !include acq-models/mod-orders-storage/schemas/piece.json
   piece-collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
-  requests-collection: !include acq-models/mod-orders/schemas/circulationRequestsCollection.json
   errors: !include raml-util/schemas/errors.schema
   UUID:
     type: string
@@ -143,20 +142,3 @@ resourceTypes:
                 value: !include examples/errors_500.sample
             text/plain:
               example: "unable to delete Piece -- Internal server error, e.g. due to misconfiguration"
-  /circulation-requests:
-    get:
-      description: Return a collection of circulation requests by Piece IDs
-      queryParameters:
-        pieceIds:
-          displayName: IDs of the pieces associated with the requests
-          type: string[]
-          description: IDs of the pieces associated with the requests
-          example: [7e74f1f1-f19e-482e-a02a-669fd632c5e0, afd0c802-2d9c-49ed-be89-770b7ef564b5]
-          required: true
-        status:
-          displayName: Status by which the requests should be filtered
-          type: string
-          description: Status by which the requests should be filtered
-          example: Open - In transit
-          required: true
-

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -850,8 +850,8 @@ public class ApplicationConfig {
   }
 
   @Bean
-  CirculationRequestsRetriever circulationRequestsRetriever(RestClient restClient) {
-    return new CirculationRequestsRetriever(restClient);
+  CirculationRequestsRetriever circulationRequestsRetriever(PieceStorageService pieceStorageService, RestClient restClient) {
+    return new CirculationRequestsRetriever(pieceStorageService, restClient);
   }
 
 }

--- a/src/main/java/org/folio/orders/utils/CommonFields.java
+++ b/src/main/java/org/folio/orders/utils/CommonFields.java
@@ -4,7 +4,8 @@ public enum CommonFields {
 
   ID("id"),
   METADATA("metadata"),
-  CREATED_DATE("createdDate");
+  CREATED_DATE("createdDate"),
+  TENANT_ID("tenantId");
 
   private final String value;
 

--- a/src/main/java/org/folio/rest/impl/PiecesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PiecesAPI.java
@@ -14,6 +14,7 @@ import org.folio.rest.annotations.Validate;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.resource.OrdersPieces;
+import org.folio.rest.jaxrs.resource.OrdersPiecesRequests;
 import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.pieces.PieceStorageService;
 import org.folio.service.pieces.flows.create.PieceCreateFlowManager;
@@ -28,7 +29,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
-public class PiecesAPI extends BaseApi implements OrdersPieces {
+public class PiecesAPI extends BaseApi implements OrdersPieces, OrdersPiecesRequests {
 
   private static final Logger logger = LogManager.getLogger();
   @Autowired
@@ -101,12 +102,12 @@ public class PiecesAPI extends BaseApi implements OrdersPieces {
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
 
-
   @Override
-  public void getOrdersPiecesCirculationRequests(List<String> pieceIds, String status, Map<String, String> okapiHeaders,
+  public void getOrdersPiecesRequests(List<String> pieceIds, String status, Map<String, String> okapiHeaders,
                                                  Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     circulationRequestsRetriever.getRequesterIdsToRequestsByPieceIds(pieceIds, status, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(requests -> asyncResultHandler.handle(succeededFuture(buildOkResponse(requests))))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
+
 }

--- a/src/main/java/org/folio/service/CirculationRequestsRetriever.java
+++ b/src/main/java/org/folio/service/CirculationRequestsRetriever.java
@@ -35,7 +35,7 @@ import static org.folio.service.inventory.util.RequestFields.ITEM_ID;
 
 public class CirculationRequestsRetriever {
 
-  private final static String OPEN_REQUEST_STATUS = "Open - *";
+  private static final String OPEN_REQUEST_STATUS = "Open - *";
 
   private final PieceStorageService pieceStorageService;
 

--- a/src/main/java/org/folio/service/CirculationRequestsRetriever.java
+++ b/src/main/java/org/folio/service/CirculationRequestsRetriever.java
@@ -3,17 +3,26 @@ package org.folio.service;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import one.util.streamex.StreamEx;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.CirculationRequest;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.RequestsCollection;
+import org.folio.service.pieces.PieceStorageService;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
 import static org.folio.orders.utils.HelperUtils.convertIdsToCqlQuery;
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ_15;
 import static org.folio.service.inventory.InventoryUtils.INVENTORY_LOOKUP_ENDPOINTS;
 import static org.folio.service.inventory.InventoryUtils.REQUESTS;
@@ -24,16 +33,19 @@ import static org.folio.service.inventory.util.RequestFields.ITEM_ID;
 
 public class CirculationRequestsRetriever {
 
-  private final static String OUTSTANDING_REQUEST_STATUS_PREFIX = "Open - ";
+  private final static String OPEN_REQUEST_STATUS = "Open - *";
+
+  private final PieceStorageService pieceStorageService;
 
   private final RestClient restClient;
 
-  public CirculationRequestsRetriever(RestClient restClient) {
+  public CirculationRequestsRetriever(PieceStorageService pieceStorageService, RestClient restClient) {
+    this.pieceStorageService = pieceStorageService;
     this.restClient = restClient;
   }
 
   public Future<Integer> getNumberOfRequestsByItemId(String itemId, RequestContext requestContext) {
-    String query = String.format("(itemId==%s and status=\"%s*\")", itemId, OUTSTANDING_REQUEST_STATUS_PREFIX);
+    String query = String.format("(itemId==%s and status=\"%s*\")", itemId, OPEN_REQUEST_STATUS);
     RequestEntry requestEntry = new RequestEntry(INVENTORY_LOOKUP_ENDPOINTS.get(REQUESTS))
       .withQuery(query).withOffset(0).withLimit(0); // limit = 0 means payload will include only totalRecords value
     return restClient.getAsJsonObject(requestEntry, requestContext)
@@ -41,21 +53,21 @@ public class CirculationRequestsRetriever {
   }
 
   public Future<Map<String, Long>> getNumbersOfRequestsByItemIds(List<String> itemIds, RequestContext requestContext) {
-    return getRequestsByItemIds(itemIds, requestContext)
+    return getRequestsByItemIds(itemIds, OPEN_REQUEST_STATUS, requestContext)
       .map(jsonList -> jsonList.stream()
         .collect(Collectors.groupingBy(json -> json.getString(ITEM_ID.getValue()), Collectors.counting()))
       );
   }
 
   public Future<Map<String, List<JsonObject>>> getRequesterIdsToRequestsByItemIds(List<String> itemIds, RequestContext requestContext) {
-    return getRequestsByItemIds(itemIds, requestContext)
+    return getRequestsByItemIds(itemIds, OPEN_REQUEST_STATUS, requestContext)
       .map(jsonList -> jsonList.stream()
         .collect(Collectors.groupingBy(json -> json.getString(REQUESTER_ID.getValue()))));
   }
 
-  private Future<List<JsonObject>> getRequestsByItemIds(List<String> itemIds, RequestContext requestContext) {
+  private Future<List<JsonObject>> getRequestsByItemIds(List<String> itemIds, String status, RequestContext requestContext) {
     var futures = StreamEx.ofSubLists(itemIds, MAX_IDS_FOR_GET_RQ_15)
-      .map(ids -> String.format("(%s and status=\"%s*\")", convertIdsToCqlQuery(ids, ITEM_ID.getValue()), OUTSTANDING_REQUEST_STATUS_PREFIX))
+      .map(ids -> String.format("(%s and status=\"%s\")", convertIdsToCqlQuery(ids, ITEM_ID.getValue()), status))
       .map(query -> new RequestEntry(INVENTORY_LOOKUP_ENDPOINTS.get(REQUESTS))
         .withQuery(query).withOffset(0).withLimit(Integer.MAX_VALUE))
       .map(entry -> restClient.getAsJsonObject(entry, requestContext))
@@ -70,6 +82,40 @@ public class CirculationRequestsRetriever {
             .mapToObj(requests::getJsonObject);
         })
         .toList());
+  }
+
+  public Future<RequestsCollection> getRequesterIdsToRequestsByPieceIds(List<String> pieceIds, String status, RequestContext requestContext) {
+    // 1. Fetch all pieces
+    return pieceStorageService.getPiecesByIds(pieceIds, requestContext)
+      // 2. Convert list of pieces to a map where we map tenants to items that are in this tenant
+      .map(pieces -> getLocationContextToItems(pieces, requestContext))
+      // 3. For each tenant fetch its items -> resulting in a list of Future<List<JsonObject>>
+      .map(ctxToItemsMap -> StreamEx.of(ctxToItemsMap.entrySet())
+        .map(ctxToItems -> getRequestsByItemIds(ctxToItems.getValue(), status, ctxToItems.getKey())).toList())
+      // 4. Put the list of futures in a composite one and flatMap all futures into a single list
+      .compose(requests -> GenericCompositeFuture.all(requests)
+        .map(cf -> StreamEx.of(cf.<List<JsonObject>>list()).toFlatList(Function.identity())))
+      // 5. Prepare response body
+      .map(this::prepareRequestsCollection);
+  }
+
+  private Map<RequestContext, List<String>> getLocationContextToItems(List<Piece> pieces, RequestContext requestContext) {
+    return StreamEx.of(pieces)
+      .filter(piece -> StringUtils.isNotEmpty(piece.getItemId()))
+      .groupingBy(piece -> createContextWithNewTenantId(requestContext, piece.getReceivingTenantId()),
+        mapping(Piece::getItemId, toList()));
+  }
+
+  private RequestsCollection prepareRequestsCollection(List<JsonObject> requests) {
+    return new RequestsCollection()
+      .withTotalRecords(requests.size())
+      .withCirculationRequests(requests.stream()
+        .map(requestJson -> {
+          var request = new CirculationRequest();
+          requestJson.getMap().forEach(request::setAdditionalProperty);
+          return request;
+        }).toList()
+      );
   }
 
 }

--- a/src/main/java/org/folio/service/CirculationRequestsRetriever.java
+++ b/src/main/java/org/folio/service/CirculationRequestsRetriever.java
@@ -5,12 +5,14 @@ import io.vertx.core.json.JsonObject;
 import one.util.streamex.StreamEx;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.orders.utils.CommonFields;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.jaxrs.model.CirculationRequest;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.RequestsCollection;
+import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.pieces.PieceStorageService;
 
 import java.util.List;
@@ -79,7 +81,8 @@ public class CirculationRequestsRetriever {
           var totalRecords = json.getInteger(COLLECTION_TOTAL.getValue());
           var requests = json.getJsonArray(COLLECTION_RECORDS.getValue());
           return IntStream.range(0, totalRecords)
-            .mapToObj(requests::getJsonObject);
+            .mapToObj(requests::getJsonObject)
+            .map(request -> request.put(CommonFields.TENANT_ID.getValue(), TenantTool.tenantId(requestContext.getHeaders())));
         })
         .toList());
   }

--- a/src/main/java/org/folio/service/consortium/SharingInstanceService.java
+++ b/src/main/java/org/folio/service/consortium/SharingInstanceService.java
@@ -65,7 +65,7 @@ public class SharingInstanceService {
           return Future.succeededFuture(response);
         } else {
           String message = String.format(SHARING_INSTANCE_ERROR, sharingInstance.sourceTenantId(), sharingInstance.targetTenantId(),
-            sharingInstance.instanceIdentifier(), sharingInstance.error());
+            sharingInstance.instanceIdentifier(), response.error());
           return Future.failedFuture(new ConsortiumException(message));
         }
       });

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -1,6 +1,7 @@
 package org.folio.service.pieces.flows.delete;
 
 import static org.folio.orders.utils.ProtectedOperationType.DELETE;
+import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,7 +61,8 @@ public class PieceDeleteFlowManager {
       return Future.succeededFuture();
     }
 
-    return circulationRequestsRetriever.getNumberOfRequestsByItemId(piece.getItemId(), requestContext)
+    var locationContext = createContextWithNewTenantId(requestContext, holder.getPieceToDelete().getReceivingTenantId());
+    return circulationRequestsRetriever.getNumberOfRequestsByItemId(piece.getItemId(), locationContext)
       .compose(totalRequests -> {
         if (totalRequests != null && totalRequests > 0) {
           logger.error("isDeletePieceRequestValid:: {} Request(s) were found for the given item {} when deleting piece {}",

--- a/src/test/resources/mockdata/pieces/pieces-for-requests.json
+++ b/src/test/resources/mockdata/pieces/pieces-for-requests.json
@@ -1,0 +1,17 @@
+{
+  "pieces": [
+    {
+      "id": "05a95f03-eb00-4248-9f2e-2bd05957ff04",
+      "itemId": "8d0350f6-3ca0-4876-9e44-0f6a6bd79e47"
+    },
+    {
+      "id": "05a95f03-eb00-4248-9f2e-2bd05957ff05",
+      "itemId": "e477dd71-3144-48ee-9972-d93f726ce0d8"
+    },
+    {
+      "id": "05a95f03-eb00-4248-9f2e-2bd05957ff06",
+      "itemId": "24645dbd-2dd9-429c-ac24-44cae19adae4"
+    }
+  ],
+  "totalRecords": 1
+}


### PR DESCRIPTION
## Purpose
[[MODORDERS-1138] Implement endpoint to fetch Circulation requests for pieces](https://folio-org.atlassian.net/browse/MODORDERS-1138)

## Approach
- Add new schema for response
- Add new endpoint to fetch requests by piece ids
- Add logic to fetch requests from other tenants based on receivingTenantId of pieces
- Add unit tests