### PR TITLE
[MODORDERS-1210] Implement API to change piece statuses in batch

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -628,6 +628,31 @@
           ]
         },
         {
+          "methods": ["PUT"],
+          "pathPattern": "/orders/pieces-batch/status",
+          "permissionsRequired": ["orders.pieces.batch.put"],
+          "modulePermissions": [
+            "orders-storage.pieces.item.put",
+            "orders-storage.pieces.collection.get",
+            "orders-storage.po-lines.item.get",
+            "orders-storage.po-lines.item.put",
+            "orders-storage.po-lines.collection.get",
+            "orders-storage.purchase-orders.item.get",
+            "orders-storage.purchase-orders.item.put",
+            "orders-storage.titles.collection.get",
+            "finance.funds.item.get",
+            "finance.ledgers.current-fiscal-year.item.get",
+            "finance.transactions.collection.get",
+            "finance.transactions.batch.execute",
+            "inventory.items.item.get",
+            "inventory.items.item.put",
+            "inventory.items.collection.get",
+            "inventory-storage.holdings.collection.get",
+            "acquisitions-units-storage.units.collection.get",
+            "acquisitions-units-storage.memberships.collection.get"
+          ]
+        },
+        {
           "methods": ["GET"],
           "pathPattern": "/orders/pieces-requests",
           "permissionsRequired": ["orders.piece-requests.collection.get"],
@@ -1520,6 +1545,11 @@
       "description": "Delete an existing piece"
     },
     {
+      "permissionName": "orders.pieces.batch.put",
+      "displayName": "orders - batch update piece statuses",
+      "description": "Batch update piece statuses"
+    },
+    {
       "permissionName": "orders.piece-requests.collection.get",
       "displayName": "Orders - Get piece requests",
       "description": "Get order piece requests"
@@ -1534,6 +1564,7 @@
         "orders.pieces.item.get",
         "orders.pieces.item.put",
         "orders.pieces.item.delete",
+        "orders.pieces.batch.put",
         "orders.piece-requests.collection.get"
       ]
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -630,7 +630,7 @@
         {
           "methods": ["PUT"],
           "pathPattern": "/orders/pieces-batch/status",
-          "permissionsRequired": ["orders.pieces.batch.put"],
+          "permissionsRequired": ["orders.pieces.collection.put"],
           "modulePermissions": [
             "orders-storage.pieces.item.put",
             "orders-storage.pieces.collection.get",
@@ -1545,7 +1545,7 @@
       "description": "Delete an existing piece"
     },
     {
-      "permissionName": "orders.pieces.batch.put",
+      "permissionName": "orders.pieces.collection.put",
       "displayName": "orders - batch update piece statuses",
       "description": "Batch update piece statuses"
     },
@@ -1560,11 +1560,11 @@
       "description" : "All permissions for the pieces",
       "subPermissions" : [
         "orders.pieces.collection.get",
+        "orders.pieces.collection.put",
         "orders.pieces.item.post",
         "orders.pieces.item.get",
         "orders.pieces.item.put",
         "orders.pieces.item.delete",
-        "orders.pieces.batch.put",
         "orders.piece-requests.collection.get"
       ]
     },

--- a/ramls/pieces-batch.raml
+++ b/ramls/pieces-batch.raml
@@ -1,0 +1,49 @@
+#%RAML 1.0
+title: Pieces Batch Operations
+baseUri: https://github.com/folio-org/mod-orders
+version: v1
+protocols: [ HTTP, HTTPS ]
+
+documentation:
+  - title: Endpoint for batch operations on Pieces
+    content: <b>Endpoint for batch operations on Pieces</b>
+
+types:
+  piece-batch-status-collection: !include acq-models/mod-orders/schemas/pieceStatusBatchCollection.json
+
+/orders/pieces-batch:
+  /status:
+    put:
+      description: Batch status update for pieces
+      body:
+        application/json:
+          type: piece-batch-status-collection
+          example:
+            strict: false
+            value: !include acq-models/mod-orders/examples/pieceStatusBatchCollection.sample
+      responses:
+        204:
+          description: "Piece records successfully updated"
+        400:
+          description: "Bad request"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include examples/errors_400.sample
+            text/plain:
+              example: "Unable to update pieces - Bad request"
+        404:
+          description: "Pieces do not exist"
+          body:
+            text/plain:
+              example: "Following pieces are not found: [id1, id2]"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include examples/errors_500.sample
+            text/plain:
+              example: "Unable to update pieces - Internal server error, e.g. due to misconfiguration"

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -11,7 +11,6 @@ documentation:
 types:
   piece: !include acq-models/mod-orders-storage/schemas/piece.json
   piece-collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
-  piece-batch-status-collection: !include acq-models/mod-orders/schemas/pieceStatusBatchCollection.json
   errors: !include raml-util/schemas/errors.schema
   UUID:
     type: string
@@ -143,38 +142,3 @@ resourceTypes:
                 value: !include examples/errors_500.sample
             text/plain:
               example: "unable to delete Piece -- Internal server error, e.g. due to misconfiguration"
-  /batch-status:
-    put:
-      description: Batch status update for pieces
-      body:
-        application/json:
-          type: piece-batch-status-collection
-          example:
-            strict: false
-            value: !include acq-models/mod-orders/examples/pieceStatusBatchCollection.sample
-      responses:
-        204:
-          description: "Piece records successfully updated"
-        400:
-          description: "Bad request"
-          body:
-            application/json:
-              example:
-                strict: false
-                value: !include examples/errors_400.sample
-            text/plain:
-              example: "Unable to update pieces - Bad request"
-        404:
-          description: "Pieces do not exist"
-          body:
-            text/plain:
-              example: "Following pieces are not found: [id1, id2]"
-        500:
-          description: "Internal server error, e.g. due to misconfiguration"
-          body:
-            application/json:
-              example:
-                strict: false
-                value: !include examples/errors_500.sample
-            text/plain:
-              example: "Unable to update pieces - Internal server error, e.g. due to misconfiguration"

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -11,6 +11,7 @@ documentation:
 types:
   piece: !include acq-models/mod-orders-storage/schemas/piece.json
   piece-collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
+  piece-batch-status: !include acq-models/mod-orders/schemas/pieceStatusBatchCollection.json
   errors: !include raml-util/schemas/errors.schema
   UUID:
     type: string
@@ -142,3 +143,38 @@ resourceTypes:
                 value: !include examples/errors_500.sample
             text/plain:
               example: "unable to delete Piece -- Internal server error, e.g. due to misconfiguration"
+  /batch-status:
+    put:
+      description: Batch status update for pieces
+      body:
+        application/json:
+          type: piece-batch-status
+          example:
+            strict: false
+            value: !include acq-models/mod-orders/examples/pieceStatusBatchCollection.sample
+      responses:
+        204:
+          description: "Piece records successfully updated"
+        400:
+          description: "Bad request"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include examples/errors_400.sample
+            text/plain:
+              example: "Unable to update pieces - Bad request"
+        404:
+          description: "Pieces do not exist"
+          body:
+            text/plain:
+              example: "Following pieces are not found: [id1, id2]"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            application/json:
+              example:
+                strict: false
+                value: !include examples/errors_500.sample
+            text/plain:
+              example: "Unable to update pieces - Internal server error, e.g. due to misconfiguration"

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -11,7 +11,7 @@ documentation:
 types:
   piece: !include acq-models/mod-orders-storage/schemas/piece.json
   piece-collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
-  piece-batch-status: !include acq-models/mod-orders/schemas/pieceStatusBatchCollection.json
+  piece-batch-status-collection: !include acq-models/mod-orders/schemas/pieceStatusBatchCollection.json
   errors: !include raml-util/schemas/errors.schema
   UUID:
     type: string
@@ -148,7 +148,7 @@ resourceTypes:
       description: Batch status update for pieces
       body:
         application/json:
-          type: piece-batch-status
+          type: piece-batch-status-collection
           example:
             strict: false
             value: !include acq-models/mod-orders/examples/pieceStatusBatchCollection.sample

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -641,13 +641,12 @@ public class ApplicationConfig {
   }
 
   @Bean
-  PieceUpdateFlowManager pieceUpdateFlowManager(PieceStorageService pieceStorageService, PieceService pieceService, ProtectionService protectionService,
-            PieceUpdateFlowPoLineService pieceUpdateFlowPoLineService, PieceUpdateFlowInventoryManager pieceUpdateFlowInventoryManager,
-            BasePieceFlowHolderBuilder basePieceFlowHolderBuilder, DefaultPieceFlowsValidator defaultPieceFlowsValidator,
-            PurchaseOrderLineService purchaseOrderLineService) {
-    return new PieceUpdateFlowManager(pieceStorageService, pieceService, protectionService, pieceUpdateFlowPoLineService,
-                            pieceUpdateFlowInventoryManager, basePieceFlowHolderBuilder, defaultPieceFlowsValidator,
-                            purchaseOrderLineService);
+  PieceUpdateFlowManager pieceUpdateFlowManager(PieceStorageService pieceStorageService, PieceService pieceService, TitlesService titlesService,
+                                                ProtectionService protectionService, PieceUpdateFlowPoLineService pieceUpdateFlowPoLineService,
+                                                PieceUpdateFlowInventoryManager pieceUpdateFlowInventoryManager, BasePieceFlowHolderBuilder basePieceFlowHolderBuilder,
+                                                DefaultPieceFlowsValidator defaultPieceFlowsValidator, PurchaseOrderLineService purchaseOrderLineService) {
+    return new PieceUpdateFlowManager(pieceStorageService, pieceService, titlesService, protectionService, pieceUpdateFlowPoLineService,
+      pieceUpdateFlowInventoryManager, basePieceFlowHolderBuilder, defaultPieceFlowsValidator, purchaseOrderLineService);
   }
 
   @Bean

--- a/src/main/java/org/folio/models/pieces/PieceBatchStatusUpdateHolder.java
+++ b/src/main/java/org/folio/models/pieces/PieceBatchStatusUpdateHolder.java
@@ -1,0 +1,29 @@
+package org.folio.models.pieces;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.folio.rest.jaxrs.model.Piece;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class PieceBatchStatusUpdateHolder extends BasePieceFlowHolder {
+
+  private Piece.ReceivingStatus receivingStatus;
+  private List<Piece> pieces;
+  private String poLineId;
+
+  @Override
+  public String getOrderLineId() {
+    return poLineId;
+  }
+
+  @Override
+  public String getTitleId() {
+    return null;
+  }
+
+}

--- a/src/main/java/org/folio/models/pieces/PieceBatchStatusUpdateHolder.java
+++ b/src/main/java/org/folio/models/pieces/PieceBatchStatusUpdateHolder.java
@@ -1,18 +1,17 @@
 package org.folio.models.pieces;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import org.folio.rest.jaxrs.model.Piece;
 
 import java.util.List;
 
 @AllArgsConstructor
-@Getter
-@Builder
 public class PieceBatchStatusUpdateHolder extends BasePieceFlowHolder {
 
+  @Getter
   private Piece.ReceivingStatus receivingStatus;
+  @Getter
   private List<Piece> pieces;
   private String poLineId;
 

--- a/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
+++ b/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
@@ -48,9 +48,9 @@ public class ReceiptStatusConsistency extends BaseHelper implements Handler<Mess
     var requestContext = new RequestContext(ctx, okapiHeaders);
 
     var poLineId = getPoLineId(messageFromEventBus);
-    var future = purchaseOrderLineService.getOrderLineById(poLineId, requestContext)
-      .compose(poLine -> pieceStorageService.getPiecesByLineId(poLineId, requestContext)
-        .compose(pieces -> updatePoLineAndOrderStatuses(pieces, poLine, requestContext))
+    var future = pieceStorageService.getPiecesByLineId(poLineId, requestContext)
+      .compose(pieces -> purchaseOrderLineService.getOrderLineById(poLineId, requestContext)
+        .compose(poLine -> updatePoLineAndOrderStatuses(pieces, poLine, requestContext))
         .onFailure(e -> logger.error("Exception occurred while fetching PoLine by id: '{}'", poLineId, e)))
       .onFailure(e -> logger.error("Exception occurred while fetching pieces by PoLine id: '{}'", poLineId, e));
 

--- a/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
+++ b/src/main/java/org/folio/orders/events/handlers/ReceiptStatusConsistency.java
@@ -1,162 +1,85 @@
 package org.folio.orders.events.handlers;
 
-import static org.folio.helper.CheckinReceivePiecesHelper.EXPECTED_STATUSES;
-import static org.folio.helper.CheckinReceivePiecesHelper.RECEIVED_STATUSES;
-import static org.folio.orders.utils.ResourcePathResolver.PIECES_STORAGE;
-import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
-import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.AWAITING_RECEIPT;
-import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.FULLY_RECEIVED;
-import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.PARTIALLY_RECEIVED;
+import static org.folio.orders.events.utils.EventUtils.getPoLineId;
+import static org.folio.orders.utils.HelperUtils.getOkapiHeaders;
+import static org.folio.service.orders.utils.StatusUtils.calculatePoLineReceiptStatus;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.folio.helper.BaseHelper;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.orders.utils.PoLineCommonUtil;
-import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Piece;
-import org.folio.rest.jaxrs.model.Piece.ReceivingStatus;
-import org.folio.rest.jaxrs.model.PieceCollection;
 import org.folio.rest.jaxrs.model.PoLine;
-import org.folio.rest.jaxrs.model.PoLine.ReceiptStatus;
 import org.folio.service.orders.PurchaseOrderLineService;
+import org.folio.service.pieces.PieceStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import one.util.streamex.StreamEx;
 
 @Component("receiptStatusHandler")
 public class ReceiptStatusConsistency extends BaseHelper implements Handler<Message<JsonObject>> {
 
-  private static final int LIMIT = Integer.MAX_VALUE;
-  private static final String PIECES_ENDPOINT = resourcesPath(PIECES_STORAGE) + "?query=poLineId==%s&limit=%s";
-
+  private final PieceStorageService pieceStorageService;
   private final PurchaseOrderLineService purchaseOrderLineService;
 
 
   @Autowired
-  public ReceiptStatusConsistency(Vertx vertx, PurchaseOrderLineService purchaseOrderLineService) {
+  public ReceiptStatusConsistency(Vertx vertx, PieceStorageService pieceStorageService, PurchaseOrderLineService purchaseOrderLineService) {
     super(vertx.getOrCreateContext());
+    this.pieceStorageService = pieceStorageService;
     this.purchaseOrderLineService = purchaseOrderLineService;
   }
 
   @Override
   public void handle(Message<JsonObject> message) {
-    JsonObject messageFromEventBus = message.body();
-
+    var messageFromEventBus = message.body();
     logger.info("Received message body: {}", messageFromEventBus);
 
-    Map<String, String> okapiHeaders = org.folio.orders.utils.HelperUtils.getOkapiHeaders(message);
+    var okapiHeaders = getOkapiHeaders(message);
     var requestContext = new RequestContext(ctx, okapiHeaders);
-    List<Future<Void>> futures = new ArrayList<>();
-    Promise<Void> promise = Promise.promise();
-    futures.add(promise.future());
 
-    String poLineIdUpdate = messageFromEventBus.getString("poLineIdUpdate");
-    String query = String.format(PIECES_ENDPOINT, poLineIdUpdate, LIMIT);
+    var poLineId = getPoLineId(messageFromEventBus);
+    var future = purchaseOrderLineService.getOrderLineById(poLineId, requestContext)
+      .compose(poLine -> pieceStorageService.getPiecesByLineId(poLineId, requestContext)
+        .compose(pieces -> updatePoLineAndOrderStatuses(pieces, poLine, requestContext))
+        .onFailure(e -> logger.error("Exception occurred while fetching PoLine by id: '{}'", poLineId, e)))
+      .onFailure(e -> logger.error("Exception occurred while fetching pieces by PoLine id: '{}'", poLineId, e));
 
-    // 1. Get all pieces for poLineId
-    getPieces(query, requestContext)
-      .compose(listOfPieces ->
-        // 2. Get PoLine for the poLineId which will be used to calculate PoLineReceiptStatus
-        purchaseOrderLineService.getOrderLineById(poLineIdUpdate, requestContext)
-          .map(poLine -> {
-            if (PoLineCommonUtil.isCancelledOrOngoingStatus(poLine)) {
-              promise.complete();
-              return null;
-            }
-            ReceiptStatus receivingStatus = calculatePoLineReceiptStatus(poLine, listOfPieces);
-            boolean statusUpdated = purchaseOrderLineService.updatePoLineReceiptStatusWithoutSave(poLine, receivingStatus);
-            if (statusUpdated) {
-              purchaseOrderLineService.saveOrderLine(poLine, requestContext)
-                .map(aVoid -> {
-                  // send event to update order status
-                  updateOrderStatus(poLine, okapiHeaders, requestContext);
-                  promise.complete();
-                  return null;
-                })
-                .onFailure(e -> {
-                  logger.error("The error updating poLine by id {}", poLineIdUpdate, e);
-                  promise.fail(e);
-                });
-            } else {
-              promise.complete();
-            }
-            return null;
-          })
-          .onFailure(e -> {
-            logger.error("The error getting poLine by id {}", poLineIdUpdate, e);
-            promise.fail(e);
-          }))
-      .onFailure(e -> {
-        logger.error("The error happened getting all pieces by poLine {}", poLineIdUpdate, e);
-        promise.fail(e);
-      });
-
-    // Now wait for all operations to be completed and send reply
-    completeAllFutures(futures, message);
+    completeAllFutures(List.of(future), message);
   }
 
-  private void updateOrderStatus(PoLine poLine, Map<String, String> okapiHeaders, RequestContext requestContext) {
-    List<JsonObject> poIds = StreamEx
-      .of(poLine)
-      .map(PoLine::getPurchaseOrderId)
-      .distinct()
-      .map(orderId -> new JsonObject().put(ORDER_ID, orderId))
-      .toList();
-    JsonObject messageContent = new JsonObject();
-    messageContent.put(OKAPI_HEADERS, okapiHeaders);
-    // Collect order ids which should be processed
-    messageContent.put(EVENT_PAYLOAD, new JsonArray(poIds));
+  private Future<Void> updatePoLineAndOrderStatuses(List<Piece> pieces, PoLine poLine, RequestContext requestContext) {
+    if (PoLineCommonUtil.isCancelledOrOngoingStatus(poLine)) {
+      return Future.succeededFuture();
+    }
+    var newStatus = pieces.isEmpty()
+      ? poLine.getReceiptStatus()
+      : calculatePoLineReceiptStatus(poLine.getId(), pieces);
+    boolean statusUpdated = purchaseOrderLineService.updatePoLineReceiptStatusWithoutSave(poLine, newStatus);
+    if (!statusUpdated) {
+      return Future.succeededFuture();
+    }
+    return purchaseOrderLineService.saveOrderLine(poLine, requestContext)
+      .compose(v -> updateOrderStatus(poLine, okapiHeaders, requestContext))
+      .onFailure(e -> logger.error("Exception occurred while updating PoLine by id: '{}'", poLine.getId(), e));
+  }
+
+  private Future<Void> updateOrderStatus(PoLine poLine, Map<String, String> okapiHeaders, RequestContext requestContext) {
+    var messageContent = JsonObject.of(
+      OKAPI_HEADERS, okapiHeaders,
+      EVENT_PAYLOAD, JsonArray.of(JsonObject.of(ORDER_ID, poLine.getPurchaseOrderId()))
+    );
     HelperUtils.sendEvent(MessageAddress.RECEIVE_ORDER_STATUS_UPDATE, messageContent, requestContext);
+    return Future.succeededFuture();
   }
 
-  private ReceiptStatus calculatePoLineReceiptStatus(PoLine poLine, List<Piece> pieces) {
-
-    if (CollectionUtils.isEmpty(pieces)) {
-      logger.info("No pieces processed - receipt status unchanged for PO Line '{}'", poLine.getId());
-      return poLine.getReceiptStatus();
-    }
-
-    long expectedQty = getPiecesQuantityByPoLineAndStatus(EXPECTED_STATUSES, pieces);
-    return calculatePoLineReceiptStatus(expectedQty, pieces);
-  }
-
-  private ReceiptStatus calculatePoLineReceiptStatus(long expectedPiecesQuantity, List<Piece> pieces) {
-    if (expectedPiecesQuantity == 0) {
-      logger.info("calculatePoLineReceiptStatus:: Fully received");
-      return FULLY_RECEIVED;
-    }
-
-    if (StreamEx.of(pieces).anyMatch(piece -> RECEIVED_STATUSES.contains(piece.getReceivingStatus()))) {
-      logger.info("calculatePoLineReceiptStatus:: Partially Received - In case there is at least one successfully received piece");
-      return PARTIALLY_RECEIVED;
-    }
-
-    logger.info("calculatePoLineReceiptStatus::Pieces were rolled-back to Expected, checking if there is any Received piece in the storage");
-    long receivedQty = getPiecesQuantityByPoLineAndStatus(RECEIVED_STATUSES, pieces);
-    return receivedQty == 0 ? AWAITING_RECEIPT : PARTIALLY_RECEIVED;
-  }
-
-  private long getPiecesQuantityByPoLineAndStatus(List<ReceivingStatus> receivingStatuses, List<Piece> pieces) {
-    return pieces.stream()
-      .filter(piece -> receivingStatuses.contains(piece.getReceivingStatus()))
-      .count();
-  }
-
-  Future<List<Piece>> getPieces(String endpoint, RequestContext requestContext) {
-    return new RestClient().get(endpoint, PieceCollection.class, requestContext)
-      .map(PieceCollection::getPieces);
-  }
 }

--- a/src/main/java/org/folio/orders/events/utils/EventUtils.java
+++ b/src/main/java/org/folio/orders/events/utils/EventUtils.java
@@ -4,14 +4,14 @@ import io.vertx.core.json.JsonObject;
 
 public class EventUtils {
 
-  private static final String POL_UPDATE = "poLineIdUpdate";
+  public static final String POL_UPDATE_FIELD = "poLineIdUpdate";
 
   public static JsonObject createPoLineUpdateEvent(String poLineId) {
-    return JsonObject.of(POL_UPDATE, poLineId);
+    return JsonObject.of(POL_UPDATE_FIELD, poLineId);
   }
 
   public static String getPoLineId(JsonObject eventPayload) {
-    return eventPayload.getString(POL_UPDATE);
+    return eventPayload.getString(POL_UPDATE_FIELD);
   }
 
   private EventUtils() {}

--- a/src/main/java/org/folio/orders/events/utils/EventUtils.java
+++ b/src/main/java/org/folio/orders/events/utils/EventUtils.java
@@ -1,0 +1,19 @@
+package org.folio.orders.events.utils;
+
+import io.vertx.core.json.JsonObject;
+
+public class EventUtils {
+
+  private static final String POL_UPDATE = "poLineIdUpdate";
+
+  public static JsonObject createPoLineUpdateEvent(String poLineId) {
+    return JsonObject.of(POL_UPDATE, poLineId);
+  }
+
+  public static String getPoLineId(JsonObject eventPayload) {
+    return eventPayload.getString(POL_UPDATE);
+  }
+
+  private EventUtils() {}
+
+}

--- a/src/main/java/org/folio/orders/utils/FutureUtils.java
+++ b/src/main/java/org/folio/orders/utils/FutureUtils.java
@@ -1,0 +1,26 @@
+package org.folio.orders.utils;
+
+import io.vertx.core.Future;
+
+import java.util.concurrent.Callable;
+
+public class FutureUtils {
+
+  public static Future<Void> asFuture(Runnable runnable) {
+    return asFuture(() -> {
+      runnable.run();
+      return null;
+    });
+  }
+
+  public static <T> Future<T> asFuture(Callable<T> callable) {
+    try {
+      return Future.succeededFuture(callable.call());
+    } catch (Exception e) {
+      return Future.failedFuture(e);
+    }
+  }
+
+  private FutureUtils() {}
+
+}

--- a/src/main/java/org/folio/rest/impl/PiecesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PiecesAPI.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.PieceBatchStatus;
 import org.folio.rest.jaxrs.resource.OrdersPieces;
 import org.folio.rest.jaxrs.resource.OrdersPiecesRequests;
 import org.folio.service.CirculationRequestsRetriever;
@@ -104,10 +105,17 @@ public class PiecesAPI extends BaseApi implements OrdersPieces, OrdersPiecesRequ
 
   @Override
   public void getOrdersPiecesRequests(List<String> pieceIds, String status, Map<String, String> okapiHeaders,
-                                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     circulationRequestsRetriever.getRequesterIdsToRequestsByPieceIds(pieceIds, status, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(requests -> asyncResultHandler.handle(succeededFuture(buildOkResponse(requests))))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
 
+  @Override
+  public void putOrdersPiecesBatchStatus(PieceBatchStatus entity, Map<String, String> okapiHeaders,
+                                         Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    pieceUpdateFlowManager.updatePiecesStatuses(entity.getPieceIds(), entity.getReceivingStatus(), new RequestContext(vertxContext, okapiHeaders))
+      .onSuccess(v -> asyncResultHandler.handle(succeededFuture(buildNoContentResponse())))
+      .onFailure(t -> handleErrorResponse(asyncResultHandler, t));
+  }
 }

--- a/src/main/java/org/folio/rest/impl/PiecesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PiecesAPI.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Piece;
-import org.folio.rest.jaxrs.model.PieceBatchStatus;
+import org.folio.rest.jaxrs.model.PieceBatchStatusCollection;
 import org.folio.rest.jaxrs.resource.OrdersPieces;
 import org.folio.rest.jaxrs.resource.OrdersPiecesRequests;
 import org.folio.service.CirculationRequestsRetriever;
@@ -63,9 +63,8 @@ public class PiecesAPI extends BaseApi implements OrdersPieces, OrdersPiecesRequ
                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     pieceCreateFlowManager.createPiece(entity, createItem, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(piece -> {
-        if (logger.isInfoEnabled()) {
-          logger.debug("Successfully created piece: {}", JsonObject.mapFrom(piece)
-            .encodePrettily());
+        if (logger.isDebugEnabled()) {
+          logger.debug("Successfully created piece: {}", JsonObject.mapFrom(piece).encodePrettily());
         }
         asyncResultHandler.handle(succeededFuture(buildCreatedResponse(piece)));
       })
@@ -112,9 +111,9 @@ public class PiecesAPI extends BaseApi implements OrdersPieces, OrdersPiecesRequ
   }
 
   @Override
-  public void putOrdersPiecesBatchStatus(PieceBatchStatus entity, Map<String, String> okapiHeaders,
+  public void putOrdersPiecesBatchStatus(PieceBatchStatusCollection pieceBatchStatusCollection, Map<String, String> okapiHeaders,
                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    pieceUpdateFlowManager.updatePiecesStatuses(entity.getPieceIds(), entity.getReceivingStatus(), new RequestContext(vertxContext, okapiHeaders))
+    pieceUpdateFlowManager.updatePiecesStatuses(pieceBatchStatusCollection.getPieceIds(), pieceBatchStatusCollection.getReceivingStatus(), new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(v -> asyncResultHandler.handle(succeededFuture(buildNoContentResponse())))
       .onFailure(t -> handleErrorResponse(asyncResultHandler, t));
   }

--- a/src/main/java/org/folio/rest/impl/PiecesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PiecesAPI.java
@@ -15,6 +15,7 @@ import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PieceBatchStatusCollection;
 import org.folio.rest.jaxrs.resource.OrdersPieces;
+import org.folio.rest.jaxrs.resource.OrdersPiecesBatch;
 import org.folio.rest.jaxrs.resource.OrdersPiecesRequests;
 import org.folio.service.CirculationRequestsRetriever;
 import org.folio.service.pieces.PieceStorageService;
@@ -30,7 +31,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
-public class PiecesAPI extends BaseApi implements OrdersPieces, OrdersPiecesRequests {
+public class PiecesAPI extends BaseApi implements OrdersPieces, OrdersPiecesRequests, OrdersPiecesBatch {
 
   private static final Logger logger = LogManager.getLogger();
   @Autowired

--- a/src/main/java/org/folio/service/pieces/PieceService.java
+++ b/src/main/java/org/folio/service/pieces/PieceService.java
@@ -1,14 +1,13 @@
 package org.folio.service.pieces;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.extern.log4j.Log4j2;
 import org.folio.orders.events.handlers.MessageAddress;
 import org.folio.rest.core.models.RequestContext;
 
-import io.vertx.core.json.JsonObject;
+import static org.folio.orders.events.utils.EventUtils.createPoLineUpdateEvent;
 
+@Log4j2
 public class PieceService {
-  private static final Logger logger = LogManager.getLogger(PieceService.class);
 
   private final PieceChangeReceiptStatusPublisher receiptStatusPublisher;
 
@@ -16,11 +15,10 @@ public class PieceService {
     this.receiptStatusPublisher = receiptStatusPublisher;
   }
 
-  public void receiptConsistencyPiecePoLine(JsonObject jsonObj, RequestContext requestContext) {
-    logger.debug("Sending event to verify receipt status");
-
-    receiptStatusPublisher.sendEvent(MessageAddress.RECEIPT_STATUS, jsonObj, requestContext);
-
-    logger.debug("Event to verify receipt status - sent");
+  public void receiptConsistencyPiecePoLine(String poLineId, RequestContext requestContext) {
+    log.debug("Sending event to verify receipt status for poLineId: {}", poLineId);
+    receiptStatusPublisher.sendEvent(MessageAddress.RECEIPT_STATUS, createPoLineUpdateEvent(poLineId), requestContext);
+    log.debug("Event to verify receipt status is sent for poLineId: {}", poLineId);
   }
+
 }

--- a/src/main/java/org/folio/service/pieces/PieceUtil.java
+++ b/src/main/java/org/folio/service/pieces/PieceUtil.java
@@ -2,6 +2,7 @@ package org.folio.service.pieces;
 
 import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.OTHER;
 
+import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,17 @@ public class PieceUtil {
   }
 
   private static boolean isLocationMatch(Piece piece, Location loc) {
-    return (Objects.nonNull(piece.getLocationId()) && piece.getLocationId().equals(loc.getLocationId())) ||
-                      (Objects.nonNull(piece.getHoldingId()) && piece.getHoldingId().equals(loc.getHoldingId()));
+    return (Objects.nonNull(piece.getLocationId()) && piece.getLocationId().equals(loc.getLocationId()))
+      || (Objects.nonNull(piece.getHoldingId()) && piece.getHoldingId().equals(loc.getHoldingId()));
   }
+
+  public static boolean updatePieceStatus(Piece piece, Piece.ReceivingStatus oldStatus, Piece.ReceivingStatus newStatus) {
+    var isStatusChanged = !oldStatus.equals(newStatus);
+    if (isStatusChanged) {
+      piece.setStatusUpdatedDate(new Date());
+    }
+    piece.setReceivingStatus(newStatus);
+    return isStatusChanged;
+  }
+
 }

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -106,6 +106,8 @@ public class PieceUpdateFlowManager {
           .compose(v -> updatePiecesStatusesByPoLine(holder, requestContext)))
         .toList())
       .compose(HelperUtils::collectResultsOnSuccess)
+      .onSuccess(v -> log.info("Pieces statuses are updated for pieceIds: {} to status: {}", pieceIds, receivingStatus))
+      .onFailure(t -> log.error("Failed to update pieces statuses for pieceIds: {} to status: {}", pieceIds, receivingStatus, t))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -120,7 +120,7 @@ public class PieceUpdateFlowManager {
     return updatePoLine(holder, holder.getPieces(), requestContext);
   }
 
-  protected <T extends BasePieceFlowHolder> Future<Void> updatePoLine(T holder, List<Piece> piecesToUpdate, RequestContext requestContext) {
+  private <T extends BasePieceFlowHolder> Future<Void> updatePoLine(T holder, List<Piece> piecesToUpdate, RequestContext requestContext) {
     var originPurchaseOrder = holder.getOriginPurchaseOrder();
     if (originPurchaseOrder.getOrderType() != OrderType.ONE_TIME || originPurchaseOrder.getWorkflowStatus() != WorkflowStatus.OPEN) {
       return Future.succeededFuture();
@@ -167,7 +167,7 @@ public class PieceUpdateFlowManager {
     return titlesService.getTitlesByPieceIds(pieceIds, requestContext)
       .map(titles -> titles.stream()
         .map(title -> protectionService.isOperationRestricted(title.getAcqUnitIds(), ProtectedOperationType.UPDATE, requestContext))
-        .collect(Collectors.toList()))
+        .toList())
       .map(GenericCompositeFuture::all)
       .map(pieces);
   }

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -19,7 +19,7 @@ import org.folio.rest.jaxrs.model.CompositePurchaseOrder.OrderType;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Piece;
-import org.folio.rest.jaxrs.model.PieceBatchStatus;
+import org.folio.rest.jaxrs.model.PieceBatchStatusCollection;
 import org.folio.service.ProtectionService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.pieces.PieceService;
@@ -89,7 +89,7 @@ public class PieceUpdateFlowManager {
       .mapEmpty();
   }
 
-  public Future<Void> updatePiecesStatuses(List<String> pieceIds, PieceBatchStatus.ReceivingStatus receivingStatus, RequestContext requestContext) {
+  public Future<Void> updatePiecesStatuses(List<String> pieceIds, PieceBatchStatusCollection.ReceivingStatus receivingStatus, RequestContext requestContext) {
     var newStatus = Piece.ReceivingStatus.fromValue(receivingStatus.value());
     return pieceStorageService.getPiecesByIds(pieceIds, requestContext)
       .map(pieces -> pieces.stream().collect(Collectors.groupingBy(Piece::getPoLineId)))

--- a/src/test/java/org/folio/orders/events/handlers/HandlersTestHelper.java
+++ b/src/test/java/org/folio/orders/events/handlers/HandlersTestHelper.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.folio.helper.BaseHelper.EVENT_PAYLOAD;
+import static org.folio.orders.events.utils.EventUtils.POL_UPDATE_FIELD;
 import static org.folio.rest.impl.EventBusContextConfiguration.eventMessages;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,7 +72,7 @@ public class HandlersTestHelper {
       assertThat(message.headers(), not(emptyIterable()));
       assertThat(message.body(), notNullValue());
       assertThat(message.body()
-        .getString("poLineIdUpdate"), not(is(emptyOrNullString())));
+        .getString(POL_UPDATE_FIELD), not(is(emptyOrNullString())));
       assertThat(message.body()
         .getString(HelperUtils.LANG), not(is(emptyOrNullString())));
     }

--- a/src/test/java/org/folio/orders/events/handlers/ReceiptStatusConsistencyTest.java
+++ b/src/test/java/org/folio/orders/events/handlers/ReceiptStatusConsistencyTest.java
@@ -5,6 +5,7 @@ import static org.folio.TestConfig.clearServiceInteractions;
 import static org.folio.TestConfig.isVerticleNotDeployed;
 import static org.folio.TestUtils.checkVertxContextCompletion;
 import static org.folio.TestUtils.getMockAsJson;
+import static org.folio.orders.events.utils.EventUtils.POL_UPDATE_FIELD;
 import static org.folio.rest.impl.MockServer.POLINES_COLLECTION;
 import static org.folio.rest.impl.MockServer.PO_LINES_MOCK_DATA_PATH;
 import static org.folio.rest.impl.MockServer.getPieceSearches;
@@ -227,7 +228,7 @@ public class ReceiptStatusConsistencyTest {
 
   private JsonObject createBody(String poLineId) {
     JsonObject jsonObj = new JsonObject();
-    jsonObj.put("poLineIdUpdate",  poLineId);
+    jsonObj.put(POL_UPDATE_FIELD,  poLineId);
     return jsonObj;
   }
 

--- a/src/test/java/org/folio/orders/events/handlers/ReceiptStatusConsistencyTest.java
+++ b/src/test/java/org/folio/orders/events/handlers/ReceiptStatusConsistencyTest.java
@@ -33,6 +33,7 @@ import org.folio.rest.acq.model.PoLine.ReceiptStatus;
 import org.folio.rest.impl.MockServer;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.service.orders.PurchaseOrderLineService;
+import org.folio.service.pieces.PieceStorageService;
 import org.folio.spring.SpringContextUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -67,6 +68,8 @@ public class ReceiptStatusConsistencyTest {
 
   @Autowired
   private PurchaseOrderLineService purchaseOrderLineService;
+  @Autowired
+  private PieceStorageService pieceStorageService;
 
   @BeforeAll
   static void before() throws InterruptedException, ExecutionException, TimeoutException {
@@ -82,7 +85,7 @@ public class ReceiptStatusConsistencyTest {
   @BeforeEach
   void setUp() {
     SpringContextUtil.autowireDependencies(this, vertx.getOrCreateContext());
-    vertx.eventBus().consumer(TEST_ADDRESS, new ReceiptStatusConsistency(vertx, purchaseOrderLineService));
+    vertx.eventBus().consumer(TEST_ADDRESS, new ReceiptStatusConsistency(vertx, pieceStorageService, purchaseOrderLineService));
   }
 
   @AfterEach

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
@@ -59,6 +59,7 @@ import org.folio.service.pieces.PieceStorageService;
 import org.folio.service.pieces.PieceUtil;
 import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
 import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
+import org.folio.service.titles.TitlesService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -397,6 +398,9 @@ public class PieceUpdateFlowManagerTest {
     @Bean PieceService pieceService() {
       return mock(PieceService.class);
     }
+    @Bean TitlesService titlesService() {
+      return mock(TitlesService.class);
+    }
     @Bean PieceUpdateFlowInventoryManager pieceUpdateFlowInventoryManager() {
       return mock(PieceUpdateFlowInventoryManager.class);
     }
@@ -423,11 +427,11 @@ public class PieceUpdateFlowManagerTest {
     }
 
     @Bean
-    PieceUpdateFlowManager pieceUpdateFlowManager(PieceStorageService pieceStorageService, PieceService pieceService,
+    PieceUpdateFlowManager pieceUpdateFlowManager(PieceStorageService pieceStorageService, PieceService pieceService, TitlesService titlesService,
                                                   ProtectionService protectionService, PieceUpdateFlowPoLineService pieceUpdateFlowPoLineService,
                                                   PieceUpdateFlowInventoryManager pieceUpdateFlowInventoryManager, BasePieceFlowHolderBuilder basePieceFlowHolderBuilder,
                                                   DefaultPieceFlowsValidator defaultPieceFlowsValidator, PurchaseOrderLineService purchaseOrderLineService) {
-      return new PieceUpdateFlowManager(pieceStorageService, pieceService, protectionService,
+      return new PieceUpdateFlowManager(pieceStorageService, pieceService, titlesService, protectionService,
         pieceUpdateFlowPoLineService, pieceUpdateFlowInventoryManager, basePieceFlowHolderBuilder,
         defaultPieceFlowsValidator, purchaseOrderLineService);
     }

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
@@ -331,7 +331,7 @@ public class PieceUpdateFlowManagerTest {
     var receiptStatus = calculatePoLineReceiptStatus(poLineId, fromStorage, update);
 
     // then
-    assertEquals(CompositePoLine.ReceiptStatus.FULLY_RECEIVED, receiptStatus);
+    assertEquals(PoLine.ReceiptStatus.FULLY_RECEIVED, receiptStatus);
   }
 
   @Test
@@ -345,7 +345,7 @@ public class PieceUpdateFlowManagerTest {
     var receiptStatus = calculatePoLineReceiptStatus(poLineId, fromStorage, update);
 
     // then
-    assertEquals(CompositePoLine.ReceiptStatus.PARTIALLY_RECEIVED, receiptStatus);
+    assertEquals(PoLine.ReceiptStatus.PARTIALLY_RECEIVED, receiptStatus);
   }
 
   @Test
@@ -359,7 +359,7 @@ public class PieceUpdateFlowManagerTest {
     var receiptStatus = calculatePoLineReceiptStatus(poLineId, fromStorage, update);
 
     // then
-    assertEquals(CompositePoLine.ReceiptStatus.AWAITING_RECEIPT, receiptStatus);
+    assertEquals(PoLine.ReceiptStatus.AWAITING_RECEIPT, receiptStatus);
   }
 
   @Test
@@ -373,7 +373,7 @@ public class PieceUpdateFlowManagerTest {
     var receiptStatus = calculatePoLineReceiptStatus(poLineId, fromStorage, update);
 
     // then
-    assertEquals(CompositePoLine.ReceiptStatus.PARTIALLY_RECEIVED, receiptStatus);
+    assertEquals(PoLine.ReceiptStatus.PARTIALLY_RECEIVED, receiptStatus);
   }
 
   private static List<Piece> givenPieces(Piece.ReceivingStatus... statuses) {


### PR DESCRIPTION
## Purpose
[[MODORDERS-1210] Implement API to change piece statuses in batch](https://folio-org.atlassian.net/browse/MODORDERS-1210)]

## Approach
- Minor refactoring of existing classes
- Add new endpoint
- Add status update method to PieceUpdateFlowManager
- Updated unit tests
- Added new unit tests
- Updated module descriptor

## Verification
![image](https://github.com/user-attachments/assets/297f5426-df38-479b-b985-e84240a9b206)
![image](https://github.com/user-attachments/assets/2209e50a-af03-4a2c-a360-a1e963677ff1)
![image](https://github.com/user-attachments/assets/83aca2d0-b3f5-4ea9-9df7-cd355f31b598)
![image](https://github.com/user-attachments/assets/f690319b-d0ce-4a94-a8b4-a7e3537320d8)