### PR TITLE
[MODORDERS-1203] Total expended amount is not displayed when order has no fund distributions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -66,6 +66,8 @@
             "invoice.invoice-lines.collection.get",
             "finance.transactions.collection.get",
             "finance.exchange-rate.item.get",
+            "finance.fiscal-years.item.get",
+            "finance.fiscal-years.collection.get",
             "finance.funds.item.get",
             "finance.funds.collection.get",
             "finance.ledgers.current-fiscal-year.item.get",
@@ -848,6 +850,7 @@
             "inventory-storage.instance-statuses.collection.get",
             "inventory-storage.contributor-name-types.collection.get",
             "user-tenants.collection.get",
+            "configuration.entries.collection.get",
             "consortia.sharing-instances.item.post",
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get"

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-di-converter-storage-client</artifactId>
-      <version>2.3.0-SNAPSHOT</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -424,8 +424,9 @@ public class ApplicationConfig {
   }
 
   @Bean
-  CompositeOrderDynamicDataPopulateService totalExpendedPopulateService(TransactionService transactionService, InvoiceService invoiceService, InvoiceLineService invoiceLineService) {
-    return new CompositeOrderTotalFieldsPopulateService(transactionService, invoiceService, invoiceLineService);
+  CompositeOrderDynamicDataPopulateService totalExpendedPopulateService(TransactionService transactionService, InvoiceService invoiceService,
+                                                                        InvoiceLineService invoiceLineService, FiscalYearService fiscalYearService) {
+    return new CompositeOrderTotalFieldsPopulateService(transactionService, invoiceService, invoiceLineService, fiscalYearService);
   }
 
   @Bean("orderLinesSummaryPopulateService")

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -271,8 +271,8 @@ public class ApplicationConfig {
   }
 
   @Bean
-  FiscalYearService fiscalYearService(RestClient restClient, FundService fundService) {
-    return new FiscalYearService(restClient, fundService);
+  FiscalYearService fiscalYearService(RestClient restClient, FundService fundService, ConfigurationEntriesCache configurationEntriesCache) {
+    return new FiscalYearService(restClient, fundService, configurationEntriesCache);
   }
 
   @Bean

--- a/src/main/java/org/folio/orders/utils/CacheUtils.java
+++ b/src/main/java/org/folio/orders/utils/CacheUtils.java
@@ -1,0 +1,30 @@
+package org.folio.orders.utils;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+public class CacheUtils {
+
+  public static <K, V> AsyncCache<K, V> buildAsyncCache(Vertx vertx, long cacheExpirationTime) {
+    return buildAsyncCache(task -> vertx.runOnContext(v -> task.run()), cacheExpirationTime);
+  }
+
+  public static <K, V> AsyncCache<K, V> buildAsyncCache(Context context, long cacheExpirationTime) {
+    return buildAsyncCache(task -> context.runOnContext(v -> task.run()), cacheExpirationTime);
+  }
+
+  private static <K, V> AsyncCache<K, V> buildAsyncCache(Executor executor, long cacheExpirationTime) {
+    return Caffeine.newBuilder()
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(executor)
+      .buildAsync();
+  }
+
+  private CacheUtils() {}
+
+}

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -440,4 +440,8 @@ public class HelperUtils {
     Future<O> apply(I item);
   }
 
+  public interface BiFunctionReturningFuture<I1, I2, O> {
+    Future<O> apply(I1 item1, I2 item2);
+  }
+
 }

--- a/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/orders/utils/ResourcePathResolver.java
@@ -5,8 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.folio.rest.RestConstants.PATH_PARAM_PLACE_HOLDER;
-
 public class ResourcePathResolver {
 
   private ResourcePathResolver() {
@@ -49,6 +47,8 @@ public class ResourcePathResolver {
   public static final String CONFIGURATION_ENTRIES = "configurations.entries";
   public static final String LEDGER_FY_ROLLOVERS = "finance.ledger-rollovers";
   public static final String LEDGER_FY_ROLLOVER_ERRORS = "finance.ledger-rollovers-errors";
+  public static final String LEDGER_CURRENT_FISCAL_YEAR = "finance.ledger.current-fiscal-year";
+  public static final String FISCAL_YEARS = "finance.fiscal-years";
   public static final String ORDER_INVOICE_RELATIONSHIP = "order-invoice-relationship";
   public static final String EXPORT_HISTORY = "export-history";
   public static final String TAGS = "tags";
@@ -96,11 +96,13 @@ public class ResourcePathResolver {
     apis.put(CONFIGURATION_ENTRIES, "/configurations/entries");
     apis.put(LEDGER_FY_ROLLOVERS, "/finance/ledger-rollovers");
     apis.put(LEDGER_FY_ROLLOVER_ERRORS, "/finance/ledger-rollovers-errors");
+    apis.put(LEDGER_CURRENT_FISCAL_YEAR, "/finance/ledgers/{id}/current-fiscal-year");
+    apis.put(FISCAL_YEARS, "/finance/fiscal-years");
     apis.put(ORDER_INVOICE_RELATIONSHIP, "/orders-storage/order-invoice-relns");
     apis.put(EXPORT_HISTORY, "/orders-storage/export-history");
     apis.put(TAGS, "/tags");
     apis.put(USERS, "/users");
-    apis.put(CONSORTIA_USER_TENANTS, "/consortia/" + PATH_PARAM_PLACE_HOLDER + "/user-tenants");
+    apis.put(CONSORTIA_USER_TENANTS, "/consortia/{id}/user-tenants");
     apis.put(ORDER_SETTINGS, "/orders-storage/settings");
     apis.put(ROUTING_LISTS, "/orders-storage/routing-lists");
 

--- a/src/main/java/org/folio/service/caches/ConfigurationEntriesCache.java
+++ b/src/main/java/org/folio/service/caches/ConfigurationEntriesCache.java
@@ -4,11 +4,10 @@ import static org.folio.orders.utils.HelperUtils.SYSTEM_CONFIG_MODULE_NAME;
 import static org.folio.service.configuration.ConfigurationEntriesService.CONFIG_QUERY;
 import static org.folio.service.configuration.ConfigurationEntriesService.TENANT_CONFIGURATION_ENTRIES;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.extern.log4j.Log4j2;
+import org.folio.orders.utils.HelperUtils.BiFunctionReturningFuture;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
@@ -16,6 +15,7 @@ import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.UserService;
 import org.folio.service.configuration.ConfigurationEntriesService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
@@ -25,27 +25,29 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
+@Log4j2
 @Component
 public class ConfigurationEntriesCache {
-  private static final Logger log = LogManager.getLogger();
+
+  private static final String UNIQUE_CACHE_KEY_PATTERN = "%s_%s_%s";
+  @Value("${orders.cache.configuration-entries.expiration.time.seconds:30}")
+  private long cacheExpirationTime;
 
   private final AsyncCache<String, JsonObject> configsCache;
   private final AsyncCache<String, String> systemCurrencyCache;
-  private static final String UNIQUE_CACHE_KEY_PATTERN = "%s_%s_%s";
   private final ConfigurationEntriesService configurationEntriesService;
+
+
   @Autowired
   public ConfigurationEntriesCache(ConfigurationEntriesService configurationEntriesService) {
     this.configurationEntriesService = configurationEntriesService;
     configsCache = Caffeine.newBuilder()
-      .expireAfterWrite(30, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext()
-        .runOnContext(v -> task.run()))
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
       .buildAsync();
-
     systemCurrencyCache = Caffeine.newBuilder()
-      .expireAfterWrite(30, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext()
-        .runOnContext(v -> task.run()))
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
       .buildAsync();
   }
 
@@ -55,25 +57,29 @@ public class ConfigurationEntriesCache {
    * @return CompletableFuture with {@link String} ISBN UUID value
    */
   public Future<JsonObject> loadConfiguration(String module, RequestContext requestContext) {
+    return loadConfigurationData(module, requestContext, configsCache, configurationEntriesService::loadConfiguration);
+  }
+
+  public Future<String> getSystemCurrency(RequestContext requestContext) {
+    return loadConfigurationData(SYSTEM_CONFIG_MODULE_NAME, requestContext, systemCurrencyCache, configurationEntriesService::getSystemCurrency);
+  }
+
+  private <T> Future<T> loadConfigurationData(String module, RequestContext requestContext,
+                                              AsyncCache<String, T> cache,
+                                              BiFunctionReturningFuture<RequestEntry, RequestContext, T> configExtractor) {
     try {
-      RequestEntry requestEntry = new RequestEntry(TENANT_CONFIGURATION_ENTRIES)
+      var requestEntry = new RequestEntry(TENANT_CONFIGURATION_ENTRIES)
         .withQuery(String.format(CONFIG_QUERY, module))
         .withOffset(0)
         .withLimit(Integer.MAX_VALUE);
-
       var cacheKey = buildUniqueKey(requestEntry, requestContext);
-
-      return Future.fromCompletionStage(configsCache.get(cacheKey, (key, executor) -> loadConfiguration(requestEntry, requestContext)));
+      return Future.fromCompletionStage(cache.get(cacheKey, (key, executor) ->
+        configExtractor.apply(requestEntry, requestContext)
+          .toCompletionStage().toCompletableFuture()));
     } catch (Exception e) {
-      log.error("loadConfiguration:: Error loading tenant configuration from cache, tenantId: '{}'", TenantTool.tenantId(requestContext.getHeaders()), e);
+      log.error("loadConfigurationData:: Error loading tenant configuration from cache, tenantId: '{}'", TenantTool.tenantId(requestContext.getHeaders()), e);
       return Future.failedFuture(e);
     }
-  }
-
-  private CompletableFuture<JsonObject> loadConfiguration(RequestEntry requestEntry, RequestContext requestContext) {
-    return configurationEntriesService.loadConfiguration(requestEntry, requestContext)
-      .toCompletionStage()
-      .toCompletableFuture();
   }
 
   private String buildUniqueKey(RequestEntry requestEntry, RequestContext requestContext) {
@@ -83,25 +89,4 @@ public class ConfigurationEntriesCache {
     return String.format(UNIQUE_CACHE_KEY_PATTERN, tenantId, userId, endpoint);
   }
 
-  public Future<String> getSystemCurrency(RequestContext requestContext) {
-
-    try {
-      RequestEntry requestEntry = new RequestEntry(TENANT_CONFIGURATION_ENTRIES)
-        .withQuery(String.format(CONFIG_QUERY, SYSTEM_CONFIG_MODULE_NAME))
-        .withOffset(0)
-        .withLimit(Integer.MAX_VALUE);
-
-      var cacheKey = buildUniqueKey(requestEntry, requestContext);
-
-      return Future.fromCompletionStage(systemCurrencyCache.get(cacheKey, (key, executor) -> getSystemCurrency(requestEntry, requestContext)));
-    } catch (Exception e) {
-      log.warn("get:: Error loading system currency from cache, tenantId: '{}'", TenantTool.tenantId(requestContext.getHeaders()), e);
-      return Future.failedFuture(e);
-    }
-  }
-  private CompletableFuture<String> getSystemCurrency(RequestEntry requestEntry, RequestContext requestContext) {
-    return configurationEntriesService.getSystemCurrency(requestEntry, requestContext)
-      .toCompletionStage()
-      .toCompletableFuture();
-  }
 }

--- a/src/main/java/org/folio/service/caches/ConfigurationEntriesCache.java
+++ b/src/main/java/org/folio/service/caches/ConfigurationEntriesCache.java
@@ -35,6 +35,7 @@ public class ConfigurationEntriesCache {
 
   private final AsyncCache<String, JsonObject> configsCache;
   private final AsyncCache<String, String> systemCurrencyCache;
+  private final AsyncCache<String, String> systemTimezoneCache;
   private final ConfigurationEntriesService configurationEntriesService;
 
 
@@ -46,6 +47,10 @@ public class ConfigurationEntriesCache {
       .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
       .buildAsync();
     systemCurrencyCache = Caffeine.newBuilder()
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
+      .buildAsync();
+    systemTimezoneCache = Caffeine.newBuilder()
       .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
       .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
       .buildAsync();
@@ -62,6 +67,10 @@ public class ConfigurationEntriesCache {
 
   public Future<String> getSystemCurrency(RequestContext requestContext) {
     return loadConfigurationData(SYSTEM_CONFIG_MODULE_NAME, requestContext, systemCurrencyCache, configurationEntriesService::getSystemCurrency);
+  }
+
+  public Future<String> getSystemTimeZone(RequestContext requestContext) {
+    return loadConfigurationData(SYSTEM_CONFIG_MODULE_NAME, requestContext, systemTimezoneCache, configurationEntriesService::getSystemTimeZone);
   }
 
   private <T> Future<T> loadConfigurationData(String module, RequestContext requestContext,

--- a/src/main/java/org/folio/service/caches/InventoryCache.java
+++ b/src/main/java/org/folio/service/caches/InventoryCache.java
@@ -1,7 +1,6 @@
 package org.folio.service.caches;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,11 +13,12 @@ import org.folio.service.inventory.InventoryService;
 import org.springframework.stereotype.Component;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 
 @Component
 public class InventoryCache {
@@ -37,17 +37,9 @@ public class InventoryCache {
 
   public InventoryCache(InventoryService inventoryService) {
     this.inventoryService = inventoryService;
-    asyncCache = Caffeine.newBuilder()
-      .expireAfterWrite(30, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext()
-        .runOnContext(v -> task.run()))
-      .buildAsync();
-
-    asyncJsonCache = Caffeine.newBuilder()
-      .expireAfterWrite(30, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext()
-        .runOnContext(v -> task.run()))
-      .buildAsync();
+    var context = Vertx.currentContext();
+    asyncCache = buildAsyncCache(context, 30);
+    asyncJsonCache = buildAsyncCache(context, 30);
   }
 
   public Future<String> getISBNProductTypeId(RequestContext requestContext) {

--- a/src/main/java/org/folio/service/caches/JobExecutionTotalRecordsCache.java
+++ b/src/main/java/org/folio/service/caches/JobExecutionTotalRecordsCache.java
@@ -1,7 +1,6 @@
 package org.folio.service.caches;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
@@ -15,7 +14,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 
 /**
  * An in-memory cache that stores total amount of imported records
@@ -38,10 +38,7 @@ public class JobExecutionTotalRecordsCache {
 
   @Autowired
   public JobExecutionTotalRecordsCache(Vertx vertx) {
-    cache = Caffeine.newBuilder()
-      .expireAfterAccess(cacheExpirationTime, TimeUnit.SECONDS)
-      .executor(task -> vertx.runOnContext(v -> task.run()))
-      .buildAsync();
+    cache = buildAsyncCache(vertx, cacheExpirationTime);
   }
 
   /**

--- a/src/main/java/org/folio/service/caches/JobProfileSnapshotCache.java
+++ b/src/main/java/org/folio/service/caches/JobProfileSnapshotCache.java
@@ -15,12 +15,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
+
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 
 @Component
 public class JobProfileSnapshotCache {
@@ -34,10 +35,7 @@ public class JobProfileSnapshotCache {
 
   @Autowired
   public JobProfileSnapshotCache(Vertx vertx) {
-    cache = Caffeine.newBuilder()
-      .expireAfterAccess(cacheExpirationTime, TimeUnit.SECONDS)
-      .executor(task -> vertx.runOnContext(v -> task.run()))
-      .buildAsync();
+    cache = buildAsyncCache(vertx, cacheExpirationTime);
   }
 
   public Future<Optional<ProfileSnapshotWrapper>> get(String profileSnapshotId, OkapiConnectionParams params) {

--- a/src/main/java/org/folio/service/caches/JobProfileSnapshotCache.java
+++ b/src/main/java/org/folio/service/caches/JobProfileSnapshotCache.java
@@ -2,7 +2,6 @@ package org.folio.service.caches;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/folio/service/caches/MappingParametersCache.java
+++ b/src/main/java/org/folio/service/caches/MappingParametersCache.java
@@ -1,7 +1,6 @@
 package org.folio.service.caches;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
@@ -48,10 +47,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static java.lang.String.format;
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 import static org.folio.orders.utils.QueryUtils.encodeQuery;
 import static org.folio.rest.RestConstants.ID;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
@@ -93,10 +92,7 @@ public class MappingParametersCache {
                                 AcquisitionsUnitsService acquisitionsUnitsService,
                                 AcquisitionMethodsService acquisitionMethodsService) {
     LOGGER.info("MappingParametersCache:: settings limit: '{}'", settingsLimit);
-    cache = Caffeine.newBuilder()
-      .expireAfterAccess(cacheExpirationTime, TimeUnit.SECONDS)
-      .executor(task -> vertx.runOnContext(v -> task.run()))
-      .buildAsync();
+    cache = buildAsyncCache(vertx, cacheExpirationTime);
     this.restClient = restClient;
     this.acquisitionsUnitsService = acquisitionsUnitsService;
     this.acquisitionMethodsService = acquisitionMethodsService;

--- a/src/main/java/org/folio/service/configuration/ConfigurationEntriesService.java
+++ b/src/main/java/org/folio/service/configuration/ConfigurationEntriesService.java
@@ -1,8 +1,7 @@
 package org.folio.service.configuration;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
@@ -11,13 +10,19 @@ import org.folio.rest.jaxrs.model.Configs;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
+@Log4j2
 public class ConfigurationEntriesService {
 
-  private static final Logger logger = LogManager.getLogger();
   public static final String TENANT_CONFIGURATION_ENTRIES = "/configurations/entries";
   public static final String CONFIG_QUERY = "module==%s";
   public static final String LOCALE_SETTINGS = "localeSettings";
-  public static final String CURRENCY_USD = "USD";
+
+  public static final String CURRENCY_CONFIG = "currency";
+  public static final String DEFAULT_CURRENCY = "USD";
+
+  public static final String TZ_CONFIG = "timezone";
+  public static final String TZ_UTC = "UTC";
+
   private final RestClient restClient;
 
   public ConfigurationEntriesService(RestClient restClient) {
@@ -27,32 +32,31 @@ public class ConfigurationEntriesService {
   public Future<JsonObject> loadConfiguration(RequestEntry requestEntry, RequestContext requestContext) {
     return restClient.get(requestEntry, Configs.class, requestContext)
       .map(configs -> {
-        if (logger.isDebugEnabled()) {
-          logger.debug("The response from mod-configuration: {}", JsonObject.mapFrom(configs).encodePrettily());
+        if (log.isDebugEnabled()) {
+          log.debug("The response from mod-configuration: {}", JsonObject.mapFrom(configs).encodePrettily());
         }
-        JsonObject config = new JsonObject();
-
+        var config = new JsonObject();
         configs.getConfigs()
           .forEach(entry -> config.put(entry.getConfigName(), entry.getValue()));
         return config;
       });
   }
 
-
   public Future<String> getSystemCurrency(RequestEntry requestEntry, RequestContext requestContext) {
-
-
     return loadConfiguration(requestEntry, requestContext)
-      .compose(config -> {
-      String localeSettings = config.getString(LOCALE_SETTINGS);
-      String systemCurrency;
-      if (StringUtils.isEmpty(localeSettings)) {
-        systemCurrency = CURRENCY_USD;
-      } else {
-        systemCurrency = new JsonObject(config.getString(LOCALE_SETTINGS)).getString("currency", "USD");
-      }
-      return Future.succeededFuture(systemCurrency);
-    });
+      .map(jsonConfig -> extractLocalSettingConfigValueByName(jsonConfig, CURRENCY_CONFIG, DEFAULT_CURRENCY));
+  }
+
+  public Future<String> getSystemTimeZone(RequestEntry requestEntry, RequestContext requestContext) {
+    return loadConfiguration(requestEntry, requestContext)
+      .map(jsonConfig -> extractLocalSettingConfigValueByName(jsonConfig, TZ_CONFIG, TZ_UTC));
+  }
+
+  private String extractLocalSettingConfigValueByName(JsonObject config, String name, String defaultValue) {
+    String localeSettings = config.getString(LOCALE_SETTINGS);
+    return StringUtils.isEmpty(localeSettings)
+      ? defaultValue
+      : new JsonObject(localeSettings).getString(name, defaultValue);
   }
 
 }

--- a/src/main/java/org/folio/service/consortium/ConsortiumConfigurationService.java
+++ b/src/main/java/org/folio/service/consortium/ConsortiumConfigurationService.java
@@ -1,7 +1,6 @@
 package org.folio.service.consortium;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.commons.lang3.StringUtils;
@@ -18,7 +17,8 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 
 public class ConsortiumConfigurationService {
   private static final Logger logger = LogManager.getLogger(ConsortiumConfigurationService.class);
@@ -36,11 +36,7 @@ public class ConsortiumConfigurationService {
 
   public ConsortiumConfigurationService(RestClient restClient) {
     this.restClient = restClient;
-
-    asyncCache = Caffeine.newBuilder()
-      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
-      .buildAsync();
+    asyncCache = buildAsyncCache(Vertx.currentContext(), cacheExpirationTime);
   }
 
   public Future<Optional<ConsortiumConfiguration>> getConsortiumConfiguration(RequestContext requestContext) {

--- a/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
+++ b/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
@@ -1,7 +1,6 @@
 package org.folio.service.consortium;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -14,10 +13,10 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 import static org.folio.orders.utils.RequestContextUtil.getUserIdFromContext;
 import static org.folio.orders.utils.ResourcePathResolver.CONSORTIA_USER_TENANTS;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
@@ -40,10 +39,8 @@ public class ConsortiumUserTenantsRetriever {
 
   public ConsortiumUserTenantsRetriever(RestClient restClient) {
     this.restClient = restClient;
-    asyncCache = Caffeine.newBuilder()
-      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
-      .buildAsync();
+    var context = Vertx.currentContext();
+    asyncCache = buildAsyncCache(context, cacheExpirationTime);
   }
 
   public Future<List<String>> getUserTenants(String consortiumId, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
+++ b/src/main/java/org/folio/service/consortium/ConsortiumUserTenantsRetriever.java
@@ -21,7 +21,6 @@ import java.util.stream.IntStream;
 import static org.folio.orders.utils.RequestContextUtil.getUserIdFromContext;
 import static org.folio.orders.utils.ResourcePathResolver.CONSORTIA_USER_TENANTS;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
-import static org.folio.rest.RestConstants.PATH_PARAM_PLACE_HOLDER;
 import static org.folio.service.pieces.util.UserTenantFields.COLLECTION_USER_TENANTS;
 import static org.folio.service.pieces.util.UserTenantFields.TENANT_ID;
 import static org.folio.service.pieces.util.UserTenantFields.USER_ID;
@@ -59,8 +58,8 @@ public class ConsortiumUserTenantsRetriever {
   }
 
   private CompletableFuture<List<String>> getUserTenantsFromRemote(String userId, String consortiumId, RequestContext requestContext) {
-    var url = CONSORTIA_USER_TENANTS_ENDPOINT.replace(PATH_PARAM_PLACE_HOLDER, consortiumId);
-    var requestEntry = new RequestEntry(url)
+    var requestEntry = new RequestEntry(CONSORTIA_USER_TENANTS_ENDPOINT)
+      .withId(consortiumId)
       .withOffset(0)
       .withLimit(Integer.MAX_VALUE)
       .withQueryParameter(USER_ID.getValue(), userId);

--- a/src/main/java/org/folio/service/finance/FiscalYearService.java
+++ b/src/main/java/org/folio/service/finance/FiscalYearService.java
@@ -1,13 +1,22 @@
 package org.folio.service.finance;
 
+import static org.folio.orders.utils.ResourcePathResolver.FISCAL_YEARS;
+import static org.folio.orders.utils.ResourcePathResolver.LEDGER_CURRENT_FISCAL_YEAR;
+import static org.folio.orders.utils.ResourcePathResolver.resourceByIdPath;
+import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
 import static org.folio.rest.core.exceptions.ErrorCodes.CURRENT_FISCAL_YEAR_NOT_FOUND;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Vertx;
 import org.folio.rest.acq.model.finance.FiscalYear;
+import org.folio.rest.acq.model.finance.FiscalYearCollection;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
@@ -15,10 +24,21 @@ import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.jaxrs.model.Parameter;
 
 import io.vertx.core.Future;
+import org.folio.rest.tools.utils.TenantTool;
+import org.springframework.beans.factory.annotation.Value;
 
 public class FiscalYearService {
 
-  private static final String CURRENT_FISCAL_YEAR = "/finance/ledgers/{id}/current-fiscal-year";
+  private static final String LEDGER_CURRENT_FISCAL_YEAR_ENDPOINT = resourcesPath(LEDGER_CURRENT_FISCAL_YEAR);
+  private static final String FISCAL_YEARS_ENDPOINT = resourcesPath(FISCAL_YEARS);
+  private static final String FISCAL_YEAR_BY_ID_ENDPOINT = resourceByIdPath(FISCAL_YEARS, "{id}");
+  private static final String FISCAL_YEAR_BY_SERIES_QUERY = "series==\"%s\" sortBy periodStart";
+  private static final String CACHE_KEY_TEMPLATE = "%s.%s";
+
+  @Value("${orders.cache.fiscal-years.expiration.time.seconds:300}")
+  private long cacheExpirationTime;
+  private final AsyncCache<String, String> currentFiscalYearCacheBySeries;
+  private final AsyncCache<String, String> seriesCacheByFiscalYearId;
 
   private final RestClient restClient;
   private final FundService fundService;
@@ -27,10 +47,18 @@ public class FiscalYearService {
   public FiscalYearService(RestClient restClient, FundService fundService) {
     this.restClient = restClient;
     this.fundService = fundService;
+    currentFiscalYearCacheBySeries = Caffeine.newBuilder()
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
+      .buildAsync();
+    seriesCacheByFiscalYearId = Caffeine.newBuilder()
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
+      .buildAsync();
   }
 
   public Future<FiscalYear> getCurrentFiscalYear(String ledgerId, RequestContext requestContext) {
-    RequestEntry requestEntry = new RequestEntry(CURRENT_FISCAL_YEAR).withId(ledgerId);
+    var requestEntry = new RequestEntry(LEDGER_CURRENT_FISCAL_YEAR_ENDPOINT).withId(ledgerId);
     return restClient.get(requestEntry, FiscalYear.class, requestContext)
       .recover(t -> {
         Throwable cause = Objects.nonNull(t.getCause()) ? t.getCause() : t;
@@ -49,7 +77,44 @@ public class FiscalYearService {
       .compose(fund -> getCurrentFiscalYear(fund.getLedgerId(), requestContext));
   }
 
+  /**
+   * Retrieves the current fiscal year ID for the series related to the fiscal year corresponding to the given ID.
+   *
+   * @param fiscalYearId fiscal year ID
+   * @param requestContext {@link RequestContext} to be used for the request
+   * @return future with the current fiscal year ID
+   */
+  public Future<String> getCurrentFYForSeriesByFYId(String fiscalYearId, RequestContext requestContext) {
+    return getSeriesByFiscalYearId(fiscalYearId, requestContext)
+      .compose(series -> getCurrentFiscalYearForSeries(series, requestContext));
+  }
+
+  private Future<String> getSeriesByFiscalYearId(String fiscalYearId, RequestContext requestContext) {
+    var cacheKey = CACHE_KEY_TEMPLATE.formatted(fiscalYearId, TenantTool.tenantId(requestContext.getHeaders()));
+    return Future.fromCompletionStage(seriesCacheByFiscalYearId.get(cacheKey, (key, executor) ->
+      getFiscalYearById(fiscalYearId, requestContext)
+        .map(FiscalYear::getSeries)
+        .toCompletionStage().toCompletableFuture()));
+  }
+
+  private Future<FiscalYear> getFiscalYearById(String fiscalYearId, RequestContext requestContext) {
+    var requestEntry = new RequestEntry(FISCAL_YEAR_BY_ID_ENDPOINT).withId(fiscalYearId);
+    return restClient.get(requestEntry, FiscalYear.class, requestContext);
+  }
+
+  private Future<String> getCurrentFiscalYearForSeries(String series, RequestContext requestContext) {
+    var cacheKey = CACHE_KEY_TEMPLATE.formatted(series, TenantTool.tenantId(requestContext.getHeaders()));
+    return Future.fromCompletionStage(currentFiscalYearCacheBySeries.get(cacheKey, (key, executor) -> {
+      var query = FISCAL_YEAR_BY_SERIES_QUERY.formatted(series);
+      var requestEntry = new RequestEntry(FISCAL_YEARS_ENDPOINT).withQuery(query);
+      return restClient.get(requestEntry, FiscalYearCollection.class, requestContext)
+          .map(fiscalYearCollection -> fiscalYearCollection.getFiscalYears().get(0).getId())
+          .toCompletionStage().toCompletableFuture();
+      }));
+  }
+
   private boolean isFiscalYearNotFound(Throwable t) {
     return t instanceof HttpException && ((HttpException) t).getCode() == 404;
   }
+
 }

--- a/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
+++ b/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
@@ -1,8 +1,8 @@
 package org.folio.service.orders;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -67,7 +67,7 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
     return collectResultsOnSuccess(invoices.stream()
       .map(Invoice::getFiscalYearId)
       .map(fiscalYearId -> fiscalYearService.getCurrentFYForSeriesByFYId(fiscalYearId, requestContext)).toList())
-      .map(HashSet::new);
+      .map(fiscalYearsIds -> fiscalYearsIds.stream().filter(Objects::nonNull).collect(Collectors.toSet()));
   }
 
   private Future<List<InvoiceLine>> getInvoiceLinesByInvoiceIds(List<Invoice> invoices, Set<String> fiscalYearIds, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
+++ b/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
@@ -61,7 +61,7 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
   }
 
   private Future<Set<String>> getCurrentFiscalYearIds(List<Invoice> invoices, FiscalYear fiscalYear, RequestContext requestContext) {
-    if (fiscalYear != null) {
+    if (fiscalYear != null && fiscalYear.getId() != null) {
       return Future.succeededFuture(Set.of(fiscalYear.getId()));
     }
     return collectResultsOnSuccess(invoices.stream()
@@ -72,7 +72,7 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
 
   private Future<List<InvoiceLine>> getInvoiceLinesByInvoiceIds(List<Invoice> invoices, Set<String> fiscalYearIds, RequestContext requestContext) {
     return collectResultsOnSuccess(invoices.stream()
-      .filter(invoice -> fiscalYearIds.contains(invoice.getFiscalYearId()))
+      .filter(invoice -> invoice.getFiscalYearId() != null && fiscalYearIds.contains(invoice.getFiscalYearId()))
       .map(invoice -> invoiceLineService.getInvoiceLinesByInvoiceId(invoice.getId(), requestContext)).toList())
       .map(invoiceLinesLists -> invoiceLinesLists.stream().flatMap(List::stream).toList());
   }

--- a/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
+++ b/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
@@ -1,19 +1,21 @@
 package org.folio.service.orders;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.extern.log4j.Log4j2;
 import one.util.streamex.StreamEx;
-import org.apache.commons.lang3.StringUtils;
 import org.folio.models.CompositeOrderRetrieveHolder;
 import org.folio.rest.acq.model.finance.FiscalYear;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.acq.model.invoice.Invoice;
 import org.folio.rest.acq.model.invoice.InvoiceLine;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.service.finance.FiscalYearService;
 import org.folio.service.finance.transaction.TransactionService;
 import org.folio.service.invoice.InvoiceLineService;
 import org.folio.service.invoice.InvoiceService;
@@ -30,20 +32,18 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
   private final TransactionService transactionService;
   private final InvoiceService invoiceService;
   private final InvoiceLineService invoiceLineService;
+  private final FiscalYearService fiscalYearService;
 
-  public CompositeOrderTotalFieldsPopulateService(TransactionService transactionService,
-                                                  InvoiceService invoiceService,
-                                                  InvoiceLineService invoiceLineService) {
+  public CompositeOrderTotalFieldsPopulateService(TransactionService transactionService, InvoiceService invoiceService,
+                                                  InvoiceLineService invoiceLineService, FiscalYearService fiscalYearService) {
     this.transactionService = transactionService;
     this.invoiceService = invoiceService;
     this.invoiceLineService = invoiceLineService;
+    this.fiscalYearService = fiscalYearService;
   }
 
   @Override
   public Future<CompositeOrderRetrieveHolder> populate(CompositeOrderRetrieveHolder holder, RequestContext requestContext) {
-    if (holder.getFiscalYear() == null) {
-      return Future.succeededFuture(holder.withTotalExpended(0d).withTotalCredited(0d).withTotalEncumbered(0d));
-    }
     // We need to fetch invoices, invoice lines and transactions in order to calculate total fields
     // totalEncumbered = sum of transactions amounts
     // totalExpended = sum of invoice lines positive total values
@@ -51,7 +51,8 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
     var query = "transactionType==Encumbrance AND encumbrance.sourcePurchaseOrderId==%s AND fiscalYearId==%s"
       .formatted(holder.getOrderId(), holder.getFiscalYearId());
     return invoiceService.getInvoicesByOrderId(holder.getOrderId(), requestContext)
-      .compose(invoices -> getInvoiceLinesByInvoiceIds(invoices, holder.getFiscalYear(), requestContext)
+      .compose(invoices -> getCurrentFiscalYearIds(invoices, holder.getFiscalYear(), requestContext)
+        .compose(fiscalYears -> getInvoiceLinesByInvoiceIds(invoices, fiscalYears, requestContext))
         .map(invoiceLines -> groupInvoiceLinesByInvoices(invoices, invoiceLines))
         .compose(invoiceToInvoiceLinesMap -> transactionService.getTransactions(query, requestContext)
           .map(transactions -> populateTotalFields(holder, invoiceToInvoiceLinesMap, transactions))))
@@ -59,9 +60,19 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
         holder.getOrderId(), holder.getFiscalYearId(), t));
   }
 
-  private Future<List<InvoiceLine>> getInvoiceLinesByInvoiceIds(List<Invoice> invoices, FiscalYear fiscalYear, RequestContext requestContext) {
+  private Future<Set<String>> getCurrentFiscalYearIds(List<Invoice> invoices, FiscalYear fiscalYear, RequestContext requestContext) {
+    if (fiscalYear != null) {
+      return Future.succeededFuture(Set.of(fiscalYear.getId()));
+    }
     return collectResultsOnSuccess(invoices.stream()
-      .filter(invoice -> StringUtils.equals(invoice.getFiscalYearId(), fiscalYear.getId()))
+      .map(Invoice::getFiscalYearId)
+      .map(fiscalYearId -> fiscalYearService.getCurrentFYForSeriesByFYId(fiscalYearId, requestContext)).toList())
+      .map(HashSet::new);
+  }
+
+  private Future<List<InvoiceLine>> getInvoiceLinesByInvoiceIds(List<Invoice> invoices, Set<String> fiscalYearIds, RequestContext requestContext) {
+    return collectResultsOnSuccess(invoices.stream()
+      .filter(invoice -> fiscalYearIds.contains(invoice.getFiscalYearId()))
       .map(invoice -> invoiceLineService.getInvoiceLinesByInvoiceId(invoice.getId(), requestContext)).toList())
       .map(invoiceLinesLists -> invoiceLinesLists.stream().flatMap(List::stream).toList());
   }

--- a/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
+++ b/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
@@ -66,6 +66,7 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
     }
     return collectResultsOnSuccess(invoices.stream()
       .map(Invoice::getFiscalYearId)
+      .filter(Objects::nonNull)
       .map(fiscalYearId -> fiscalYearService.getCurrentFYForSeriesByFYId(fiscalYearId, requestContext)).toList())
       .map(fiscalYearsIds -> fiscalYearsIds.stream().filter(Objects::nonNull).collect(Collectors.toSet()));
   }

--- a/src/main/java/org/folio/service/organization/OrganizationService.java
+++ b/src/main/java/org/folio/service/organization/OrganizationService.java
@@ -1,6 +1,7 @@
 package org.folio.service.organization;
 
 import static java.util.stream.Collectors.toList;
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 import static org.folio.orders.utils.QueryUtils.convertIdsToCqlQuery;
 import static org.folio.orders.utils.QueryUtils.encodeQuery;
 import static org.folio.rest.RestConstants.ERROR_CAUSE;
@@ -15,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -37,7 +37,6 @@ import org.folio.service.UserService;
 import org.springframework.stereotype.Component;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -56,11 +55,7 @@ public class OrganizationService {
 
   private final Errors processingErrors = new Errors();
   public OrganizationService(RestClient restClient) {
-    asyncCache = Caffeine.newBuilder()
-      .expireAfterWrite(30, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext()
-        .runOnContext(v -> task.run()))
-      .buildAsync();
+    asyncCache = buildAsyncCache(Vertx.currentContext(), 30);
     this.restClient = restClient;
   }
 

--- a/src/main/java/org/folio/service/settings/SettingsRetriever.java
+++ b/src/main/java/org/folio/service/settings/SettingsRetriever.java
@@ -1,7 +1,6 @@
 package org.folio.service.settings;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import lombok.extern.log4j.Log4j2;
@@ -17,8 +16,8 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
+import static org.folio.orders.utils.CacheUtils.buildAsyncCache;
 import static org.folio.orders.utils.ResourcePathResolver.ORDER_SETTINGS;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
 
@@ -37,11 +36,7 @@ public class SettingsRetriever {
 
   public SettingsRetriever(RestClient restClient) {
     this.restClient = restClient;
-
-    asyncCache = Caffeine.newBuilder()
-      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
-      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
-      .buildAsync();
+    asyncCache = buildAsyncCache(Vertx.currentContext(), cacheExpirationTime);
   }
 
   public Future<Optional<Setting>> getSettingByKey(SettingKey settingKey, RequestContext requestContext) {

--- a/src/test/java/org/folio/service/caches/ConfigurationEntriesCacheTest.java
+++ b/src/test/java/org/folio/service/caches/ConfigurationEntriesCacheTest.java
@@ -1,0 +1,99 @@
+package org.folio.service.caches;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.folio.CopilotGenerated;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.service.configuration.ConfigurationEntriesService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+@CopilotGenerated
+@ExtendWith(MockitoExtension.class)
+public class ConfigurationEntriesCacheTest {
+
+  @Mock
+  private RequestContext requestContextMock;
+  @Mock
+  private ConfigurationEntriesService configurationEntriesServiceMock;
+  @InjectMocks
+  private ConfigurationEntriesCache configurationEntriesCache;
+
+  @Test
+  void shouldLoadConfigurationFromCache() {
+    String module = "testModule";
+    JsonObject config = new JsonObject().put("key", "value");
+    doReturn(Future.succeededFuture(config))
+      .when(configurationEntriesServiceMock).loadConfiguration(any(RequestEntry.class), any(RequestContext.class));
+
+    Future<JsonObject> result = configurationEntriesCache.loadConfiguration(module, requestContextMock);
+
+    assertEquals(config, result.result());
+  }
+
+  @Test
+  void shouldReturnSystemCurrencyFromCache() {
+    String currency = "USD";
+    doReturn(Future.succeededFuture(currency))
+      .when(configurationEntriesServiceMock).getSystemCurrency(any(RequestEntry.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesCache.getSystemCurrency(requestContextMock);
+
+    assertEquals(currency, result.result());
+  }
+
+  @Test
+  void shouldReturnSystemTimeZoneFromCache() {
+    String timeZone = "UTC";
+    doReturn(Future.succeededFuture(timeZone))
+      .when(configurationEntriesServiceMock).getSystemTimeZone(any(RequestEntry.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesCache.getSystemTimeZone(requestContextMock);
+
+    assertEquals(timeZone, result.result());
+  }
+
+  @Test
+  void shouldFailToLoadConfigurationWhenServiceFails() {
+    String module = "testModule";
+    doReturn(Future.failedFuture(new RuntimeException("Service failure")))
+      .when(configurationEntriesServiceMock).loadConfiguration(any(RequestEntry.class), any(RequestContext.class));
+
+    Future<JsonObject> result = configurationEntriesCache.loadConfiguration(module, requestContextMock);
+
+    assertTrue(result.failed());
+    assertEquals(RuntimeException.class, result.cause().getClass());
+  }
+
+  @Test
+  void shouldFailToReturnSystemCurrencyWhenServiceFails() {
+    doReturn(Future.failedFuture(new RuntimeException("Service failure")))
+      .when(configurationEntriesServiceMock).getSystemCurrency(any(RequestEntry.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesCache.getSystemCurrency(requestContextMock);
+
+    assertTrue(result.failed());
+    assertEquals(RuntimeException.class, result.cause().getClass());
+  }
+
+  @Test
+  void shouldFailToReturnSystemTimeZoneWhenServiceFails() {
+    doReturn(Future.failedFuture(new RuntimeException("Service failure")))
+      .when(configurationEntriesServiceMock).getSystemTimeZone(any(RequestEntry.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesCache.getSystemTimeZone(requestContextMock);
+
+    assertTrue(result.failed());
+    assertEquals(RuntimeException.class, result.cause().getClass());
+  }
+
+}

--- a/src/test/java/org/folio/service/configuration/ConfigurationEntriesServiceTest.java
+++ b/src/test/java/org/folio/service/configuration/ConfigurationEntriesServiceTest.java
@@ -1,0 +1,145 @@
+package org.folio.service.configuration;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.folio.CopilotGenerated;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configs;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+@CopilotGenerated
+@ExtendWith(MockitoExtension.class)
+public class ConfigurationEntriesServiceTest {
+
+  @Mock
+  private RequestContext requestContextMock;
+  @Mock
+  private RestClient restClientMock;
+  @InjectMocks
+  private ConfigurationEntriesService configurationEntriesService;
+
+  @Test
+  void shouldLoadConfigurationSuccessfully() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+    JsonObject expectedConfig = new JsonObject().put("key", "value");
+    Configs configs = new Configs().withConfigs(List.of(new Config().withConfigName("key").withValue("value")));
+
+    doReturn(Future.succeededFuture(configs))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<JsonObject> result = configurationEntriesService.loadConfiguration(requestEntry, requestContextMock);
+
+    assertEquals(expectedConfig, result.result());
+  }
+
+  @Test
+  void shouldReturnDefaultCurrencyWhenLocaleSettingsNotPresent() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+    JsonObject config = new JsonObject();
+    Configs configs = new Configs().withConfigs(List.of());
+
+    doReturn(Future.succeededFuture(configs))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesService.getSystemCurrency(requestEntry, requestContextMock);
+
+    assertEquals("USD", result.result());
+  }
+
+  @Test
+  void shouldReturnConfiguredCurrency() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+    JsonObject config = new JsonObject().put("localeSettings", new JsonObject().put("currency", "EUR").encode());
+    Configs configs = new Configs().withConfigs(List.of(new Config().withConfigName("localeSettings").withValue(config.getString("localeSettings"))));
+
+    doReturn(Future.succeededFuture(configs))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesService.getSystemCurrency(requestEntry, requestContextMock);
+
+    assertEquals("EUR", result.result());
+  }
+
+  @Test
+  void shouldReturnDefaultTimeZoneWhenLocaleSettingsNotPresent() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+    JsonObject config = new JsonObject();
+    Configs configs = new Configs().withConfigs(List.of());
+
+    doReturn(Future.succeededFuture(configs))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesService.getSystemTimeZone(requestEntry, requestContextMock);
+
+    assertEquals("UTC", result.result());
+  }
+
+  @Test
+  void shouldReturnConfiguredTimeZone() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+    JsonObject config = new JsonObject().put("localeSettings", new JsonObject().put("timezone", "PST").encode());
+    Configs configs = new Configs().withConfigs(List.of(new Config().withConfigName("localeSettings").withValue(config.getString("localeSettings"))));
+
+    doReturn(Future.succeededFuture(configs))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesService.getSystemTimeZone(requestEntry, requestContextMock);
+
+    assertEquals("PST", result.result());
+  }
+
+  @Test
+  void shouldFailToLoadConfigurationWhenRestClientFails() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+
+    doReturn(Future.failedFuture(new RuntimeException("Service failure")))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<JsonObject> result = configurationEntriesService.loadConfiguration(requestEntry, requestContextMock);
+
+    assertTrue(result.failed());
+    assertEquals(RuntimeException.class, result.cause().getClass());
+  }
+
+  @Test
+  void shouldFailToReturnSystemCurrencyWhenRestClientFails() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+
+    doReturn(Future.failedFuture(new RuntimeException("Service failure")))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesService.getSystemCurrency(requestEntry, requestContextMock);
+
+    assertTrue(result.failed());
+    assertEquals(RuntimeException.class, result.cause().getClass());
+  }
+
+  @Test
+  void shouldFailToReturnSystemTimeZoneWhenRestClientFails() {
+    RequestEntry requestEntry = new RequestEntry("/configurations/entries");
+
+    doReturn(Future.failedFuture(new RuntimeException("Service failure")))
+      .when(restClientMock).get(eq(requestEntry), eq(Configs.class), any(RequestContext.class));
+
+    Future<String> result = configurationEntriesService.getSystemTimeZone(requestEntry, requestContextMock);
+
+    assertTrue(result.failed());
+    assertEquals(RuntimeException.class, result.cause().getClass());
+  }
+
+}


### PR DESCRIPTION
## Purpose
[[MODORDERS-1203] Total expended amount is not displayed when order has no fund distributions](https://folio-org.atlassian.net/browse/MODORDERS-1203)

## Approach
- Refactor configuration entries service and cache
- Fetch and cache system time zone
- Extend fiscal year service to fetch current fiscal year for series
- Update and add new generated tests

## Verification
https://github.com/folio-org/folio-integration-tests/pull/1592