### PR TITLE
[MODORDERS-1174] Filter pieces based on user affiliations

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -489,7 +489,9 @@
           "pathPattern": "/orders/pieces",
           "permissionsRequired": ["orders.pieces.collection.get"],
           "modulePermissions": [
-            "orders-storage.pieces.collection.get"
+            "orders-storage.pieces.collection.get",
+            "consortia.user-tenants.collection.get",
+            "user-tenants.collection.get"
           ]
         },
         {

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -31,6 +31,7 @@ import org.folio.service.caches.ConfigurationEntriesCache;
 import org.folio.service.caches.InventoryCache;
 import org.folio.service.configuration.ConfigurationEntriesService;
 import org.folio.service.consortium.ConsortiumConfigurationService;
+import org.folio.service.consortium.ConsortiumUserTenantsRetriever;
 import org.folio.service.consortium.SharingInstanceService;
 import org.folio.service.exchange.ExchangeRateProviderResolver;
 import org.folio.service.exchange.FinanceExchangeRateService;
@@ -521,8 +522,10 @@ public class ApplicationConfig {
   }
 
   @Bean
-  PieceStorageService pieceStorageService(RestClient restClient) {
-    return new PieceStorageService(restClient);
+  PieceStorageService pieceStorageService(ConsortiumConfigurationService consortiumConfigurationService,
+                                          ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever,
+                                          RestClient restClient) {
+    return new PieceStorageService(consortiumConfigurationService, consortiumUserTenantsRetriever, restClient);
   }
 
   @Bean
@@ -846,6 +849,11 @@ public class ApplicationConfig {
   @Bean
   ConsortiumConfigurationService consortiumConfigurationService(RestClient restClient) {
     return new ConsortiumConfigurationService(restClient);
+  }
+
+  @Bean
+  ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever(RestClient restClient) {
+    return new ConsortiumUserTenantsRetriever(restClient);
   }
 
   @Bean

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -93,7 +93,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
 
   private Future<Void> clearTitleBindItemsIfNeeded(String titleId, String bindItemId, RequestContext requestContext) {
     String query = String.format("titleId==%s and bindItemId==%s and isBound==true", titleId, bindItemId);
-    return pieceStorageService.getAllPieces(query, requestContext)
+    return pieceStorageService.getAllPieces(0, 0, query, requestContext)
       .compose(pieceCollection -> {
         var totalRecords = pieceCollection.getTotalRecords();
         if (totalRecords != 0) {

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -93,7 +93,7 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
 
   private Future<Void> clearTitleBindItemsIfNeeded(String titleId, String bindItemId, RequestContext requestContext) {
     String query = String.format("titleId==%s and bindItemId==%s and isBound==true", titleId, bindItemId);
-    return pieceStorageService.getPieces(0, 0, query, requestContext)
+    return pieceStorageService.getAllPieces(query, requestContext)
       .compose(pieceCollection -> {
         var totalRecords = pieceCollection.getTotalRecords();
         if (totalRecords != 0) {

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -377,7 +377,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
 
   private Future<List<Piece>> getPiecesByPoLine(String poLineId, RequestContext requestContext) {
     String query = String.format("poLineId==%s", poLineId);
-    return pieceStorageService.getPieces(Integer.MAX_VALUE, 0, query, requestContext)
+    return pieceStorageService.getAllPieces(query, requestContext)
       .map(PieceCollection::getPieces);
   }
 

--- a/src/main/java/org/folio/orders/utils/RequestContextUtil.java
+++ b/src/main/java/org/folio/orders/utils/RequestContextUtil.java
@@ -22,4 +22,8 @@ public class RequestContextUtil {
     return new RequestContext(requestContext.getContext(), modifiedHeaders);
   }
 
+  public static String getUserIdFromContext(RequestContext requestContext) {
+    return requestContext.getHeaders().get(XOkapiHeaders.USER_ID);
+  }
+
 }

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -53,6 +53,8 @@ public class ResourcePathResolver {
   public static final String ROUTING_LISTS = "routingLists";
   public static final String ORDER_SETTINGS = "orderSettings";
   public static final String USERS = "users";
+  public static final String CONSORTIA_USER_TENANTS = "consortia.user-tenants";
+
 
   private static final Map<String, String> SUB_OBJECT_ITEM_APIS;
   private static final Map<String, String> SUB_OBJECT_COLLECTION_APIS;
@@ -96,6 +98,7 @@ public class ResourcePathResolver {
     apis.put(EXPORT_HISTORY, "/orders-storage/export-history");
     apis.put(TAGS, "/tags");
     apis.put(USERS, "/users");
+    apis.put(CONSORTIA_USER_TENANTS, "/consortia/:id/user-tenants");
     apis.put(ORDER_SETTINGS, "/orders-storage/settings");
     apis.put(ROUTING_LISTS, "/orders-storage/routing-lists");
 

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.folio.rest.RestConstants.PATH_PARAM_PLACE_HOLDER;
+
 public class ResourcePathResolver {
 
   private ResourcePathResolver() {
@@ -98,7 +100,7 @@ public class ResourcePathResolver {
     apis.put(EXPORT_HISTORY, "/orders-storage/export-history");
     apis.put(TAGS, "/tags");
     apis.put(USERS, "/users");
-    apis.put(CONSORTIA_USER_TENANTS, "/consortia/:id/user-tenants");
+    apis.put(CONSORTIA_USER_TENANTS, "/consortia/" + PATH_PARAM_PLACE_HOLDER + "/user-tenants");
     apis.put(ORDER_SETTINGS, "/orders-storage/settings");
     apis.put(ROUTING_LISTS, "/orders-storage/routing-lists");
 

--- a/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
+++ b/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
@@ -1,0 +1,48 @@
+package org.folio.service.consortium;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.folio.orders.utils.RequestContextUtil.getUserIdFromContext;
+import static org.folio.orders.utils.ResourcePathResolver.CONSORTIA_USER_TENANTS;
+import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+import static org.folio.service.pieces.util.UserTenantFields.COLLECTION_USER_TENANTS;
+import static org.folio.service.pieces.util.UserTenantFields.TENANT_ID;
+import static org.folio.service.pieces.util.UserTenantFields.USER_ID;
+
+public class ConsortiumUserTenantsRetriever {
+
+  private static final String CONSORTIA_USER_TENANTS_ENDPOINT = resourcesPath(CONSORTIA_USER_TENANTS);
+
+  private final RestClient restClient;
+
+  public ConsortiumUserTenantsRetriever(RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  public Future<List<String>> getUserTenants(String consortiumId, RequestContext requestContext) {
+    var userId = getUserIdFromContext(requestContext);
+    var requestEntry = new RequestEntry(CONSORTIA_USER_TENANTS_ENDPOINT)
+      .withOffset(0)
+      .withLimit(Integer.MAX_VALUE)
+      .withId(consortiumId)
+      .withQueryParameter(USER_ID.getValue(), userId);
+    return restClient.getAsJsonObject(requestEntry, requestContext)
+      .map(this::extractTenantIds);
+  }
+
+  private List<String> extractTenantIds(JsonObject userTenantCollection) {
+    var userTenants = userTenantCollection.getJsonArray(COLLECTION_USER_TENANTS.getValue());
+    return IntStream.range(0, userTenants.size())
+      .mapToObj(userTenants::getJsonObject)
+      .map(userTenant -> userTenant.getString(TENANT_ID.getValue()))
+      .toList();
+  }
+
+}

--- a/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
+++ b/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
@@ -12,6 +12,7 @@ import java.util.stream.IntStream;
 import static org.folio.orders.utils.RequestContextUtil.getUserIdFromContext;
 import static org.folio.orders.utils.ResourcePathResolver.CONSORTIA_USER_TENANTS;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+import static org.folio.rest.RestConstants.PATH_PARAM_PLACE_HOLDER;
 import static org.folio.service.pieces.util.UserTenantFields.COLLECTION_USER_TENANTS;
 import static org.folio.service.pieces.util.UserTenantFields.TENANT_ID;
 import static org.folio.service.pieces.util.UserTenantFields.USER_ID;
@@ -28,10 +29,10 @@ public class ConsortiumUserTenantsRetriever {
 
   public Future<List<String>> getUserTenants(String consortiumId, RequestContext requestContext) {
     var userId = getUserIdFromContext(requestContext);
-    var requestEntry = new RequestEntry(CONSORTIA_USER_TENANTS_ENDPOINT)
+    var url = CONSORTIA_USER_TENANTS_ENDPOINT.replace(PATH_PARAM_PLACE_HOLDER, consortiumId);
+    var requestEntry = new RequestEntry(url)
       .withOffset(0)
       .withLimit(Integer.MAX_VALUE)
-      .withId(consortiumId)
       .withQueryParameter(USER_ID.getValue(), userId);
     return restClient.getAsJsonObject(requestEntry, requestContext)
       .map(this::extractTenantIds);

--- a/src/main/java/org/folio/service/orders/HoldingsSummaryService.java
+++ b/src/main/java/org/folio/service/orders/HoldingsSummaryService.java
@@ -37,7 +37,7 @@ public class HoldingsSummaryService {
     var queryForPiece = String.format("?query=holdingId==%s", holdingId);
     var queryForLines = String.format("?query=locations=\"holdingId\" : \"%s\"", holdingId);
 
-    return pieceStorageService.getPieces(Integer.MAX_VALUE, 0, queryForPiece, requestContext)
+    return pieceStorageService.getAllPieces(queryForPiece, requestContext)
       .map(piecesCollection -> {
         Set<String> lineIds = piecesCollection.getPieces().stream()
           .map(Piece::getPoLineId)

--- a/src/main/java/org/folio/service/pieces/PieceStorageService.java
+++ b/src/main/java/org/folio/service/pieces/PieceStorageService.java
@@ -118,16 +118,19 @@ public class PieceStorageService {
     return Future.succeededFuture(Collections.emptyList());
   }
 
-  public Future<PieceCollection> getAllPieces(String query, RequestContext requestContext) {
-    var requestEntry = new RequestEntry(PIECE_STORAGE_ENDPOINT).withQuery(query).withOffset(0).withLimit(Integer.MAX_VALUE);
-    return restClient.get(requestEntry, PieceCollection.class, requestContext);
-  }
-
   public Future<PieceCollection> getPieces(int limit, int offset, String query, RequestContext requestContext) {
-    var requestEntry = new RequestEntry(PIECE_STORAGE_ENDPOINT).withQuery(query).withOffset(offset).withLimit(limit);
-    return restClient.get(requestEntry, PieceCollection.class, requestContext)
+    return getAllPieces(limit, offset, query, requestContext)
       .compose(piecesCollection -> filterPiecesByUserTenantsIfNecessary(piecesCollection.getPieces(), requestContext)
         .map(piecesCollection::withPieces));
+  }
+
+  public Future<PieceCollection> getAllPieces(String query, RequestContext requestContext) {
+    return getAllPieces(Integer.MAX_VALUE, 0, query, requestContext);
+  }
+
+  public Future<PieceCollection> getAllPieces(int limit, int offset, String query, RequestContext requestContext) {
+    var requestEntry = new RequestEntry(PIECE_STORAGE_ENDPOINT).withQuery(query).withOffset(offset).withLimit(limit);
+    return restClient.get(requestEntry, PieceCollection.class, requestContext);
   }
 
   private Future<List<Piece>> filterPiecesByUserTenantsIfNecessary(List<Piece> pieces, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/pieces/util/UserTenantFields.java
+++ b/src/main/java/org/folio/service/pieces/util/UserTenantFields.java
@@ -1,0 +1,19 @@
+package org.folio.service.pieces.util;
+
+public enum UserTenantFields {
+
+  USER_ID("userId"),
+  TENANT_ID("tenantId"),
+  COLLECTION_USER_TENANTS("userTenants");
+
+  private final String value;
+
+  UserTenantFields(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/src/test/java/org/folio/service/CirculationRequestsRetrieverTest.java
+++ b/src/test/java/org/folio/service/CirculationRequestsRetrieverTest.java
@@ -11,6 +11,8 @@ import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.jaxrs.model.PieceCollection;
+import org.folio.service.consortium.ConsortiumConfigurationService;
+import org.folio.service.consortium.ConsortiumUserTenantsRetriever;
 import org.folio.service.pieces.PieceStorageService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -235,13 +237,25 @@ public class CirculationRequestsRetrieverTest {
     }
 
     @Bean
-    public PieceStorageService pieceStorageService(RestClient restClient) {
-      return spy(new PieceStorageService(restClient));
+    public PieceStorageService pieceStorageService(ConsortiumConfigurationService consortiumConfigurationService,
+                                                   ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever,
+                                                   RestClient restClient) {
+      return spy(new PieceStorageService(consortiumConfigurationService, consortiumUserTenantsRetriever, restClient));
     }
 
     @Bean
     public CirculationRequestsRetriever circulationRequestsRetriever(PieceStorageService pieceStorageService, RestClient restClient) {
       return new CirculationRequestsRetriever(pieceStorageService, restClient);
+    }
+
+    @Bean
+    ConsortiumConfigurationService consortiumConfigurationService(RestClient restClient) {
+      return new ConsortiumConfigurationService(restClient);
+    }
+
+    @Bean
+    ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever(RestClient restClient) {
+      return new ConsortiumUserTenantsRetriever(restClient);
     }
 
   }

--- a/src/test/java/org/folio/service/inventory/HoldingsSummaryServiceTest.java
+++ b/src/test/java/org/folio/service/inventory/HoldingsSummaryServiceTest.java
@@ -69,7 +69,7 @@ public class HoldingsSummaryServiceTest {
     when(purchaseOrderLineService.getOrderLines(anyString(), anyInt(), anyInt(), any()))
       .thenReturn(Future.succeededFuture(polines));
 
-    when(pieceStorageService.getPieces(anyInt(), anyInt(), anyString(), any()))
+    when(pieceStorageService.getAllPieces(anyString(), any()))
       .thenReturn(Future.succeededFuture(pieces));
 
     var hs = holdingsSummaryService.getHoldingsSummary(UUID.randomUUID().toString(), requestContext)

--- a/src/test/java/org/folio/service/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
+++ b/src/test/java/org/folio/service/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
@@ -39,6 +39,7 @@ import org.folio.service.caches.ConfigurationEntriesCache;
 import org.folio.service.caches.InventoryCache;
 import org.folio.service.configuration.ConfigurationEntriesService;
 import org.folio.service.consortium.ConsortiumConfigurationService;
+import org.folio.service.consortium.ConsortiumUserTenantsRetriever;
 import org.folio.service.consortium.SharingInstanceService;
 import org.folio.service.inventory.InventoryHoldingManager;
 import org.folio.service.inventory.InventoryItemManager;
@@ -221,17 +222,28 @@ public class OrderLineUpdateInstanceHandlerTest {
       return new ProtectionService(acquisitionsUnitsService);
     }
 
-    @Bean PieceStorageService pieceStorageService(RestClient restClient) {
-      return new PieceStorageService(restClient);
+    @Bean PieceStorageService pieceStorageService(ConsortiumConfigurationService consortiumConfigurationService,
+                                                  ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever,
+                                                  RestClient restClient) {
+      return new PieceStorageService(consortiumConfigurationService, consortiumUserTenantsRetriever, restClient);
     }
+
     @Bean InventoryService inventoryService (RestClient restClient) {
       return new InventoryService(restClient);
     }
+
     @Bean SharingInstanceService sharingInstanceService (RestClient restClient) {
       return new SharingInstanceService(restClient);
     }
-    @Bean ConsortiumConfigurationService consortiumConfigurationService (RestClient restClient) {
+
+    @Bean
+    ConsortiumConfigurationService consortiumConfigurationService(RestClient restClient) {
       return new ConsortiumConfigurationService(restClient);
+    }
+
+    @Bean
+    ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever(RestClient restClient) {
+      return new ConsortiumUserTenantsRetriever(restClient);
     }
 
     @Bean PurchaseOrderStorageService purchaseOrderStorageService () {

--- a/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
@@ -32,6 +32,8 @@ import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PieceCollection;
 import org.folio.service.ProtectionService;
+import org.folio.service.consortium.ConsortiumConfigurationService;
+import org.folio.service.consortium.ConsortiumUserTenantsRetriever;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -136,8 +138,21 @@ public class PieceStorageServiceTest {
       return mock(ProtectionService.class);
     }
 
-    @Bean PieceStorageService pieceStorageService(RestClient restClient, ProtectionService protectionService) {
-      return spy(new PieceStorageService(restClient));
+    @Bean PieceStorageService pieceStorageService(ConsortiumConfigurationService consortiumConfigurationService,
+                                                  ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever,
+                                                  RestClient restClient) {
+      return spy(new PieceStorageService(consortiumConfigurationService, consortiumUserTenantsRetriever, restClient));
     }
+
+    @Bean
+    ConsortiumConfigurationService consortiumConfigurationService(RestClient restClient) {
+      return new ConsortiumConfigurationService(restClient);
+    }
+
+    @Bean
+    ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever(RestClient restClient) {
+      return new ConsortiumUserTenantsRetriever(restClient);
+    }
+
   }
 }

--- a/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
@@ -1,6 +1,7 @@
 package org.folio.service.pieces;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.TestConfig.autowireDependencies;
 import static org.folio.TestConfig.clearServiceInteractions;
 import static org.folio.TestConfig.clearVertxContext;
@@ -8,6 +9,8 @@ import static org.folio.TestConfig.getFirstContextFromVertx;
 import static org.folio.TestConfig.getVertx;
 import static org.folio.TestConfig.initSpringContext;
 import static org.folio.TestConfig.isVerticleNotDeployed;
+import static org.folio.TestUtils.getMockAsJson;
+import static org.folio.rest.impl.MockServer.BASE_MOCK_DATA_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,11 +24,13 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.ApiTestSuite;
+import org.folio.models.consortium.ConsortiumConfiguration;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
@@ -54,8 +59,20 @@ import io.vertx.junit5.VertxTestContext;
 @ExtendWith(VertxExtension.class)
 public class PieceStorageServiceTest {
 
+  private static final String USER_TENANTS_PATH = BASE_MOCK_DATA_PATH + "userTenants/";
+  private static final String USER_TENANTS_MOCK = "userTenants";
+
+  private static final String PIECES_PATH = BASE_MOCK_DATA_PATH + "pieces/";
+  private static final String PIECES_MOCK = "pieces-for-user-tenants";
+
   @Autowired
   PieceStorageService pieceStorageService;
+
+  @Autowired
+  ConsortiumConfigurationService consortiumConfigurationService;
+
+  @Autowired
+  ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever;
 
   @Autowired
   private RestClient restClientMock;
@@ -106,6 +123,7 @@ public class PieceStorageServiceTest {
       .withTotalRecords(1);
 
     when(restClientMock.get(any(RequestEntry.class), any(), any())).thenReturn(Future.succeededFuture(pieceCollection));
+    when(consortiumConfigurationService.getConsortiumConfiguration(any(RequestContext.class))).thenReturn(Future.succeededFuture(Optional.empty()));
 
     String expectedQuery = String.format("id==%s", pieceId);
     var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, expectedQuery, requestContext);
@@ -128,17 +146,69 @@ public class PieceStorageServiceTest {
     verify(pieceStorageService, times(1)).deletePiece(any(String.class), eq(requestContext));
   }
 
+  @Test
+  void testGetPiecesFilterByUserTenants(VertxTestContext vertxTestContext) {
+    var userTenantsMockData = getMockAsJson(USER_TENANTS_PATH, USER_TENANTS_MOCK);
+    var piecesMockData = getMockAsJson(PIECES_PATH, PIECES_MOCK).mapTo(PieceCollection.class);
+    var consortiumConfiguration = Optional.of(new ConsortiumConfiguration("tenantId0", UUID.randomUUID().toString()));
+
+    doReturn(Future.succeededFuture(consortiumConfiguration)).when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
+    doReturn(Future.succeededFuture(piecesMockData)).when(restClientMock).get(any(RequestEntry.class), eq(PieceCollection.class), any(RequestContext.class));
+    doReturn(Future.succeededFuture(userTenantsMockData)).when(restClientMock).getAsJsonObject(any(), any(RequestContext.class));
+
+    var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, null, requestContext);
+
+    verify(restClientMock, times(1)).get(any(RequestEntry.class), eq(PieceCollection.class), eq(requestContext));
+    verify(restClientMock, times(1)).getAsJsonObject(any(), any(RequestContext.class));
+    verify(consortiumConfigurationService, times(1)).getConsortiumConfiguration(eq(requestContext));
+
+    vertxTestContext.assertComplete(future)
+      .onComplete(f -> {
+        var result = f.result();
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalRecords()).isEqualTo(2);
+        assertThat(result.getPieces()).hasSize(2);
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void testGetPiecesFilterByUserTenantsNonECS(VertxTestContext vertxTestContext) {
+    var piecesMockData = getMockAsJson(PIECES_PATH, PIECES_MOCK).mapTo(PieceCollection.class);
+
+    doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
+    doReturn(Future.succeededFuture(piecesMockData)).when(restClientMock).get(any(RequestEntry.class), eq(PieceCollection.class), any(RequestContext.class));
+
+    var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, null, requestContext);
+
+    verify(restClientMock, times(1)).get(any(RequestEntry.class), eq(PieceCollection.class), eq(requestContext));
+    verify(restClientMock, times(0)).getAsJsonObject(any(), any(RequestContext.class));
+    verify(consortiumConfigurationService, times(1)).getConsortiumConfiguration(eq(requestContext));
+
+    vertxTestContext.assertComplete(future)
+      .onComplete(f -> {
+        var result = f.result();
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalRecords()).isEqualTo(3);
+        assertThat(result.getPieces()).hasSize(3);
+        vertxTestContext.completeNow();
+      });
+  }
+
   private static class ContextConfiguration {
 
-    @Bean RestClient restClient() {
+    @Bean
+    RestClient restClient() {
       return mock(RestClient.class);
     }
 
-    @Bean ProtectionService protectionService() {
+    @Bean
+    ProtectionService protectionService() {
       return mock(ProtectionService.class);
     }
 
-    @Bean PieceStorageService pieceStorageService(ConsortiumConfigurationService consortiumConfigurationService,
+    @Bean
+    PieceStorageService pieceStorageService(ConsortiumConfigurationService consortiumConfigurationService,
                                                   ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever,
                                                   RestClient restClient) {
       return spy(new PieceStorageService(consortiumConfigurationService, consortiumUserTenantsRetriever, restClient));
@@ -146,13 +216,14 @@ public class PieceStorageServiceTest {
 
     @Bean
     ConsortiumConfigurationService consortiumConfigurationService(RestClient restClient) {
-      return new ConsortiumConfigurationService(restClient);
+      return spy(new ConsortiumConfigurationService(restClient));
     }
 
     @Bean
     ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever(RestClient restClient) {
-      return new ConsortiumUserTenantsRetriever(restClient);
+      return spy(new ConsortiumUserTenantsRetriever(restClient));
     }
 
   }
+
 }

--- a/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
@@ -156,7 +156,7 @@ public class PieceStorageServiceTest {
     doReturn(Future.succeededFuture(piecesMockData)).when(restClientMock).get(any(RequestEntry.class), eq(PieceCollection.class), any(RequestContext.class));
     doReturn(Future.succeededFuture(userTenantsMockData)).when(restClientMock).getAsJsonObject(any(), any(RequestContext.class));
 
-    var future = pieceStorageService.getAllPieces(null, requestContext);
+    var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, null, requestContext);
 
     verify(restClientMock, times(1)).get(any(RequestEntry.class), eq(PieceCollection.class), eq(requestContext));
     verify(restClientMock, times(1)).getAsJsonObject(any(), any(RequestContext.class));
@@ -166,7 +166,7 @@ public class PieceStorageServiceTest {
       .onComplete(f -> {
         var result = f.result();
         assertThat(result).isNotNull();
-        assertThat(result.getTotalRecords()).isEqualTo(2);
+        assertThat(result.getTotalRecords()).isEqualTo(3);
         assertThat(result.getPieces()).hasSize(2);
         vertxTestContext.completeNow();
       });
@@ -179,7 +179,7 @@ public class PieceStorageServiceTest {
     doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
     doReturn(Future.succeededFuture(piecesMockData)).when(restClientMock).get(any(RequestEntry.class), eq(PieceCollection.class), any(RequestContext.class));
 
-    var future = pieceStorageService.getAllPieces(null, requestContext);
+    var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, null, requestContext);
 
     verify(restClientMock, times(1)).get(any(RequestEntry.class), eq(PieceCollection.class), eq(requestContext));
     verify(restClientMock, times(0)).getAsJsonObject(any(), any(RequestContext.class));

--- a/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
@@ -126,7 +126,7 @@ public class PieceStorageServiceTest {
     when(consortiumConfigurationService.getConsortiumConfiguration(any(RequestContext.class))).thenReturn(Future.succeededFuture(Optional.empty()));
 
     String expectedQuery = String.format("id==%s", pieceId);
-    var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, expectedQuery, requestContext);
+    var future = pieceStorageService.getAllPieces(expectedQuery, requestContext);
 
     verify(restClientMock).get(any(RequestEntry.class), eq(PieceCollection.class), eq(requestContext));
     vertxTestContext.assertComplete(future)
@@ -156,7 +156,7 @@ public class PieceStorageServiceTest {
     doReturn(Future.succeededFuture(piecesMockData)).when(restClientMock).get(any(RequestEntry.class), eq(PieceCollection.class), any(RequestContext.class));
     doReturn(Future.succeededFuture(userTenantsMockData)).when(restClientMock).getAsJsonObject(any(), any(RequestContext.class));
 
-    var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, null, requestContext);
+    var future = pieceStorageService.getAllPieces(null, requestContext);
 
     verify(restClientMock, times(1)).get(any(RequestEntry.class), eq(PieceCollection.class), eq(requestContext));
     verify(restClientMock, times(1)).getAsJsonObject(any(), any(RequestContext.class));
@@ -179,7 +179,7 @@ public class PieceStorageServiceTest {
     doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
     doReturn(Future.succeededFuture(piecesMockData)).when(restClientMock).get(any(RequestEntry.class), eq(PieceCollection.class), any(RequestContext.class));
 
-    var future = pieceStorageService.getPieces(Integer.MAX_VALUE, 0, null, requestContext);
+    var future = pieceStorageService.getAllPieces(null, requestContext);
 
     verify(restClientMock, times(1)).get(any(RequestEntry.class), eq(PieceCollection.class), eq(requestContext));
     verify(restClientMock, times(0)).getAsJsonObject(any(), any(RequestContext.class));

--- a/src/test/resources/mockdata/pieces/pieces-for-user-tenants.json
+++ b/src/test/resources/mockdata/pieces/pieces-for-user-tenants.json
@@ -1,0 +1,16 @@
+{
+  "pieces": [
+    {
+      "id": "05a95f03-eb00-4248-9f2e-2bd05957ff04",
+      "receivingTenantId": "tenantId1"
+    },
+    {
+      "id": "05a95f03-eb00-4248-9f2e-2bd05957ff05",
+      "receivingTenantId": "tenantId2"
+    },
+    {
+      "id": "05a95f03-eb00-4248-9f2e-2bd05957ff06"
+    }
+  ],
+  "totalRecords": 3
+}

--- a/src/test/resources/mockdata/userTenants/userTenants.json
+++ b/src/test/resources/mockdata/userTenants/userTenants.json
@@ -1,0 +1,13 @@
+{
+  "userTenants": [
+    {
+      "id": "05c34b3d-33fa-46fc-8906-4ade19a570fd",
+      "userId": "440c89e3-7f6c-578a-9ea8-310dad23605e",
+      "username": "testUser",
+      "tenantId": "tenantId1",
+      "tenantName": "Tenant1",
+      "isPrimary": true
+    }
+  ],
+  "totalRecords": 1
+}


### PR DESCRIPTION
## Purpose
[[MODORDERS-1174] Filter pieces based on user affiliations](https://folio-org.atlassian.net/browse/MODORDERS-1174)

## Approach
- Fetch user tenants in case of ECS mode
- Filter pieces with user tenants if needed
- Update tests

## Screenshots
#### Orders Karate Tests
![image](https://github.com/user-attachments/assets/3e07d063-fd93-40dd-aa43-4ee641882650)
