### PR TITLE
[MODORDERS-1177] A user cannot add/edit piece when related order has another pieces with affiliations in tenants user does not belong to

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -483,10 +483,8 @@ public class ApplicationConfig {
   InventoryItemManager inventoryItemManager(RestClient restClient,
                                             ConfigurationEntriesCache configurationEntriesCache,
                                             InventoryCache inventoryCache,
-                                            ConsortiumConfigurationService consortiumConfigurationService,
-                                            PurchaseOrderStorageService purchaseOrderStorageService) {
-    return new InventoryItemManager(restClient, configurationEntriesCache, inventoryCache,
-      consortiumConfigurationService, purchaseOrderStorageService);
+                                            ConsortiumConfigurationService consortiumConfigurationService) {
+    return new InventoryItemManager(restClient, configurationEntriesCache, inventoryCache, consortiumConfigurationService);
   }
 
   @Bean

--- a/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
+++ b/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
@@ -36,7 +36,7 @@ public class OrderTemplatesAPI implements OrdersOrderTemplates {
     OrderTemplatesHelper orderTemplatesHelper = new OrderTemplatesHelper(okapiHeaders, vertxContext);
     orderTemplatesHelper.createOrderTemplate(entity)
       .onSuccess(template -> {
-        if (logger.isInfoEnabled()) {
+        if (logger.isDebugEnabled()) {
           logger.debug("Successfully created new order template: {}", JsonObject.mapFrom(template)
             .encodePrettily());
         }
@@ -53,7 +53,7 @@ public class OrderTemplatesAPI implements OrdersOrderTemplates {
     OrderTemplatesHelper helper = new OrderTemplatesHelper(okapiHeaders, vertxContext);
     helper.getOrderTemplates(query, offset, limit)
       .onSuccess(templates -> {
-        if (logger.isInfoEnabled()) {
+        if (logger.isDebugEnabled()) {
           logger.debug("Successfully retrieved order templates collection: {}", JsonObject.mapFrom(templates).encodePrettily());
         }
         asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(templates)));
@@ -101,7 +101,7 @@ public class OrderTemplatesAPI implements OrdersOrderTemplates {
     OrderTemplatesHelper helper = new OrderTemplatesHelper(okapiHeaders, vertxContext);
     helper.getOrderTemplateById(id)
       .onSuccess(template -> {
-        if (logger.isInfoEnabled()) {
+        if (logger.isDebugEnabled()) {
           logger.debug("Successfully retrieved order template: {}", JsonObject.mapFrom(template)
             .encodePrettily());
         }
@@ -117,7 +117,7 @@ public class OrderTemplatesAPI implements OrdersOrderTemplates {
     OrderTemplatesHelper helper = new OrderTemplatesHelper(okapiHeaders, vertxContext);
     helper.deleteOrderTemplate(id)
       .onSuccess(ok -> {
-        if (logger.isInfoEnabled()) {
+        if (logger.isDebugEnabled()) {
           logger.debug("Successfully deleted order template with id={}", id);
         }
         asyncResultHandler.handle(succeededFuture(helper.buildNoContentResponse()));

--- a/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
+++ b/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
@@ -52,12 +52,7 @@ public class OrderTemplatesAPI implements OrdersOrderTemplates {
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     OrderTemplatesHelper helper = new OrderTemplatesHelper(okapiHeaders, vertxContext);
     helper.getOrderTemplates(query, offset, limit)
-      .onSuccess(templates -> {
-        if (logger.isDebugEnabled()) {
-          logger.debug("Successfully retrieved order templates collection: {}", JsonObject.mapFrom(templates).encodePrettily());
-        }
-        asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(templates)));
-      })
+      .onSuccess(templates -> asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(templates))))
       .onFailure(t -> handleErrorResponse(asyncResultHandler, helper, t));
   }
 
@@ -100,13 +95,7 @@ public class OrderTemplatesAPI implements OrdersOrderTemplates {
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     OrderTemplatesHelper helper = new OrderTemplatesHelper(okapiHeaders, vertxContext);
     helper.getOrderTemplateById(id)
-      .onSuccess(template -> {
-        if (logger.isDebugEnabled()) {
-          logger.debug("Successfully retrieved order template: {}", JsonObject.mapFrom(template)
-            .encodePrettily());
-        }
-        asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(template)));
-      })
+      .onSuccess(template -> asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(template))))
       .onFailure(t -> handleErrorResponse(asyncResultHandler, helper, t));
   }
 

--- a/src/main/java/org/folio/rest/impl/OrdersApi.java
+++ b/src/main/java/org/folio/rest/impl/OrdersApi.java
@@ -9,8 +9,6 @@ import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.helper.PurchaseOrderHelper;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.core.models.RequestContext;
@@ -27,11 +25,8 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 
 public class OrdersApi extends BaseApi implements OrdersCompositeOrders, OrdersRollover {
-
-  private static final Logger logger = LogManager.getLogger();
 
   @Autowired
   private OrderRolloverService orderRolloverService;

--- a/src/main/java/org/folio/rest/impl/OrdersApi.java
+++ b/src/main/java/org/folio/rest/impl/OrdersApi.java
@@ -95,12 +95,7 @@ public class OrdersApi extends BaseApi implements OrdersCompositeOrders, OrdersR
 
     purchaseOrderHelper
       .getPurchaseOrders(limit, offset, query, new RequestContext(vertxContext, okapiHeaders))
-      .onSuccess(orders -> {
-        if (logger.isInfoEnabled()) {
-          logger.debug("Successfully retrieved orders: {}", JsonObject.mapFrom(orders).encodePrettily());
-        }
-        asyncResultHandler.handle(succeededFuture(buildOkResponse(orders)));
-      })
+      .onSuccess(orders -> asyncResultHandler.handle(succeededFuture(buildOkResponse(orders))))
       .onFailure(t -> handleErrorResponse(asyncResultHandler, t));
   }
 

--- a/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
@@ -44,7 +44,8 @@ public class ReceivingEncumbranceStrategy implements EncumbranceWorkflowStrategy
       })
       .map(aVoid -> encumbrancesProcessingHolderBuilder.distributeHoldersByOperation(encumbranceRelationsHolders))
       .compose(holder -> encumbranceService.createOrUpdateEncumbrances(holder, requestContext))
-      .onSuccess(holders -> LOG.debug("End processing encumbrances for piece add/delete"));
+      .onSuccess(holders -> LOG.info("End processing encumbrances for piece add/delete for order id: {}", compPO.getId()))
+      .onFailure(t -> LOG.error("Failed to process encumbrances for piece add/delete for order id: {}", compPO.getId(), t));
   }
 
   public Future<List<EncumbranceRelationsHolder>> prepareEncumbranceRelationsHolder(List<EncumbranceRelationsHolder> holders,

--- a/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
@@ -44,7 +44,7 @@ public class ReceivingEncumbranceStrategy implements EncumbranceWorkflowStrategy
       })
       .map(aVoid -> encumbrancesProcessingHolderBuilder.distributeHoldersByOperation(encumbranceRelationsHolders))
       .compose(holder -> encumbranceService.createOrUpdateEncumbrances(holder, requestContext))
-      .onSuccess(holders -> LOG.info("End processing encumbrances for piece add/delete for order id: {}", compPO.getId()))
+      .onSuccess(holders -> LOG.debug("End processing encumbrances for piece add/delete for order id: {}", compPO.getId()))
       .onFailure(t -> LOG.error("Failed to process encumbrances for piece add/delete for order id: {}", compPO.getId(), t));
   }
 

--- a/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/ReceivingEncumbranceStrategy.java
@@ -14,7 +14,7 @@ import org.folio.service.orders.OrderWorkflowType;
 import io.vertx.core.Future;
 
 public class ReceivingEncumbranceStrategy implements EncumbranceWorkflowStrategy {
-  private static final Logger LOG = LogManager.getLogger(ReceivingEncumbranceStrategy.class);
+  private static final Logger logger = LogManager.getLogger(ReceivingEncumbranceStrategy.class);
 
   private final EncumbranceService encumbranceService;
   private final FundsDistributionService fundsDistributionService;
@@ -44,8 +44,8 @@ public class ReceivingEncumbranceStrategy implements EncumbranceWorkflowStrategy
       })
       .map(aVoid -> encumbrancesProcessingHolderBuilder.distributeHoldersByOperation(encumbranceRelationsHolders))
       .compose(holder -> encumbranceService.createOrUpdateEncumbrances(holder, requestContext))
-      .onSuccess(holders -> LOG.debug("End processing encumbrances for piece add/delete for order id: {}", compPO.getId()))
-      .onFailure(t -> LOG.error("Failed to process encumbrances for piece add/delete for order id: {}", compPO.getId(), t));
+      .onSuccess(holders -> logger.debug("processEncumbrances:: End processing encumbrances for piece add/delete for order id: {}", compPO.getId()))
+      .onFailure(t -> logger.error("Failed to process encumbrances for piece add/delete for order id: {}", compPO.getId(), t));
   }
 
   public Future<List<EncumbranceRelationsHolder>> prepareEncumbranceRelationsHolder(List<EncumbranceRelationsHolder> holders,

--- a/src/main/java/org/folio/service/inventory/InventoryItemManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemManager.java
@@ -22,10 +22,10 @@ import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.ReceivedItem;
+import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.caches.ConfigurationEntriesCache;
 import org.folio.service.caches.InventoryCache;
 import org.folio.service.consortium.ConsortiumConfigurationService;
-import org.folio.service.orders.PurchaseOrderStorageService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -74,18 +74,15 @@ public class InventoryItemManager {
   private final ConfigurationEntriesCache configurationEntriesCache;
   private final InventoryCache inventoryCache;
   private final ConsortiumConfigurationService consortiumConfigurationService;
-  private final PurchaseOrderStorageService purchaseOrderStorageService;
 
   public InventoryItemManager(RestClient restClient,
                               ConfigurationEntriesCache configurationEntriesCache,
                               InventoryCache inventoryCache,
-                              ConsortiumConfigurationService consortiumConfigurationService,
-                              PurchaseOrderStorageService purchaseOrderStorageService) {
+                              ConsortiumConfigurationService consortiumConfigurationService) {
     this.restClient = restClient;
     this.configurationEntriesCache = configurationEntriesCache;
     this.inventoryCache = inventoryCache;
     this.consortiumConfigurationService = consortiumConfigurationService;
-    this.purchaseOrderStorageService = purchaseOrderStorageService;
   }
 
 
@@ -433,7 +430,7 @@ public class InventoryItemManager {
   private Future<String> createItemInInventory(JsonObject itemData, RequestContext requestContext) {
     Promise<String> promise = Promise.promise();
     RequestEntry requestEntry = new RequestEntry(ITEM_STOR_ENDPOINT);
-    logger.info("Trying to create Item in inventory");
+    logger.info("Trying to create Item in inventory in tenant: {}", TenantTool.tenantId(requestContext.getHeaders()));
     restClient.postJsonObjectAndGetId(requestEntry, itemData, requestContext)
       .onSuccess(promise::complete)
       // In case item creation failed, return null instead of id

--- a/src/main/java/org/folio/service/orders/PurchaseOrderLineService.java
+++ b/src/main/java/org/folio/service/orders/PurchaseOrderLineService.java
@@ -112,14 +112,22 @@ public class PurchaseOrderLineService {
   }
 
   public Future<Void> saveOrderLine(PoLine poLine, RequestContext requestContext) {
+    return saveOrderLine(poLine, poLine.getLocations(), requestContext);
+  }
+
+  private Future<Void> saveOrderLine(PoLine poLine, List<Location> locations, RequestContext requestContext) {
     RequestEntry requestEntry = new RequestEntry(BY_ID_ENDPOINT).withId(poLine.getId());
-    return updateSearchLocations(poLine, requestContext)
+    return updateSearchLocations(poLine, locations, requestContext)
       .compose(v -> restClient.put(requestEntry, poLine, requestContext));
   }
 
   public Future<Void> saveOrderLine(CompositePoLine compositePoLine, RequestContext requestContext) {
+    return saveOrderLine(compositePoLine, compositePoLine.getLocations(), requestContext);
+  }
+
+  public Future<Void> saveOrderLine(CompositePoLine compositePoLine, List<Location> locations, RequestContext requestContext) {
     PoLine poLine = HelperUtils.convertToPoLine(compositePoLine);
-    return saveOrderLine(poLine, requestContext);
+    return saveOrderLine(poLine, locations, requestContext);
   }
 
   public Future<Void> saveOrderLines(PoLineCollection poLineCollection, RequestContext requestContext) {
@@ -503,7 +511,11 @@ public class PurchaseOrderLineService {
   }
 
   private Future<Void> updateSearchLocations(PoLine poLine, RequestContext requestContext) {
-    return retrieveSearchLocationIds(poLine.getLocations(), requestContext)
+    return updateSearchLocations(poLine, poLine.getLocations(), requestContext);
+  }
+
+  private Future<Void> updateSearchLocations(PoLine poLine, List<Location> locations, RequestContext requestContext) {
+    return retrieveSearchLocationIds(locations, requestContext)
       .map(poLine::withSearchLocationIds)
       .mapEmpty();
   }

--- a/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
+++ b/src/main/java/org/folio/service/pieces/PieceUpdateInventoryService.java
@@ -42,7 +42,7 @@ public class PieceUpdateInventoryService {
   public Future<String> manualPieceFlowCreateItemRecord(Piece piece, CompositePurchaseOrder compPO,
                                                         CompositePoLine compPOL, RequestContext requestContext) {
     final int ITEM_QUANTITY = 1;
-    logger.info("manualPieceFlowCreateItemRecord:: Handling {} items for PO Line and holdings with id={}, receivingTenantId={}",
+    logger.debug("manualPieceFlowCreateItemRecord:: Handling {} items for PO Line and holdings with id={}, receivingTenantId={}",
       ITEM_QUANTITY, piece.getHoldingId(), piece.getReceivingTenantId());
     if (piece.getFormat() == Piece.Format.ELECTRONIC && DefaultPieceFlowsValidator.isCreateItemForElectronicPiecePossible(piece, compPOL)) {
       return inventoryItemManager.createMissingElectronicItems(compPO, compPOL, piece, ITEM_QUANTITY, requestContext)

--- a/src/main/java/org/folio/service/pieces/PieceUtil.java
+++ b/src/main/java/org/folio/service/pieces/PieceUtil.java
@@ -38,7 +38,7 @@ public class PieceUtil {
         .filter(loc -> isLocationMatch(piece, loc))
         .collect(Collectors.toList());
     }
-    logger.info("findOrderPieceLineLocation:: Found {} locations for pieceId: {} and poLineId: {}",
+    logger.debug("findOrderPieceLineLocation:: Found {} locations for pieceId: {} and poLineId: {}",
       JsonArray.of(result).encodePrettily(), piece.getId(), piece.getPoLineId());
     return result;
   }

--- a/src/main/java/org/folio/service/pieces/PieceUtil.java
+++ b/src/main/java/org/folio/service/pieces/PieceUtil.java
@@ -9,9 +9,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import io.vertx.core.json.JsonArray;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Eresource;
@@ -20,27 +17,20 @@ import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.Piece;
 
 public class PieceUtil {
-  private static final Logger logger = LogManager.getLogger(PieceUtil.class);
-
   public static List<Location> findOrderPieceLineLocation(Piece piece, CompositePoLine compPoLine) {
-    List<Location> result;
     if ((piece.getFormat() == Piece.Format.ELECTRONIC || piece.getFormat() == Piece.Format.PHYSICAL) &&
-                  (CompositePoLine.OrderFormat.P_E_MIX == compPoLine.getOrderFormat())) {
-      result = compPoLine.getLocations().stream()
+      (CompositePoLine.OrderFormat.P_E_MIX == compPoLine.getOrderFormat())) {
+      return compPoLine.getLocations().stream()
         .filter(loc -> isLocationMatch(piece, loc)).collect(Collectors.toList());
     } else if (piece.getFormat() == Piece.Format.ELECTRONIC && CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE == compPoLine.getOrderFormat()) {
-      result = compPoLine.getLocations().stream()
+      return compPoLine.getLocations().stream()
         .filter(loc -> Objects.nonNull(loc.getQuantityElectronic()))
         .filter(loc -> isLocationMatch(piece, loc)).collect(Collectors.toList());
-    } else {
-      result = compPoLine.getLocations().stream()
-        .filter(loc -> Objects.nonNull(loc.getQuantityPhysical()))
-        .filter(loc -> isLocationMatch(piece, loc))
-        .collect(Collectors.toList());
     }
-    logger.debug("findOrderPieceLineLocation:: Found {} locations for pieceId: {} and poLineId: {}",
-      JsonArray.of(result).encodePrettily(), piece.getId(), piece.getPoLineId());
-    return result;
+    return compPoLine.getLocations().stream()
+      .filter(loc -> Objects.nonNull(loc.getQuantityPhysical()))
+      .filter(loc -> isLocationMatch(piece, loc))
+      .collect(Collectors.toList());
   }
 
   public static Map<Piece.Format, Integer> calculatePiecesQuantityWithoutLocation(CompositePoLine compPOL) {

--- a/src/main/java/org/folio/service/pieces/PieceUtil.java
+++ b/src/main/java/org/folio/service/pieces/PieceUtil.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.orders.utils.PoLineCommonUtil;
@@ -39,7 +39,7 @@ public class PieceUtil {
         .collect(Collectors.toList());
     }
     logger.info("findOrderPieceLineLocation:: Found {} locations for pieceId: {} and poLineId: {}",
-      JsonObject.mapFrom(result).encodePrettily(), piece.getId(), piece.getPoLineId());
+      JsonArray.of(result).encodePrettily(), piece.getId(), piece.getPoLineId());
     return result;
   }
 

--- a/src/main/java/org/folio/service/pieces/flows/BasePieceFlowUpdatePoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/BasePieceFlowUpdatePoLineService.java
@@ -6,6 +6,7 @@ import org.folio.models.pieces.BasePieceFlowHolder;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Cost;
+import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.service.finance.transaction.ReceivingEncumbranceStrategy;
 import org.folio.service.orders.PurchaseOrderLineService;
@@ -13,6 +14,8 @@ import org.folio.service.orders.PurchaseOrderStorageService;
 import org.folio.service.pieces.validators.PieceValidatorUtil;
 
 import io.vertx.core.Future;
+
+import java.util.List;
 
 public abstract class BasePieceFlowUpdatePoLineService<T extends BasePieceFlowHolder> implements PoLineUpdateQuantityService<T> {
   protected final PurchaseOrderStorageService purchaseOrderStorageService;
@@ -35,10 +38,12 @@ public abstract class BasePieceFlowUpdatePoLineService<T extends BasePieceFlowHo
           updateEstimatedPrice(holder.getPoLineToSave());
           return null;
         })
-        .compose(v -> purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), requestContext));
+        .compose(v -> purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), getPieceLocations(holder), requestContext));
     }
     return Future.succeededFuture();
   }
+
+  protected abstract List<Location> getPieceLocations(T holder);
 
   protected CompositePoLine updateEstimatedPrice(CompositePoLine compPoLine) {
     Cost cost = compPoLine.getCost();

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowInventoryManager.java
@@ -40,9 +40,9 @@ public class PieceCreateFlowInventoryManager {
       .compose(instanceId -> handleHolding(compPOL, piece, instanceId, locationContext))
       .compose(holdingId -> handleItem(compPO, compPOL, createItem, piece, locationContext))
       .map(itemId -> Optional.ofNullable(itemId).map(piece::withItemId))
-      .onSuccess(optional -> logger.info("processInventory:: successfully processed for piece with itemId: {}, poLineId: {}, receivingTenantId: {}",
+      .onSuccess(optional -> logger.info("processInventory:: successfully created inventory for piece with itemId: {}, poLineId: {}, receivingTenantId: {}",
         piece.getItemId(), piece.getPoLineId(), piece.getReceivingTenantId()))
-      .onFailure(t -> logger.error("Failed to process inventory for piece with itemId: {}, poLineId: {}, receivingTenantId: {}",
+      .onFailure(t -> logger.error("Failed to create inventory for piece with itemId: {}, poLineId: {}, receivingTenantId: {}",
         piece.getItemId(), piece.getPoLineId(), piece.getReceivingTenantId(), t))
       .mapEmpty();
   }

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
@@ -35,7 +35,8 @@ public class PieceCreateFlowManager {
   }
 
   public Future<Piece> createPiece(Piece pieceToCreate, boolean createItem, RequestContext requestContext) {
-    logger.info("manual createPiece start");
+    logger.info("createPiece:: manual createPiece start, poLineId: {}, receivingTenantId: {}",
+      pieceToCreate.getPoLineId(), pieceToCreate.getReceivingTenantId());
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(pieceToCreate).withCreateItem(createItem);
     return basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext)
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineService.java
@@ -24,6 +24,11 @@ public class PieceCreateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
   }
 
   @Override
+  protected List<Location> getPieceLocations(PieceCreationHolder holder) {
+    return PieceUtil.findOrderPieceLineLocation(holder.getPieceToCreate(), holder.getPoLineToSave());
+  }
+
+  @Override
   public boolean poLineUpdateQuantity(PieceCreationHolder holder) {
     CompositePoLine lineToSave = holder.getPoLineToSave();
     Piece piece = holder.getPieceToCreate();

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowPoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowPoLineService.java
@@ -23,6 +23,11 @@ public class PieceDeleteFlowPoLineService extends BasePieceFlowUpdatePoLineServi
   }
 
   @Override
+  protected List<Location> getPieceLocations(PieceDeletionHolder holder) {
+    return PieceUtil.findOrderPieceLineLocation(holder.getPieceToDelete(), holder.getPoLineToSave());
+  }
+
+  @Override
   public boolean poLineUpdateQuantity(PieceDeletionHolder holder) {
     CompositePoLine lineToSave = holder.getPoLineToSave();
     Piece piece = holder.getPieceToDelete();

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineService.java
@@ -36,7 +36,7 @@ public class PieceUpdateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
   public Future<Void> updatePoLine(PieceUpdateHolder holder, RequestContext requestContext) {
     boolean isLineUpdated = updatePoLineWithoutSave(holder);
     if (isLineUpdated) {
-      return purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), requestContext);
+      return purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), getPieceLocations(holder), requestContext);
     } else {
       return Future.succeededFuture();
     }

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineService.java
@@ -43,6 +43,11 @@ public class PieceUpdateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
   }
 
   @Override
+  protected List<Location> getPieceLocations(PieceUpdateHolder holder) {
+    return PieceUtil.findOrderPieceLineLocation(holder.getPieceToUpdate(), holder.getPoLineToSave());
+  }
+
+  @Override
   public boolean poLineUpdateQuantity(PieceUpdateHolder pieceUpdateHolder) {
     CompositePoLine lineToSave = pieceUpdateHolder.getPoLineToSave();
     Piece pieceToUpdate = pieceUpdateHolder.getPieceToUpdate();

--- a/src/test/java/org/folio/service/inventory/InventoryManagerTest.java
+++ b/src/test/java/org/folio/service/inventory/InventoryManagerTest.java
@@ -87,7 +87,6 @@ import org.folio.service.caches.InventoryCache;
 import org.folio.service.configuration.ConfigurationEntriesService;
 import org.folio.service.consortium.ConsortiumConfigurationService;
 import org.folio.service.consortium.SharingInstanceService;
-import org.folio.service.orders.PurchaseOrderStorageService;
 import org.folio.utils.RequestContextMatcher;
 import org.hamcrest.core.IsInstanceOf;
 import org.jetbrains.annotations.NotNull;
@@ -142,8 +141,6 @@ public class InventoryManagerTest {
   private SharingInstanceService sharingInstanceService;
   @Autowired
   private ConsortiumConfigurationService consortiumConfigurationService;
-  @Autowired
-  private PurchaseOrderStorageService purchaseOrderStorageService;
 
 
   private Map<String, String> okapiHeadersMock;
@@ -910,9 +907,6 @@ public class InventoryManagerTest {
     }
 
     @Bean
-    public PurchaseOrderStorageService purchaseOrderStorageService() {return mock(PurchaseOrderStorageService.class);}
-
-    @Bean
     public SharingInstanceService sharingInstanceService() {
       return mock(SharingInstanceService.class);
     }
@@ -926,10 +920,8 @@ public class InventoryManagerTest {
     public InventoryItemManager inventoryItemManager(RestClient restClient,
                                                      ConfigurationEntriesCache configurationEntriesCache,
                                                      InventoryCache inventoryCache,
-                                                     ConsortiumConfigurationService consortiumConfigurationService,
-                                                     PurchaseOrderStorageService purchaseOrderStorageService) {
-      return spy(new InventoryItemManager(restClient, configurationEntriesCache, inventoryCache,
-        consortiumConfigurationService, purchaseOrderStorageService));
+                                                     ConsortiumConfigurationService consortiumConfigurationService) {
+      return spy(new InventoryItemManager(restClient, configurationEntriesCache, inventoryCache, consortiumConfigurationService));
     }
 
     @Bean

--- a/src/test/java/org/folio/service/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
+++ b/src/test/java/org/folio/service/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
@@ -247,10 +247,8 @@ public class OrderLineUpdateInstanceHandlerTest {
     public InventoryItemManager inventoryItemManager(RestClient restClient,
                                                      ConfigurationEntriesCache configurationEntriesCache,
                                                      InventoryCache inventoryCache,
-                                                     ConsortiumConfigurationService consortiumConfigurationService,
-                                                     PurchaseOrderStorageService purchaseOrderStorageService) {
-      return new InventoryItemManager(restClient, configurationEntriesCache, inventoryCache,
-        consortiumConfigurationService, purchaseOrderStorageService);
+                                                     ConsortiumConfigurationService consortiumConfigurationService) {
+      return new InventoryItemManager(restClient, configurationEntriesCache, inventoryCache, consortiumConfigurationService);
     }
 
     @Bean

--- a/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineServiceTest.java
@@ -11,11 +11,12 @@ import static org.folio.TestConfig.isVerticleNotDeployed;
 import static org.folio.rest.jaxrs.model.PurchaseOrder.WorkflowStatus.OPEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -37,6 +38,7 @@ import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.service.finance.transaction.ReceivingEncumbranceStrategy;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
+import org.folio.service.pieces.PieceUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -100,8 +102,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
   @Test
   @DisplayName("Add 1 electronic piece with holding to electronic pol with 1 location and same holding id as in piece")
-  void electAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndHoldingIdInPOLAndPieceTheSame()
-                                        throws ExecutionException, InterruptedException {
+  void electAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndHoldingIdInPOLAndPieceTheSame() {
     String orderId = UUID.randomUUID().toString();
     String holdingId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -122,7 +123,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
                                       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -137,14 +138,14 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
                                         incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(piece, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
 
   @Test
   @DisplayName("Add 1 physical piece with holding to physical pol with 1 location and same holding id as in piece")
-  void physAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndHoldingIdInPOLAndPieceTheSame()
-                throws ExecutionException, InterruptedException {
+  void physAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndHoldingIdInPOLAndPieceTheSame() {
     String orderId = UUID.randomUUID().toString();
     String holdingId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -165,7 +166,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
 
@@ -179,7 +180,8 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(piece, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   private static Stream<Arguments> shouldSetReceivingTenantIdFromPieceArgs() {
@@ -231,8 +233,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
   @Test
   @DisplayName("Add 1 physical piece with location to physical pol with 1 location and same location id as in piece")
-  void physAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndLocationIdInPOLAndPieceTheSame()
-                      throws ExecutionException, InterruptedException {
+  void physAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndLocationIdInPOLAndPieceTheSame() {
     String orderId = UUID.randomUUID().toString();
     String locationId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -253,7 +254,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
     //Then
@@ -266,13 +267,13 @@ public class PieceCreateFlowPoLineServiceTest {
     assertEquals(2, poLineToSave.getLocations().get(0).getQuantity());
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(piece, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @Test
   @DisplayName("Add 1 electronic piece with location to electronic pol with 1 location and same location id as in piece")
-  void elecAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndLocationIdInPOLAndPieceTheSame()
-                throws ExecutionException, InterruptedException {
+  void elecAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndLocationIdInPOLAndPieceTheSame() {
     String orderId = UUID.randomUUID().toString();
     String locationId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -293,7 +294,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -307,13 +308,13 @@ public class PieceCreateFlowPoLineServiceTest {
     assertEquals(2, poLineToSave.getLocations().get(0).getQuantity());
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(piece, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @Test
   @DisplayName("Add 1 electronic piece with location to electronic pol with 1 location with holding id")
-  void elecAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndLocationIdInPieceAndPOLWithHoldingId()
-                        throws ExecutionException, InterruptedException {
+  void elecAddStrategyShouldIncreaseQuantityTo2ForCostAndLocationIfInitiallyWas1AndLocationIdInPieceAndPOLWithHoldingId() {
     String orderId = UUID.randomUUID().toString();
     String locationId = UUID.randomUUID().toString();
     String holdingId = UUID.randomUUID().toString();
@@ -323,8 +324,6 @@ public class PieceCreateFlowPoLineServiceTest {
     Cost cost = new Cost().withQuantityElectronic(1)
       .withListUnitPrice(1d).withExchangeRate(1d).withCurrency("USD")
       .withPoLineEstimatedPrice(1d);
-    List<Location> locations = new ArrayList<>();
-    locations.add(loc);
     PurchaseOrder purchaseOrder = new PurchaseOrder().withId(orderId).withWorkflowStatus(OPEN);
     Eresource eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE);
     PoLine originPoLine = new PoLine().withIsPackage(false).withPurchaseOrderId(orderId)
@@ -337,7 +336,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -353,13 +352,13 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
                                         incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(piece, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @Test
   @DisplayName("Add 1 electronic piece with holding id to mixed pol with 1 location with holding id and electronic and physical qty")
-  void shouldIncreaseQuantityTo3ForCostAndLocationIfInitiallyWas2AndHoldingIdInPieceAndMixedPOLWithHoldingId()
-    throws ExecutionException, InterruptedException {
+  void shouldIncreaseQuantityTo3ForCostAndLocationIfInitiallyWas2AndHoldingIdInPieceAndMixedPOLWithHoldingId() {
     String orderId = UUID.randomUUID().toString();
     String holdingId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -382,7 +381,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -398,13 +397,13 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(pieceToCreate, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @Test
   @DisplayName("Add 1 electronic piece with location id to mixed pol with 1 location with location id and electronic and physical qty")
-  void shouldIncreaseQuantityTo3ForCostAndLocationIfInitiallyWas2AndLocationIdInPieceAndMixedPOLWithLocationId()
-    throws ExecutionException, InterruptedException {
+  void shouldIncreaseQuantityTo3ForCostAndLocationIfInitiallyWas2AndLocationIdInPieceAndMixedPOLWithLocationId() {
     String orderId = UUID.randomUUID().toString();
     String locationId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -427,7 +426,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -443,13 +442,13 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(pieceToCreate, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @Test
   @DisplayName("Add 1 electronic piece without location id to mixed pol with 1 location with location id and physical qty and create inventory NONE")
-  void shouldNotUpdateLocationIfCreateInventoryNoneForElectronicButUpdateCostQty()
-    throws ExecutionException, InterruptedException {
+  void shouldNotUpdateLocationIfCreateInventoryNoneForElectronicButUpdateCostQty() {
     String orderId = UUID.randomUUID().toString();
     String locationId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -472,7 +471,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -488,13 +487,13 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(pieceToCreate, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @Test
   @DisplayName("Add 1 physical piece without location id to mixed pol with 1 location with location id and physical qty and create inventory NONE")
-  void shouldNotUpdateLocationIfCreateInventoryNoneForPhysicalButUpdateCostQty()
-    throws ExecutionException, InterruptedException {
+  void shouldNotUpdateLocationIfCreateInventoryNoneForPhysicalButUpdateCostQty() {
     String orderId = UUID.randomUUID().toString();
     String locationId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
@@ -517,7 +516,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -533,13 +532,13 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(pieceToCreate, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @Test
   @DisplayName("Add 1 physical piece without location id to physical pol without location and physical qty and create inventory NONE")
-  void shouldNotUpdateLocationIfCreateInventoryNoneForPhysicalAndNoLocationInTheLineButUpdateCostQty()
-    throws ExecutionException, InterruptedException {
+  void shouldNotUpdateLocationIfCreateInventoryNoneForPhysicalAndNoLocationInTheLineButUpdateCostQty() {
     String orderId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
     Piece pieceToCreate = new Piece().withPoLineId(lineId).withFormat(Piece.Format.PHYSICAL);
@@ -560,7 +559,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -573,7 +572,8 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(pieceToCreate, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @ParameterizedTest
@@ -581,8 +581,7 @@ public class PieceCreateFlowPoLineServiceTest {
   @CsvSource(value = {"Electronic Resource:Instance:2:3:Electronic:6:6.0",
                       "Electronic Resource:None:2:3:Electronic:6:6.0"}, delimiter = ':')
   void electAddStrategyShouldIncreaseQuantityTo3ForCostAndLocationIfInitiallyWas2AndLocationIdInPOLAndPieceTheSameInventoryNone(
-          String lineType, String createInventory, int qty1, int qty2, String pieceFormat, int expQty, double expEstimatedPrice)
-          throws ExecutionException, InterruptedException {
+          String lineType, String createInventory, int qty1, int qty2, String pieceFormat, int expQty, double expEstimatedPrice) {
     String orderId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
     String locationId1 = UUID.randomUUID().toString();
@@ -605,7 +604,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -631,7 +630,8 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(piece, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   @ParameterizedTest
@@ -641,8 +641,7 @@ public class PieceCreateFlowPoLineServiceTest {
                       "Other:None:2:4:Other:7:7.0",
                       "Other:None:2:4:Other:7:7.0"}, delimiter = ':')
   void physOrNonetAddStrategyShouldIncreaseQuantityTo3ForCostAndLocationIfInitiallyWas2AndLocationIdInPOLAndPieceTheSameInventoryNone(
-    String lineType, String createInventory, int qty1, int qty2, String pieceFormat, int expQty, double expEstimatedPrice)
-    throws ExecutionException, InterruptedException {
+    String lineType, String createInventory, int qty1, int qty2, String pieceFormat, int expQty, double expEstimatedPrice) {
     String orderId = UUID.randomUUID().toString();
     String lineId = UUID.randomUUID().toString();
     String locationId1 = UUID.randomUUID().toString();
@@ -665,7 +664,7 @@ public class PieceCreateFlowPoLineServiceTest {
 
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
     pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
@@ -691,7 +690,8 @@ public class PieceCreateFlowPoLineServiceTest {
 
     verify(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
-    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), requestContext);
+    List<Location> locations = PieceUtil.findOrderPieceLineLocation(piece, poLineToSave);
+    verify(purchaseOrderLineService).saveOrderLine(incomingUpdateHolder.getPoLineToSave(), locations, requestContext);
   }
 
   private static class ContextConfiguration {

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
@@ -54,6 +54,7 @@ import org.folio.service.caches.InventoryCache;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.pieces.PieceService;
 import org.folio.service.pieces.PieceStorageService;
+import org.folio.service.pieces.PieceUtil;
 import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
 import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
 import org.junit.jupiter.api.AfterAll;
@@ -175,7 +176,9 @@ public class PieceUpdateFlowManagerTest {
     doNothing().when(pieceService).receiptConsistencyPiecePoLine(any(JsonObject.class), eq(requestContext));
     doReturn(succeededFuture(null)).when(pieceUpdateFlowPoLineService).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
     doReturn(succeededFuture(null))
-      .when(purchaseOrderLineService).saveOrderLine(any(CompositePoLine.class), eq(requestContext));
+      .when(purchaseOrderLineService).saveOrderLine(any(CompositePoLine.class),
+        eq(PieceUtil.findOrderPieceLineLocation(pieceToUpdate, PoLineCommonUtil.convertToCompositePoLine(poLine))),
+        eq(requestContext));
 
     //When
     pieceUpdateFlowManager.updatePiece(pieceToUpdate, true, true, requestContext).result();


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDERS-1177

## Approach
Update only those locations that is related to the piece, but not all locations. It allows to reduce lot of http calls to fetch holdings for other not modified locations. Also it allowed to fix root cause of the issue because call to tenant where user does not have an affiliation is not made 