### PR TITLE
[MODORDERS-1194] Update libraries of dependant acq modules to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.8.0</version>
+      <version>3.6.1</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,39 +52,42 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <ramlfiles_acq_models_path>${ramlfiles_path}/acq-models</ramlfiles_acq_models_path>
-    <raml-module-builder.version>35.2.0</raml-module-builder.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!--Dependency Management Properties-->
-    <vertx.version>4.5.4</vertx.version>
-    <jackson-bom.version>2.13.4</jackson-bom.version>
-    <log4j.version>2.23.0</log4j.version>
-    <testcontainers-bom.version>1.19.6</testcontainers-bom.version>
+    <vertx.version>4.5.10</vertx.version>
+    <jackson-bom.version>2.18.0</jackson-bom.version>
+    <log4j.version>2.24.1</log4j.version>
+    <testcontainers-bom.version>1.20.2</testcontainers-bom.version>
 
     <!--Dependency Properties-->
+    <spring.version>6.1.14</spring.version>
+    <aspectj.version>1.9.22.1</aspectj.version>
+    <rest-assured.version>5.5.0</rest-assured.version>
+
+    <!--Folio dependencies properties-->
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <mod-configuration-client.version>5.10.0</mod-configuration-client.version>
     <folio-di-support.version>2.1.0</folio-di-support.version>
-    <spring.version>6.1.5</spring.version>
-    <aspectj.version>1.9.21.1</aspectj.version>
-    <rest-assured.version>5.4.0</rest-assured.version>
 
     <!--Maven plugin dependencies-->
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
-    <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-    <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+    <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
-    <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
 
     <!--Test dependencies-->
-    <junit-jupiter.version>5.10.0</junit-jupiter.version>
-    <junit-bom.version>5.10.0</junit-bom.version>
+    <junit-jupiter.version>5.11.2</junit-jupiter.version>
+    <junit-bom.version>5.11.2</junit-bom.version>
     <jmockit.version>1.49</jmockit.version>
 
     <!--Sonar exclusion-->
@@ -201,7 +204,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.25.3</version>
+      <version>3.26.3</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -217,7 +220,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.2.0</version>
+      <version>4.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -233,12 +236,12 @@
     <dependency>
       <groupId>one.util</groupId>
       <artifactId>streamex</artifactId>
-      <version>0.8.1</version>
+      <version>0.8.3</version>
     </dependency>
     <dependency>
       <groupId>org.javamoney</groupId>
       <artifactId>moneta</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.4</version>
       <type>pom</type>
     </dependency>
     <dependency>
@@ -270,7 +273,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.1.3</version>
+      <version>3.1.8</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -315,7 +318,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>5.10.0</version>
+      <version>5.14.2</version>
       <scope>test</scope>
     </dependency>
     <!-- The RMB runtime defines usage of log4j2 for vert.x logging interface. Including Log4j 2 SLF4J Binding to allow SLF4J API to use Log4j 2 as the implementation. -->
@@ -348,7 +351,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.6.1</version>
+      <version>3.8.0</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
@@ -373,7 +376,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-utils</artifactId>
-      <version>1.11.0</version>
+      <version>1.12.1</version>
       <type>jar</type>
       <exclusions>
         <exclusion>
@@ -397,7 +400,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.30</version>
+      <version>1.18.34</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -473,7 +476,7 @@
       <plugin>
         <groupId>org.jsonschema2pojo</groupId>
         <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-        <version>1.0.2</version>
+        <version>1.2.2</version>
         <configuration>
           <includes>
             <include>*.json</include>
@@ -765,7 +768,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.1</version>
         <executions>
           <execution>
             <id>set-system-properties</id>


### PR DESCRIPTION
## Purpose
[[MODORDERS-1194] Update libraries of dependant acq modules to the latest versions
](https://folio-org.atlassian.net/browse/MODORDERS-1194)

## Approach
- Update versions
- Add module descriptor validator