### PR TITLE
[MODORDERS-1222] - Error when trying to Unopen an ongoing order to add a purchase order line with multiple funds

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -213,8 +213,7 @@ public class PurchaseOrderHelper {
         }
         return null;
       }).compose(v -> updateOrder(compPO, deleteHoldings, requestContext))
-      .onSuccess(v -> logger.info("putCompositeOrderById :: Successfully updated order: {}",
-        JsonObject.mapFrom(compPO).encodePrettily()))
+      .onSuccess(v -> logger.info("putCompositeOrderById :: Successfully updated order: {}", compPO.getId()))
       .onFailure(t -> logger.error("putCompositeOrderById :: Failed to update order: {}",
         JsonObject.mapFrom(compPO).encodePrettily(), t));
   }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." 
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/MODORDERS-1222
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did but help other
 developers *work* with your solution in the future.
-->
- Filtered duplicate poLines in side of retrieveMapFiscalYearsWithCompPOLines method  