### PR TITLE
[EUREKA-561-4]. Add validateUserUnaffiliatedLocationUpdates method to Order Open/unopen

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -712,14 +712,14 @@ public class ApplicationConfig {
     ProtectionService protectionService, InventoryItemStatusSyncService itemStatusSyncService,
     OpenCompositeOrderManager openCompositeOrderManager, PurchaseOrderStorageService purchaseOrderStorageService,
     ConfigurationEntriesCache configurationEntriesCache, PoNumberHelper poNumberHelper,
-    OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator,
-    ReOpenCompositeOrderManager reOpenCompositeOrderManager, OrderValidationService orderValidationService) {
+    OpenCompositeOrderFlowValidator openCompositeOrderFlowValidator, ReOpenCompositeOrderManager reOpenCompositeOrderManager,
+    OrderValidationService orderValidationService, CompositePoLineValidationService compositePoLineValidationService) {
     return new PurchaseOrderHelper(purchaseOrderLineHelper, orderLinesSummaryPopulateService, encumbranceService,
       combinedPopulateService, encumbranceWorkflowStrategyFactory, orderInvoiceRelationService, tagService,
       purchaseOrderLineService, titlesService, protectionService, itemStatusSyncService,
       openCompositeOrderManager, purchaseOrderStorageService, configurationEntriesCache,
       poNumberHelper, openCompositeOrderFlowValidator, reOpenCompositeOrderManager,
-      orderValidationService);
+      orderValidationService, compositePoLineValidationService);
   }
 
   @Bean
@@ -746,18 +746,18 @@ public class ApplicationConfig {
                                                   PurchaseOrderStorageService purchaseOrderStorageService,
                                                   RestClient restClient,
                                                   CompositePoLineValidationService compositePoLineValidationService,
-                                                  POLInvoiceLineRelationService polInvoiceLineRelationService,
-                                                  OrganizationService organizationService,
-                                                  ConsortiumConfigurationService consortiumConfigurationService,
-                                                  ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever) {
+                                                  OrganizationService organizationService) {
     return new PurchaseOrderLineHelper(itemStatusSyncService, inventoryInstanceManager, encumbranceService, expenseClassValidationService,
       encumbranceWorkflowStrategyFactory, orderInvoiceRelationService, titlesService, protectionService,
       purchaseOrderLineService, purchaseOrderStorageService, restClient, compositePoLineValidationService,
-      organizationService, consortiumConfigurationService, consortiumUserTenantsRetriever);
+      organizationService);
   }
 
-  @Bean CompositePoLineValidationService compositePoLineValidationService(ExpenseClassValidationService expenseClassValidationService) {
-    return new CompositePoLineValidationService(expenseClassValidationService);
+  @Bean
+  CompositePoLineValidationService compositePoLineValidationService(ExpenseClassValidationService expenseClassValidationService,
+                                                                    ConsortiumConfigurationService consortiumConfigurationService,
+                                                                    ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever) {
+    return new CompositePoLineValidationService(expenseClassValidationService, consortiumConfigurationService, consortiumUserTenantsRetriever);
   }
 
   @Bean TitleValidationService titleValidationService() {

--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -238,8 +238,8 @@ public class PurchaseOrderHelper {
             if (!compPO.getCompositePoLines().isEmpty()) {
               compPO.getCompositePoLines().forEach(poLine -> {
                 var compPoLineFromStorage = clonedPoFromStorage.getCompositePoLines().stream()
-                  .filter(Objects::nonNull).filter(entry-> Objects.nonNull(entry.getId()))
-                  .filter(entry -> entry.getId().equals(poLine.getId())).findFirst().orElse(null);
+                  .filter(entry -> StringUtils.equals(entry.getId(), poLine.getId()))
+                  .findFirst().orElse(null);
                 if (Objects.nonNull(compPoLineFromStorage)) {
                   var updatedLocations = poLine.getLocations();
                   var storedLocations = compPoLineFromStorage.getLocations();

--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -239,11 +239,11 @@ public class PurchaseOrderHelper {
               compPO.getCompositePoLines().forEach(poLine -> {
                 var compPoLineFromStorage = clonedPoFromStorage.getCompositePoLines().stream()
                   .filter(Objects::nonNull).filter(entry-> Objects.nonNull(entry.getId()))
-                  .filter(entry -> entry.getId().equals(poLine.getId()))
-                  .findFirst().orElse(null);
+                  .filter(entry -> entry.getId().equals(poLine.getId())).findFirst().orElse(null);
                 if (Objects.nonNull(compPoLineFromStorage)) {
-                  var poLineFromStorage = PoLineCommonUtil.convertToPoLine(compPoLineFromStorage);
-                  poLineFutures.add(compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(poLine, poLineFromStorage, requestContext));
+                  var updatedLocations = poLine.getLocations();
+                  var storedLocations = compPoLineFromStorage.getLocations();
+                  poLineFutures.add(compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(poLine.getId(), updatedLocations, storedLocations, requestContext));
                 }
               });
             }

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -278,7 +278,7 @@ public class PurchaseOrderLineHelper {
         .compose(compOrder -> protectionService.isOperationRestricted(compOrder.getAcqUnitIds(), UPDATE, requestContext)
           .compose(v -> purchaseOrderLineService.validateAndNormalizeISBNAndProductType(Collections.singletonList(compOrderLine), requestContext))
           .compose(v -> validateAccessProviders(compOrderLine, requestContext))
-          .compose(v -> compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(compOrderLine, poLineFromStorage, requestContext))
+          .compose(v -> compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(compOrderLine.getId(), compOrderLine.getLocations(), poLineFromStorage.getLocations(), requestContext))
           .compose(v -> expenseClassValidationService.validateExpenseClassesForOpenedOrder(compOrder, Collections.singletonList(compOrderLine), requestContext))
           .compose(v -> processPoLineEncumbrances(compOrder, compOrderLine, poLineFromStorage, requestContext)))
         .map(v -> compOrderLine.withPoLineNumber(poLineFromStorage.getPoLineNumber())) // PoLine number must not be modified during PoLine update, set original value

--- a/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
@@ -345,16 +345,16 @@ public class CompositePoLineValidationService extends BaseValidationService {
     }
   }
 
-  public Future<Void> validateUserUnaffiliatedLocationUpdates(String poLineId, List<Location> updatedPoLineLoc,
-                                                              List<Location> storedPoLineLoc, RequestContext requestContext) {
+  public Future<Void> validateUserUnaffiliatedLocationUpdates(String poLineId, List<Location> updatedPoLineLocations,
+                                                              List<Location> storedPoLineLocations, RequestContext requestContext) {
     return getUserTenantsIfNeeded(requestContext)
       .compose(userTenants -> {
         if (CollectionUtils.isEmpty(userTenants)) {
           logger.info("validateUserUnaffiliatedLocationUpdates:: User tenants is empty");
           return Future.succeededFuture();
         }
-        var storageUnaffiliatedLocations = extractUnaffiliatedLocations(storedPoLineLoc, userTenants);
-        var updatedUnaffiliatedLocations = extractUnaffiliatedLocations(updatedPoLineLoc, userTenants);
+        var storageUnaffiliatedLocations = extractUnaffiliatedLocations(storedPoLineLocations, userTenants);
+        var updatedUnaffiliatedLocations = extractUnaffiliatedLocations(updatedPoLineLocations, userTenants);
         logger.info("validateUserUnaffiliatedLocationUpdates:: Found unaffiliated POL location tenant ids, poLineId: '{}', stored: '{}', updated: '{}'",
           poLineId,
           storageUnaffiliatedLocations.stream().map(Location::getTenantId).distinct().toList(),

--- a/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
@@ -345,26 +345,27 @@ public class CompositePoLineValidationService extends BaseValidationService {
     }
   }
 
-  public Future<Void> validateUserUnaffiliatedLocationUpdates(CompositePoLine updatedPoLine, PoLine storedPoLine, RequestContext requestContext) {
+  public Future<Void> validateUserUnaffiliatedLocationUpdates(String poLineId, List<Location> updatedPoLineLoc,
+                                                              List<Location> storedPoLineLoc, RequestContext requestContext) {
     return getUserTenantsIfNeeded(requestContext)
       .compose(userTenants -> {
         if (CollectionUtils.isEmpty(userTenants)) {
           logger.info("validateUserUnaffiliatedLocationUpdates:: User tenants is empty");
           return Future.succeededFuture();
         }
-        var storageUnaffiliatedLocations = extractUnaffiliatedLocations(storedPoLine.getLocations(), userTenants);
-        var updatedUnaffiliatedLocations = extractUnaffiliatedLocations(updatedPoLine.getLocations(), userTenants);
+        var storageUnaffiliatedLocations = extractUnaffiliatedLocations(storedPoLineLoc, userTenants);
+        var updatedUnaffiliatedLocations = extractUnaffiliatedLocations(updatedPoLineLoc, userTenants);
         logger.info("validateUserUnaffiliatedLocationUpdates:: Found unaffiliated POL location tenant ids, poLineId: '{}', stored: '{}', updated: '{}'",
-          updatedPoLine.getId(),
+          poLineId,
           storageUnaffiliatedLocations.stream().map(Location::getTenantId).distinct().toList(),
           updatedUnaffiliatedLocations.stream().map(Location::getTenantId).distinct().toList());
         if (!SetUtils.isEqualSet(storageUnaffiliatedLocations, updatedUnaffiliatedLocations)) {
           logger.info("validateUserUnaffiliatedLocationUpdates:: User is not affiliated with all locations on the POL, poLineId: '{}'",
-            updatedPoLine.getId());
+            poLineId);
           return Future.failedFuture(new HttpException(422, ErrorCodes.LOCATION_UPDATE_WITHOUT_AFFILIATION));
         }
         logger.info("validateUserUnaffiliatedLocationUpdates:: User is affiliated with all locations on the POL, poLineId: '{}'",
-          updatedPoLine.getId());
+          poLineId);
         return Future.succeededFuture();
       });
   }

--- a/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
+++ b/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
@@ -46,6 +47,7 @@ import org.folio.service.finance.transaction.EncumbranceService;
 import org.folio.service.inventory.InventoryItemStatusSyncService;
 import org.folio.service.invoice.InvoiceLineService;
 import org.folio.service.orders.CompositeOrderDynamicDataPopulateService;
+import org.folio.service.orders.CompositePoLineValidationService;
 import org.folio.service.orders.OrderInvoiceRelationService;
 import org.folio.service.orders.OrderValidationService;
 import org.folio.service.orders.PurchaseOrderLineService;
@@ -100,6 +102,8 @@ public class PurchaseOrderHelperTest {
   ConfigurationEntriesCache configurationEntriesCache;
   @Mock
   OrderValidationService orderValidationService;
+  @Mock
+  CompositePoLineValidationService compositePoLineValidationService;
 
   @BeforeEach
   void beforeEach() {
@@ -175,6 +179,7 @@ public class PurchaseOrderHelperTest {
     CompositePurchaseOrder compPO = order.mapTo(CompositePurchaseOrder.class);
     prepareOrderForPostRequest(compPO);
     compPO.setId(UUID.randomUUID().toString());
+    compPO.getCompositePoLines().forEach(line -> line.withId(UUID.randomUUID().toString()));
     CompositePurchaseOrder poFromStorage = JsonObject.mapFrom(compPO).mapTo(CompositePurchaseOrder.class);
 
     boolean deleteHoldings = false;
@@ -195,6 +200,8 @@ public class PurchaseOrderHelperTest {
       .when(purchaseOrderStorageService).saveOrder(any(PurchaseOrder.class), eq(requestContext));
     doReturn(succeededFuture(null))
       .when(encumbranceService).updateEncumbrancesOrderStatusAndReleaseIfClosed(any(CompositePurchaseOrder.class), eq(requestContext));
+    doReturn(succeededFuture(null))
+      .when(compositePoLineValidationService).validateUserUnaffiliatedLocationUpdates(anyString(), any(), any(), eq(requestContext));
 
     // When
     Future<Void> future = purchaseOrderHelper.putCompositeOrderById(compPO.getId(), deleteHoldings, compPO, requestContext);

--- a/src/test/java/org/folio/helper/PurchaseOrderLineHelperTest.java
+++ b/src/test/java/org/folio/helper/PurchaseOrderLineHelperTest.java
@@ -3,11 +3,7 @@ package org.folio.helper;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Optional;
 import java.util.stream.Stream;
-
-import org.folio.models.consortium.ConsortiumConfiguration;
 import org.folio.rest.acq.model.SequenceNumbers;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.exceptions.HttpException;
@@ -19,8 +15,6 @@ import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.ReportingCode;
-import org.folio.service.consortium.ConsortiumConfigurationService;
-import org.folio.service.consortium.ConsortiumUserTenantsRetriever;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,13 +33,9 @@ import java.util.UUID;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.TestUtils.callPrivateMethod;
-import static org.folio.TestUtils.getLocationsForTenants;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -56,10 +46,6 @@ public class PurchaseOrderLineHelperTest {
   private PurchaseOrderLineHelper purchaseOrderLineHelper;
   @Mock
   private PurchaseOrderLineService purchaseOrderLineService;
-  @Mock
-  private ConsortiumConfigurationService consortiumConfigurationService;
-  @Mock
-  private ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever;
   @Mock
   private RequestContext requestContext;
   @Mock
@@ -192,49 +178,4 @@ public class PurchaseOrderLineHelperTest {
     var newCost = new Cost().withCurrency(currencyCode).withExchangeRate(oldExchangeRate);
     assertEquals(expected, PurchaseOrderLineHelper.hasAlteredExchangeRate(oldCost, newCost));
   }
-
-  @Test
-  void testValidateUserUnaffiliatedLocationUpdates() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    var locationsStored = getLocationsForTenants(List.of("tenant1", "tenant2", "tenant3"));
-    var locationsUpdated = getLocationsForTenants(List.of("tenant1", "tenant3"));
-    var storagePoLine = new PoLine().withLocations(locationsStored);
-    var updatedPoLine = new CompositePoLine().withLocations(locationsUpdated);
-
-    doReturn(succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))))
-      .when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
-    doReturn(succeededFuture(List.of("tenant1", "tenant2")))
-      .when(consortiumUserTenantsRetriever).getUserTenants(eq("consortiumId"), eq("centralTenantId"), any(RequestContext.class));
-
-    var future = callValidateUserUnaffiliatedLocationUpdates(updatedPoLine, storagePoLine, requestContext, purchaseOrderLineHelper);
-
-    assertTrue(future.succeeded());
-  }
-
-  @Test
-  void testValidateUserUnaffiliatedLocationUpdatesInvalid() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    var locationsStored = getLocationsForTenants(List.of("tenant1", "tenant2", "tenant3"));
-    var locationsUpdated = getLocationsForTenants(List.of("tenant1", "tenant3"));
-    locationsUpdated.get(1).withQuantityPhysical(10);
-    var storagePoLine = new PoLine().withLocations(locationsStored);
-    var updatedPoLine = new CompositePoLine().withLocations(locationsUpdated);
-
-    doReturn(succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))))
-      .when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
-    doReturn(succeededFuture(List.of("tenant1")))
-      .when(consortiumUserTenantsRetriever).getUserTenants(eq("consortiumId"), anyString(), any(RequestContext.class));
-
-    var future = callValidateUserUnaffiliatedLocationUpdates(updatedPoLine, storagePoLine, requestContext, purchaseOrderLineHelper);
-
-    assertTrue(future.failed());
-    assertInstanceOf(HttpException.class, future.cause());
-  }
-
-  private Future<Void> callValidateUserUnaffiliatedLocationUpdates(CompositePoLine updatedPoLine, PoLine storagePoLine,
-                                                                   RequestContext requestContext, PurchaseOrderLineHelper purchaseOrderLineHelper)
-    throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-
-    return callPrivateMethod(purchaseOrderLineHelper, "validateUserUnaffiliatedLocationUpdates", Future.class,
-      new Class[]{ CompositePoLine.class, PoLine.class, RequestContext.class }, new Object[] { updatedPoLine, storagePoLine, requestContext });
-  }
-
 }

--- a/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
+++ b/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
@@ -408,7 +408,7 @@ public class CompositePoLineValidationServiceTest {
   }
 
   @Test
-  void testValidateUserUnaffiliatedLocationUpdatesInvalid() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+  void testValidateUserUnaffiliatedLocationUpdatesInvalid() {
     var locationsStored = getLocationsForTenants(List.of("tenant1", "tenant2", "tenant3"));
     var locationsUpdated = getLocationsForTenants(List.of("tenant1", "tenant3"));
     locationsUpdated.get(1).withQuantityPhysical(10);

--- a/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
+++ b/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
@@ -402,7 +402,7 @@ public class CompositePoLineValidationServiceTest {
     doReturn(succeededFuture(List.of("tenant1", "tenant2")))
       .when(consortiumUserTenantsRetriever).getUserTenants(eq("consortiumId"), eq("centralTenantId"), any(RequestContext.class));
 
-    var future =  compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(updatedPoLine, storagePoLine, requestContext);
+    var future = compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(updatedPoLine.getId(), updatedPoLine.getLocations(), storagePoLine.getLocations(), requestContext);
 
     assertTrue(future.succeeded());
   }
@@ -420,7 +420,7 @@ public class CompositePoLineValidationServiceTest {
     doReturn(succeededFuture(List.of("tenant1")))
       .when(consortiumUserTenantsRetriever).getUserTenants(eq("consortiumId"), anyString(), any(RequestContext.class));
 
-    var future =  compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(updatedPoLine, storagePoLine, requestContext);
+    var future = compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(updatedPoLine.getId(), updatedPoLine.getLocations(), storagePoLine.getLocations(), requestContext);
 
     assertTrue(future.failed());
     assertInstanceOf(HttpException.class, future.cause());

--- a/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
+++ b/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
@@ -1,6 +1,7 @@
 package org.folio.service.orders;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.TestUtils.getLocationsForTenants;
 import static org.folio.rest.core.exceptions.ErrorCodes.*;
 import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.OTHER;
 import static org.folio.rest.jaxrs.model.CompositePoLine.OrderFormat.P_E_MIX;
@@ -8,18 +9,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Future;
+import org.folio.models.consortium.ConsortiumConfiguration;
 import org.folio.rest.core.exceptions.ErrorCodes;
+import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.Cost;
@@ -27,6 +35,9 @@ import org.folio.rest.jaxrs.model.Details;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Physical;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.service.consortium.ConsortiumConfigurationService;
+import org.folio.service.consortium.ConsortiumUserTenantsRetriever;
 import org.folio.service.finance.expenceclass.ExpenseClassValidationService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +51,10 @@ public class CompositePoLineValidationServiceTest {
   private AutoCloseable mockitoMocks;
   @Mock
   private ExpenseClassValidationService expenseClassValidationService;
+  @Mock
+  private ConsortiumConfigurationService consortiumConfigurationService;
+  @Mock
+  private ConsortiumUserTenantsRetriever consortiumUserTenantsRetriever;
   @InjectMocks
   private CompositePoLineValidationService compositePoLineValidationService;
   @Mock
@@ -367,10 +382,47 @@ public class CompositePoLineValidationServiceTest {
     assertThat(errors, hasSize(0));
   }
 
+
   private Set<String> errorsToCodes(List<Error> errors) {
     return errors
       .stream()
       .map(Error::getCode)
       .collect(Collectors.toSet());
+  }
+
+  @Test
+  void testValidateUserUnaffiliatedLocationUpdates() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    var locationsStored = getLocationsForTenants(List.of("tenant1", "tenant2", "tenant3"));
+    var locationsUpdated = getLocationsForTenants(List.of("tenant1", "tenant3"));
+    var storagePoLine = new PoLine().withLocations(locationsStored);
+    var updatedPoLine = new CompositePoLine().withLocations(locationsUpdated);
+
+    doReturn(succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))))
+      .when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
+    doReturn(succeededFuture(List.of("tenant1", "tenant2")))
+      .when(consortiumUserTenantsRetriever).getUserTenants(eq("consortiumId"), eq("centralTenantId"), any(RequestContext.class));
+
+    var future =  compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(updatedPoLine, storagePoLine, requestContext);
+
+    assertTrue(future.succeeded());
+  }
+
+  @Test
+  void testValidateUserUnaffiliatedLocationUpdatesInvalid() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    var locationsStored = getLocationsForTenants(List.of("tenant1", "tenant2", "tenant3"));
+    var locationsUpdated = getLocationsForTenants(List.of("tenant1", "tenant3"));
+    locationsUpdated.get(1).withQuantityPhysical(10);
+    var storagePoLine = new PoLine().withLocations(locationsStored);
+    var updatedPoLine = new CompositePoLine().withLocations(locationsUpdated);
+
+    doReturn(succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))))
+      .when(consortiumConfigurationService).getConsortiumConfiguration(any(RequestContext.class));
+    doReturn(succeededFuture(List.of("tenant1")))
+      .when(consortiumUserTenantsRetriever).getUserTenants(eq("consortiumId"), anyString(), any(RequestContext.class));
+
+    var future =  compositePoLineValidationService.validateUserUnaffiliatedLocationUpdates(updatedPoLine, storagePoLine, requestContext);
+
+    assertTrue(future.failed());
+    assertInstanceOf(HttpException.class, future.cause());
   }
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/EUREKA-561>

## Approach

- Add `validateUserUnaffiliatedLocationUpdates` to `updateOrder` method to guard against unaffiliated order opening/unopening
- Tested with Karate tests against a mod-orders modules: 

![image](https://github.com/user-attachments/assets/f00862dd-7721-4448-9147-e785732a0bf4)

