### PR TITLE
[MODORDERS-1210] Improve validation for piece batch status update

### DIFF
--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -173,7 +173,7 @@ public class PieceUpdateFlowManager {
     var isAnyPiecesUpdated = holder.getPieces().stream()
       .map(piece -> updatePieceStatus(piece, piece.getReceivingStatus(), holder.getReceivingStatus()))
       .reduce(Boolean.FALSE, Boolean::logicalOr); // Don't replace .map() with .anyMatch(), as it needs to iterate over all elements
-    if (!isAnyPiecesUpdated) {
+    if (!Boolean.TRUE.equals(isAnyPiecesUpdated)) {
       return Future.succeededFuture();
     }
     var updates = holder.getPieces().stream().map(piece -> pieceStorageService.updatePiece(piece, requestContext)).toList();


### PR DESCRIPTION
## Purpose
[[MODORDERS-1210] Implement API to change piece statuses in batch](https://folio-org.atlassian.net/browse/MODORDERS-1210)

## Approach
- First validate operation restriction to avoid unnecessary API call
- Add fetched piece quantity validation
- Changed error response in case piece is not found
```
{
  "errors": [
    {
      "message": "The piece record is not found",
      "code": "pieceNotFound",
      "parameters": [
        {
          "key": "pieceIds",
          "value": "[479b2177-3dc8-46aa-8cbc-81d0a1456242]"
        }
      ]
    }
  ],
  "total_records": 1
}
```