### PR TITLE
[MODORDERS-1149] Async fix

### DIFF
--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -329,6 +330,21 @@ public class HelperUtils {
   public static <T> Future<List<T>> collectResultsOnSuccess(Collection<Future<T>> futures) {
     return GenericCompositeFuture.join(new ArrayList<>(futures))
       .map(CompositeFuture::list);
+  }
+
+  /**
+   * The method allows to compose any elements with the same action in sequence.
+   *
+   * @param  list    elements to be executed in sequence
+   * @param  method  action that will be executed sequentially based on the number of list items
+   * @return         the last composed element(Feature result)
+   */
+  public static <T, R> Future<R> chainCall(List<T> list, Function<T, Future<R>> method) {
+    Future<R> f = Future.succeededFuture();
+    for (T item : list) {
+      f = f.compose(r -> method.apply(item));
+    }
+    return f;
   }
 
   /**

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
+import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.service.inventory.InventoryItemManager.ID;
 import static org.folio.service.inventory.InventoryItemManager.ITEM_HOLDINGS_RECORD_ID;
 
@@ -194,7 +195,7 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
                                         Function<Location, Future<Void>> processFunction) {
     return retrieveUniqueLocations(holder.getStoragePoLine(), requestContext)
       .compose(tenantIdToLocationsMap ->
-        GenericCompositeFuture.all(tenantIdToLocationsMap.values().stream()
+        collectResultsOnSuccess(tenantIdToLocationsMap.values().stream()
           .map(locations ->
             GenericCompositeFuture.join(locations.stream()
               .map(processFunction)

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
+import static org.folio.orders.utils.HelperUtils.chainCall;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.service.inventory.InventoryItemManager.ID;
 import static org.folio.service.inventory.InventoryItemManager.ITEM_HOLDINGS_RECORD_ID;
@@ -196,11 +197,7 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
     return retrieveUniqueLocations(holder.getStoragePoLine(), requestContext)
       .compose(tenantIdToLocationsMap ->
         collectResultsOnSuccess(tenantIdToLocationsMap.values().stream()
-          .map(locations ->
-            GenericCompositeFuture.join(locations.stream()
-              .map(processFunction)
-              .toList())
-          )
+          .map(locations -> chainCall(locations, processFunction))
           .collect(toList()))
       )
       .mapEmpty();


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDERS-1149
Without prcessing futures in chaing we had the following exception:
`org.folio.rest.core.exceptions.ConsortiumException: Error during sharing Instance for sourceTenantId: consortium, targetTenantId: college, instanceIdentifier: f14b2828-28ee-4169-9fa0-ee5c38db7e66, error: Failed to post inventory instance with reason: id value already exists in table instance: f14b2828-28ee-4169-9fa0-ee5c38db7e66`
It is because code tried to share instance from 2 locations to the same instanceId simultaneously.