### PR TITLE
[MODORDERS-1169]. Fix piece update on null processedHoldings.get(holdingKey)

### DIFF
--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -399,10 +399,14 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
     logger.info("calculatePoLineReceiptStatus:: Processed pieces: {}, Pieces from storage: {}", piecesSuccessfullyProcessed.size(), piecesByPoLine.size());
     piecesSuccessfullyProcessed.forEach(v -> logger.info("calculatePoLineReceiptStatus:: Processed Piece, id: {}, status: {}", v.getId(), v.getReceivingStatus()));
     piecesByPoLine.forEach(v -> logger.info("calculatePoLineReceiptStatus:: Piece from storage, id: {}, status: {}", v.getId(), v.getReceivingStatus()));
-    long expectedPiecesQuantity = piecesByPoLine.stream().filter(piece -> EXPECTED_STATUSES.contains(piece.getReceivingStatus())).count();
-    long receivedQty = piecesByPoLine.stream().filter(piece -> RECEIVED_STATUSES.contains(piece.getReceivingStatus())).count();
+    long expectedPiecesQuantity = piecesByPoLine.stream()
+      .filter(piece -> EXPECTED_STATUSES.contains(piece.getReceivingStatus()))
+      .count();
+    long receivedPiecesQuantity = piecesByPoLine.stream()
+      .filter(piece -> RECEIVED_STATUSES.contains(piece.getReceivingStatus()))
+      .count();
     logger.info("calculatePoLineReceiptStatus:: Expected pieces: {}", expectedPiecesQuantity);
-    logger.info("calculatePoLineReceiptStatus:: Received pieces: {}", receivedQty);
+    logger.info("calculatePoLineReceiptStatus:: Received pieces: {}", receivedPiecesQuantity);
     // Fully Received: If receiving and there is no expected piece remaining
     if (!poLine.getCheckinItems().equals(Boolean.TRUE) && expectedPiecesQuantity == 0) {
       return FULLY_RECEIVED;
@@ -412,7 +416,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
       return PARTIALLY_RECEIVED;
     }
     // If pieces were rolled-back to Expected we check if there is any Received piece in the storage
-    return receivedQty == 0 ? AWAITING_RECEIPT : PARTIALLY_RECEIVED;
+    return receivedPiecesQuantity == 0 ? AWAITING_RECEIPT : PARTIALLY_RECEIVED;
   }
 
   //-------------------------------------------------------------------------------------

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -767,8 +767,6 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
   protected abstract Future<Boolean> receiveInventoryItemAndUpdatePiece(JsonObject item, Piece piece, RequestContext locationContext);
 
   private boolean holdingUpdateOnCheckinReceiveRequired(Piece piece, CompositePoLine poLine) {
-    // In case of affiliation change current holding is irrelevant because we will create a new holding in
-    // another tenant, hence we need to block the creation of instances per affiliation-changed piece here
     boolean isHoldingUpdateRequired;
     if (piece.getFormat() == Piece.Format.ELECTRONIC) {
       isHoldingUpdateRequired = PoLineCommonUtil.isHoldingUpdateRequiredForEresource(poLine);

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -751,11 +751,13 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
 
       if (holdingUpdateOnCheckinReceiveRequired(piece, poLine) && !isRevertToOnOrder(piece) && !processedHoldings.isEmpty()) {
         String holdingKey = buildProcessedHoldingKey(piece, title.getInstanceId());
-        String holdingId = processedHoldings.get(holdingKey);
-        item.put(ITEM_HOLDINGS_RECORD_ID, holdingId);
-        logger.info("processItemsUpdate:: Item was processed, itemId: {}", piece.getItemId());
-      } else {
-        logger.info("processItemsUpdate:: Item processing is not required, deferred, itemId: {}", piece.getItemId());
+        if (processedHoldings.containsKey(holdingKey)) {
+          String holdingId = processedHoldings.get(holdingKey);
+          item.put(ITEM_HOLDINGS_RECORD_ID, holdingId);
+          logger.info("processItemsUpdate:: Item was processed, itemId: {}", piece.getItemId());
+        } else {
+          logger.info("processItemsUpdate:: Item processing is not required, itemId: {}", piece.getItemId());
+        }
       }
       RequestContext locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, getReceivingTenantId(piece));
       futuresForItemsUpdates.add(receiveInventoryItemAndUpdatePiece(item, piece, locationContext));

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -617,12 +617,8 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
     if (!ifHoldingNotProcessed(piece.getId()) || isRevertToOnOrder(piece)) {
       return Future.succeededFuture(true);
     }
-    // Get the initial tenant on the piece from storage
-    String srcTenantId = piece.getReceivingTenantId();
-    // Get the new tenant from the CheckInPiece object coming from the UI
-    String dstTenantId = getReceivingTenantId(piece);
     Location location = new Location().withLocationId(getLocationId(piece)).withHoldingId(getHoldingId(piece));
-    RequestContext locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, dstTenantId);
+    RequestContext locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, getReceivingTenantId(piece));
     return inventoryInstanceManager.createShadowInstanceIfNeeded(instanceId, locationContext)
       .compose(instance -> {
         // Does not create a holding for every piece so will be

--- a/src/main/java/org/folio/orders/utils/RequestContextUtil.java
+++ b/src/main/java/org/folio/orders/utils/RequestContextUtil.java
@@ -18,7 +18,7 @@ public class RequestContextUtil {
     }
     var modifiedHeaders = new CaseInsensitiveMap<>(requestContext.getHeaders());
     modifiedHeaders.put(XOkapiHeaders.TENANT, tenantId);
-    logger.debug("Request context has been changed with new tenant: {}", tenantId);
+    logger.info("Request context has been changed with new tenant: {}", tenantId);
     return new RequestContext(requestContext.getContext(), modifiedHeaders);
   }
 

--- a/src/main/java/org/folio/orders/utils/RequestContextUtil.java
+++ b/src/main/java/org/folio/orders/utils/RequestContextUtil.java
@@ -18,7 +18,7 @@ public class RequestContextUtil {
     }
     var modifiedHeaders = new CaseInsensitiveMap<>(requestContext.getHeaders());
     modifiedHeaders.put(XOkapiHeaders.TENANT, tenantId);
-    logger.info("Request context has been changed with new tenant: {}", tenantId);
+    logger.debug("Request context has been changed with new tenant: {}", tenantId);
     return new RequestContext(requestContext.getContext(), modifiedHeaders);
   }
 

--- a/src/main/java/org/folio/service/inventory/InventoryHoldingManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryHoldingManager.java
@@ -214,6 +214,7 @@ public class InventoryHoldingManager {
         holdingsRecJson.put(HOLDING_INSTANCE_ID, instanceId);
         holdingsRecJson.put(HOLDING_PERMANENT_LOCATION_ID, locationId);
         holdingsRecJson.put(HOLDING_SOURCE, sourceId);
+        logger.info("createHolding:: Creating a new holding, instanceId: {}, locationId: {}", instanceId, locationId);
         return holdingsRecJson;
       })
       .compose(holdingsRecJson -> {

--- a/src/main/java/org/folio/service/pieces/ItemRecreateInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/ItemRecreateInventoryService.java
@@ -5,9 +5,11 @@ import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS_NAME;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.models.ItemStatus;
 import org.folio.rest.core.models.RequestContext;
@@ -60,13 +62,13 @@ public class ItemRecreateInventoryService {
     }
 
     return inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
-      .map(item -> getItemWithStatus(item, ItemStatus.ON_ORDER.value()));
+      .map(item -> getItemWithStatus(item, EnumSet.of(ItemStatus.ON_ORDER, ItemStatus.ORDER_CLOSED)));
   }
 
-  private JsonObject getItemWithStatus(JsonObject item, String status) {
+  private JsonObject getItemWithStatus(JsonObject item, Set<ItemStatus> statuses) {
     return Optional.ofNullable(item)
       .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
-      .filter(itemStatus -> status.equalsIgnoreCase(itemStatus.getString(ITEM_STATUS_NAME)))
+      .filter(itemStatus -> statuses.contains(ItemStatus.fromValue(itemStatus.getString(ITEM_STATUS_NAME))))
       .orElse(null);
   }
 }

--- a/src/main/java/org/folio/service/pieces/ItemRecreateInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/ItemRecreateInventoryService.java
@@ -1,17 +1,10 @@
 package org.folio.service.pieces;
 
-import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS;
-import static org.folio.service.inventory.InventoryItemManager.ITEM_STATUS_NAME;
-
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Set;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
-import org.folio.models.ItemStatus;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
@@ -29,46 +22,39 @@ public class ItemRecreateInventoryService {
     this.inventoryItemManager = inventoryItemManager;
   }
 
-  // Return an Id of the recreated Item
-  public Future<String> recreateItemInDestinationTenant(CompositePurchaseOrder compPO, CompositePoLine compPol,
+  /**
+   * Recreates an item in a destination tenant
+   * Example case:
+   * Change piece affiliation from member tenant 1 (e.g. university) to member tenant 2 (e.g. college)
+   * Performed actions:
+   * 1. Find item in member tenant 1 by id
+   * 2. If an item is found create an item in member tenant 2 with the same item id
+   * 3. Then delete the item in member tenant 1 by item id
+   *
+   * @param compOrder Composite PO
+   * @param compPoLine Composite POL
+   * @param piece Piece
+   * @param srcLocCtx Source location context
+   * @param dstLocCtx Destination location context
+   * @return id of the recreated Item
+   */
+  public Future<String> recreateItemInDestinationTenant(CompositePurchaseOrder compOrder, CompositePoLine compPoLine,
                                                         Piece piece, RequestContext srcLocCtx, RequestContext dstLocCtx) {
-    // Example Case: Member Tenant 1 (University) -> Member Tenant 2 (College)
-    // Create Item in Member Tenant 2 with the same Item Id
-    // Delete Item in Member Tenant 1 by Item Id
-    Future<List<String>> itemFuture;
-    if (piece.getFormat() == Piece.Format.ELECTRONIC && DefaultPieceFlowsValidator.isCreateItemForElectronicPiecePossible(piece, compPol)) {
-      itemFuture = inventoryItemManager.createMissingElectronicItems(compPO, compPol, piece, ITEM_QUANTITY, dstLocCtx);
-    } else if (DefaultPieceFlowsValidator.isCreateItemForNonElectronicPiecePossible(piece, compPol)) {
-      itemFuture = inventoryItemManager.createMissingPhysicalItems(compPO, compPol, piece, ITEM_QUANTITY, dstLocCtx);
-    } else {
-      itemFuture = Future.succeededFuture(List.of());
-    }
-
-    return itemFuture
-      .map(itemIds -> itemIds.stream().findFirst().orElseThrow(() -> new NoSuchElementException("Recreated Item Id could not be found")))
-      .compose(itemId -> deleteItem(piece, srcLocCtx).map(voidResult -> itemId));
-  }
-
-  private Future<Void> deleteItem(Piece piece, RequestContext requestContext) {
-    return getOnOrderItemForPiece(piece, requestContext)
-      .compose(item -> Optional.ofNullable(item)
-        .map(itemEntry -> inventoryItemManager.deleteItem(piece.getItemId(), true, requestContext))
-        .orElse(Future.succeededFuture()));
-  }
-
-  private Future<JsonObject> getOnOrderItemForPiece(Piece piece, RequestContext requestContext) {
     if (StringUtils.isEmpty(piece.getItemId())) {
       return Future.succeededFuture();
     }
-
-    return inventoryItemManager.getItemRecordById(piece.getItemId(), true, requestContext)
-      .map(item -> getItemWithStatus(item, EnumSet.of(ItemStatus.ON_ORDER, ItemStatus.ORDER_CLOSED)));
-  }
-
-  private JsonObject getItemWithStatus(JsonObject item, Set<ItemStatus> statuses) {
-    return Optional.ofNullable(item)
-      .map(itemObj -> itemObj.getJsonObject(ITEM_STATUS))
-      .filter(itemStatus -> statuses.contains(ItemStatus.fromValue(itemStatus.getString(ITEM_STATUS_NAME))))
-      .orElse(null);
+    return inventoryItemManager.getItemRecordById(piece.getItemId(), true, srcLocCtx)
+      .compose(item -> {
+        if (Objects.nonNull(item)) {
+          if (piece.getFormat() == Piece.Format.ELECTRONIC && DefaultPieceFlowsValidator.isCreateItemForElectronicPiecePossible(piece, compPoLine)) {
+            return inventoryItemManager.createMissingElectronicItems(compOrder, compPoLine, piece, ITEM_QUANTITY, dstLocCtx);
+          } else if (DefaultPieceFlowsValidator.isCreateItemForNonElectronicPiecePossible(piece, compPoLine)) {
+            return inventoryItemManager.createMissingPhysicalItems(compOrder, compPoLine, piece, ITEM_QUANTITY,  dstLocCtx);
+          }
+        }
+        return Future.succeededFuture(List.of());
+      })
+      .map(itemIds -> itemIds.stream().findFirst().orElseThrow(() -> new NoSuchElementException("Recreated item id could not be found")))
+      .compose(itemId -> inventoryItemManager.deleteItem(piece.getItemId(), true, srcLocCtx).map(v -> itemId));
   }
 }

--- a/src/test/resources/mockdata/lines/po_line_collection.json
+++ b/src/test/resources/mockdata/lines/po_line_collection.json
@@ -327,13 +327,13 @@
       },
       "locations": [
         {
-          "locationId": "b241764c-1466-4e1d-a028-1a3684a5da87",
+          "holdingId": "c2c2fe4e-03cb-42c5-890d-8b2041d2f4d0",
           "quantity": 2,
           "quantityElectronic": 0,
           "quantityPhysical": 2
         },
         {
-          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "locationId": "546c5d9a-4845-42b8-aa4f-6bd62bd7bbdc",
           "quantity": 1,
           "quantityElectronic": 0,
           "quantityPhysical": 1

--- a/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
+++ b/src/test/resources/mockdata/receiving/receive-physical-resources-6-of-10-with-errors.json
@@ -8,49 +8,49 @@
           "barcode": 11111111112,
           "comment": "Expected error pieceAlreadyReceived",
           "displaySummary": "Vol. 1",
-          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "holdingId": "c2c2fe4e-03cb-42c5-890d-8b2041d2f4d0",
           "pieceId": "8c057872-9c75-4fb1-879d-de3b089b0388"
         },
         {
           "barcode": 11111111113,
           "comment": "Expected error itemNotFound",
           "displaySummary": "Vol. 1",
-          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "holdingId": "c2c2fe4e-03cb-42c5-890d-8b2041d2f4d0",
           "pieceId": "6f495150-9a7c-4104-84fa-16f3ec9ab005"
         },
         {
           "barcode": 11111111114,
           "comment": "Very important note",
           "displaySummary": "Vol. 1",
-          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "holdingId": "c2c2fe4e-03cb-42c5-890d-8b2041d2f4d0",
           "pieceId": "2884f2cd-ccab-47e1-a021-9b22a05230d9"
         },
         {
           "barcode": 11111111115,
           "comment": "Expected error piecePolMismatch",
           "displaySummary": "Vol. 1",
-          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "holdingId": "c2c2fe4e-03cb-42c5-890d-8b2041d2f4d0",
           "pieceId": "2f6056bd-e7f1-4e51-add2-b0c803066c74"
         },
         {
           "barcode": 11111111116,
           "comment": "Expected error pieceNotFound",
           "displaySummary": "Vol. 1",
-          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "holdingId": "c2c2fe4e-03cb-42c5-890d-8b2041d2f4d0",
           "pieceId": "99e04f91-6985-48df-997d-289773fd8c44"
         },
         {
           "barcode": 11111111117,
           "comment": "500500500500 Expected error pieceUpdateFailed",
           "displaySummary": "Vol. 1",
-          "locationId": "168f8a86-d26c-406e-813f-c7527f241ac3",
+          "holdingId": "546c5d9a-4845-42b8-aa4f-6bd62bd7bbdc",
           "pieceId": "de647d4a-cc53-440d-be2b-da12559ba51c"
         },
         {
           "barcode": 11111111118,
           "comment": "Very important note",
           "displaySummary": "Vol. 1",
-          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+         "holdingId": "c2c2fe4e-03cb-42c5-890d-8b2041d2f4d0",
           "pieceId": "f7272eb2-499f-4c29-985e-7ffc468d2360"
         },
         {


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1169>

## Approach

- Add a condition to prevent setting a null `holdingId` in the map, which is used to update the processed pieces
- Remove item status validation during item recreation on receive with an affiliation change
- Make holding creation apply for every piece that has an incoming `locationId`, which requires a new holding to be made
- Simplify item recreation method to fetch an item from the source tenant before other operations
- Tested with mod-orders and cross-module Karate tests:
  - ![image](https://github.com/user-attachments/assets/398d935f-7a4c-43df-82b3-307fb2769d8e)
  - ![image](https://github.com/user-attachments/assets/17dfd950-9836-4f6e-9698-e0c7a9a4d10c)
 
