### PR TITLE
[MODORDERS-1195] - Closed purchase order line associated with a deleted piece record cannot be saved

### DIFF
--- a/src/main/java/org/folio/orders/utils/PoLineCommonUtil.java
+++ b/src/main/java/org/folio/orders/utils/PoLineCommonUtil.java
@@ -296,6 +296,10 @@ public final class PoLineCommonUtil {
     return defaultIfNull(compPOL.getCost().getQuantityElectronic(), 0);
   }
 
+  public static int getOverallCostQuantity(CompositePoLine comPOL) {
+    return getElectronicCostQuantity(comPOL) + getPhysicalCostQuantity(comPOL);
+  }
+
   public static JsonObject verifyProtectedFieldsChanged(List<String> protectedFields, JsonObject objectFromStorage,
     JsonObject requestObject) {
     Set<String> fields = new HashSet<>();

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -130,7 +130,8 @@ public enum ErrorCodes {
   CREATE_INVENTORY_INCORRECT_FOR_BINDARY_ACTIVE("createInventoryIncorrectForBindaryActive", "When PoLine is bindery active, Create Inventory must be 'Instance, Holding, Item'"),
   RECEIVING_WORKFLOW_INCORRECT_FOR_BINDARY_ACTIVE("receivingWorkflowIncorrectForBindaryActive", "When PoLine is bindery active, its receiving workflow must be set to 'Independent order and receipt quantity'"),
   BIND_ITEM_MUST_INCLUDE_EITHER_HOLDING_ID_OR_LOCATION_ID("bindItemMustIncludeEitherHoldingIdOrLocationId", "During binding pieces, the bindItem object must have either holdingId or locationId field populated"),
-  BUDGET_NOT_FOUND_FOR_FISCAL_YEAR("budgetNotFoundForFiscalYear", "Could not find an active budget for a fund with the current fiscal year of another fund in the fund distribution");
+  BUDGET_NOT_FOUND_FOR_FISCAL_YEAR("budgetNotFoundForFiscalYear", "Could not find an active budget for a fund with the current fiscal year of another fund in the fund distribution"),
+  LAST_PIECE("lastPiece", "The piece cannot be deleted because it is the last piece for the poLine in order 'Closed' with Receiving Workflow 'Synchronized order and receipt quantity' and cost quantity '1'"),;
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -53,14 +53,14 @@ public class PieceDeleteFlowManager {
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext))
       .compose(aVoid -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .compose(aVoid -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), DELETE, requestContext))
-      .compose(aVoid -> isAllowedToDeletePiece(holder, requestContext))
+      .compose(aVoid -> isAllowedToDeletePiece(holder))
       .compose(aVoid -> isDeletePieceRequestValid(holder, requestContext))
       .compose(aVoid -> pieceDeleteFlowInventoryManager.processInventory(holder, requestContext))
       .compose(pair -> updatePoLine(holder, requestContext))
       .compose(aVoid -> pieceStorageService.deletePiece(holder.getPieceToDelete().getId(), true, requestContext));
   }
 
-  private Future<Void> isAllowedToDeletePiece(PieceDeletionHolder holder, RequestContext requestContext) {
+  private Future<Void> isAllowedToDeletePiece(PieceDeletionHolder holder) {
     var poLineCheckItems = holder.getOriginPoLine().getCheckinItems(); // false = Synchronized order and receipt quantity
     var overallCostQuantity = getOverallCostQuantity(holder.getOriginPoLine());
     if (Boolean.FALSE.equals(poLineCheckItems) && overallCostQuantity == 1) {

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -13,7 +13,6 @@ import org.folio.rest.RestConstants;
 import org.folio.rest.core.exceptions.ErrorCodes;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
-import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.ProtectionService;
@@ -62,12 +61,10 @@ public class PieceDeleteFlowManager {
   }
 
   private Future<Void> isAllowedToDeletePiece(PieceDeletionHolder holder, RequestContext requestContext) {
-    var poLineCheckItems = holder.getOriginPoLine().getCheckinItems();
-    var orderStatus = holder.getOriginPurchaseOrder().getWorkflowStatus();
+    var poLineCheckItems = holder.getOriginPoLine().getCheckinItems(); // false = Synchronized order and receipt quantity
     var overallCostQuantity = getOverallCostQuantity(holder.getOriginPoLine());
-    if (!poLineCheckItems && CompositePurchaseOrder.WorkflowStatus.CLOSED.equals(orderStatus) && overallCostQuantity == 1) {
-      var params = List.of(new Parameter().withKey("WorkFlowStatus").withValue(orderStatus.value()),
-        new Parameter().withKey("OverallCostQuantity").withValue(String.valueOf(overallCostQuantity)));
+    if (Boolean.FALSE.equals(poLineCheckItems) && overallCostQuantity == 1) {
+      var params = List.of(new Parameter().withKey("OverallCostQuantity").withValue(String.valueOf(overallCostQuantity)));
       var error = ErrorCodes.LAST_PIECE.toError().withParameters(params);
       logger.error("isAllowedToDeletePiece:: {}", error.getMessage());
       throw new HttpException(RestConstants.VALIDATION_ERROR, error);

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -1,7 +1,10 @@
 package org.folio.service.pieces.flows.delete;
 
+import static org.folio.orders.utils.PoLineCommonUtil.getOverallCostQuantity;
 import static org.folio.orders.utils.ProtectedOperationType.DELETE;
 import static org.folio.orders.utils.RequestContextUtil.createContextWithNewTenantId;
+
+import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -10,6 +13,8 @@ import org.folio.rest.RestConstants;
 import org.folio.rest.core.exceptions.ErrorCodes;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.ProtectionService;
 import org.folio.service.pieces.PieceStorageService;
@@ -49,10 +54,25 @@ public class PieceDeleteFlowManager {
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext))
       .compose(aVoid -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .compose(aVoid -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), DELETE, requestContext))
+      .compose(aVoid -> isAllowedToDeletePiece(holder, requestContext))
       .compose(aVoid -> isDeletePieceRequestValid(holder, requestContext))
       .compose(aVoid -> pieceDeleteFlowInventoryManager.processInventory(holder, requestContext))
       .compose(pair -> updatePoLine(holder, requestContext))
       .compose(aVoid -> pieceStorageService.deletePiece(holder.getPieceToDelete().getId(), true, requestContext));
+  }
+
+  private Future<Void> isAllowedToDeletePiece(PieceDeletionHolder holder, RequestContext requestContext) {
+    var poLineCheckItems = holder.getOriginPoLine().getCheckinItems();
+    var orderStatus = holder.getOriginPurchaseOrder().getWorkflowStatus();
+    var overallCostQuantity = getOverallCostQuantity(holder.getOriginPoLine());
+    if (!poLineCheckItems && CompositePurchaseOrder.WorkflowStatus.CLOSED.equals(orderStatus) && overallCostQuantity == 1) {
+      var params = List.of(new Parameter().withKey("WorkFlowStatus").withValue(orderStatus.value()),
+        new Parameter().withKey("OverallCostQuantity").withValue(String.valueOf(overallCostQuantity)));
+      var error = ErrorCodes.LAST_PIECE.toError().withParameters(params);
+      logger.error("isAllowedToDeletePiece:: {}", error.getMessage());
+      throw new HttpException(RestConstants.VALIDATION_ERROR, error);
+    }
+    return Future.succeededFuture();
   }
 
   private Future<Void> isDeletePieceRequestValid(PieceDeletionHolder holder, RequestContext requestContext) {

--- a/src/test/java/org/folio/TestUtils.java
+++ b/src/test/java/org/folio/TestUtils.java
@@ -164,8 +164,8 @@ public final class TestUtils {
       .withOrderFormat(CompositePoLine.OrderFormat.PHYSICAL_RESOURCE)
       .withAcquisitionMethod(PURCHASE_METHOD)
       .withPhysical(new Physical().withMaterialType("2d1398ae-e1aa-4c7c-b9c9-15adf8cf6425"))
-      .withCost(new Cost().withCurrency("EUR").withQuantityPhysical(1).withListUnitPrice(10.0))
-      .withLocations(Collections.singletonList(new Location().withLocationId("2a00b0be-1447-42a1-a112-124450991899").withQuantityPhysical(1).withQuantity(1)))
+      .withCost(new Cost().withCurrency("EUR").withQuantityPhysical(2).withListUnitPrice(10.0))
+      .withLocations(Collections.singletonList(new Location().withLocationId("2a00b0be-1447-42a1-a112-124450991899").withQuantityPhysical(2).withQuantity(2)))
       .withTitleOrPackage("Title")
       .withPurchaseOrderId(orderId);
   }

--- a/src/test/java/org/folio/rest/impl/PieceApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PieceApiTest.java
@@ -380,7 +380,7 @@ public class PieceApiTest {
     String titleId = UUID.randomUUID().toString();
     CompositePurchaseOrder order = new CompositePurchaseOrder().withId(orderId);
     Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
-    Cost cost = new Cost().withQuantityElectronic(1);
+    Cost cost = new Cost().withQuantityElectronic(2);
     CompositePoLine poLine = new CompositePoLine().withId(lineId).withPurchaseOrderId(order.getId())
       .withIsPackage(false).withPurchaseOrderId(orderId).withId(lineId)
       .withOrderFormat(CompositePoLine.OrderFormat.PHYSICAL_RESOURCE)
@@ -432,7 +432,7 @@ public class PieceApiTest {
     String titleId = UUID.randomUUID().toString();
     CompositePurchaseOrder order = new CompositePurchaseOrder().withId(orderId);
     Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
-    Cost cost = new Cost().withQuantityElectronic(1);
+    Cost cost = new Cost().withQuantityElectronic(2);
     CompositePoLine poLine = new CompositePoLine().withId(lineId).withPurchaseOrderId(order.getId())
       .withIsPackage(false).withPurchaseOrderId(orderId).withId(lineId)
       .withOrderFormat(CompositePoLine.OrderFormat.PHYSICAL_RESOURCE)
@@ -464,7 +464,7 @@ public class PieceApiTest {
 
     CompositePurchaseOrder order = new CompositePurchaseOrder().withId(orderId);
     Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
-    Cost cost = new Cost().withQuantityElectronic(1);
+    Cost cost = new Cost().withQuantityElectronic(2);
     CompositePoLine poLine = new CompositePoLine().withId(lineId).withPurchaseOrderId(order.getId())
       .withIsPackage(false).withPurchaseOrderId(orderId).withId(lineId)
       .withOrderFormat(CompositePoLine.OrderFormat.PHYSICAL_RESOURCE)
@@ -494,7 +494,7 @@ public class PieceApiTest {
 
     PurchaseOrder order = new PurchaseOrder().withId(UUID.randomUUID().toString());
     CompositePoLine poLine = new CompositePoLine().withId(UUID.randomUUID().toString()).withPurchaseOrderId(order.getId())
-      .withCost(new Cost().withQuantityElectronic(1));
+      .withCost(new Cost().withQuantityElectronic(2));
     Title title = new Title().withId(UUID.randomUUID().toString()).withTitle("title name");
     Piece piece = new Piece().withId(UUID.randomUUID().toString())
       .withItemId("522a501a-56b5-48d9-b28a-3a8f02482d98")

--- a/src/test/java/org/folio/rest/impl/PieceApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PieceApiTest.java
@@ -493,7 +493,8 @@ public class PieceApiTest {
     logger.info("=== Test delete piece by id without requests ===");
 
     PurchaseOrder order = new PurchaseOrder().withId(UUID.randomUUID().toString());
-    CompositePoLine poLine = new CompositePoLine().withId(UUID.randomUUID().toString()).withPurchaseOrderId(order.getId());
+    CompositePoLine poLine = new CompositePoLine().withId(UUID.randomUUID().toString()).withPurchaseOrderId(order.getId())
+      .withCost(new Cost().withQuantityElectronic(1));
     Title title = new Title().withId(UUID.randomUUID().toString()).withTitle("title name");
     Piece piece = new Piece().withId(UUID.randomUUID().toString())
       .withItemId("522a501a-56b5-48d9-b28a-3a8f02482d98")

--- a/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
@@ -143,7 +143,7 @@ public class PieceDeleteFlowManagerTest {
     holding.put(HOLDING_PERMANENT_LOCATION_ID, locationId);
     Piece piece = new Piece().withId(UUID.randomUUID().toString()).withPoLineId(lineId).withItemId(itemId).withTitleId(titleId)
       .withHoldingId(holdingId).withFormat(Piece.Format.ELECTRONIC);
-    Cost cost = new Cost().withQuantityElectronic(1)
+    Cost cost = new Cost().withQuantityElectronic(2)
       .withListUnitPriceElectronic(1d).withExchangeRate(1d).withCurrency("USD")
       .withPoLineEstimatedPrice(1d);
     Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
@@ -310,7 +310,7 @@ public class PieceDeleteFlowManagerTest {
     Piece piece = new Piece().withId(UUID.randomUUID().toString()).withPoLineId(lineId).withTitleId(titleId)
       .withLocationId(locationId).withFormat(Piece.Format.ELECTRONIC);
     Location loc = new Location().withLocationId(locationId).withQuantityElectronic(1).withQuantity(1);
-    Cost cost = new Cost().withQuantityElectronic(1)
+    Cost cost = new Cost().withQuantityElectronic(2)
       .withListUnitPriceElectronic(1d).withExchangeRate(1d).withCurrency("USD")
       .withPoLineEstimatedPrice(1d);
     PoLine poLine = new PoLine().withIsPackage(false).withCheckinItems(false).withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE)
@@ -370,7 +370,7 @@ public class PieceDeleteFlowManagerTest {
     Piece piece = new Piece().withId(UUID.randomUUID().toString()).withPoLineId(lineId)
                              .withHoldingId(holdingId).withFormat(Piece.Format.ELECTRONIC);
     Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
-    Cost cost = new Cost().withQuantityElectronic(1)
+    Cost cost = new Cost().withQuantityElectronic(2)
       .withListUnitPriceElectronic(1d).withExchangeRate(1d).withCurrency("USD")
       .withPoLineEstimatedPrice(1d);
     PoLine poLine = new PoLine().withIsPackage(false).withCheckinItems(false).withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE)


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." 
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/MODORDERS-1195
## Approach
 - added validation to avoid order status closed and poLine quantity = 1 and Synchronized Receiving Workflow

## Result
It will throw error if it try to delete piece based on conditions
<img width="1920" alt="image_2024-10-17_17-23-47" src="https://github.com/user-attachments/assets/050f9e02-2b70-4cad-b8e2-6c59e4e688f0">
