### PR TITLE
Release mod-orders v12.9.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 ## 13.0.0 - Unreleased
 
+## 12.9.5 - Released (Ramsons R2 2024)
+The primary focus of this release was to add missed module permission and do some queries optimization for fetching user-tenants for validation
+only when the Central Ordering feature is enabled.
+[Full Changelog](https://github.com/folio-org/mod-orders/compare/v12.9.4...v12.9.5)
+
+### Bug Fixes
+* [MODORDERS-1223](https://issues.folio.org/browse/MODORDERS-1223) - (ECS) Can open/unopen order with PO line locations from tenant in which user does not have affiliation
+
+
 ## 12.9.4 - Released (Ramsons R2 2024)
 The primary focus of this release was to fix issue with preventing opening order with PO line locations from tenant in which user does not have affiliation
 and fixing error when trying to unopen an ongoing order to add a purchase order line with multiple funds.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2078,6 +2078,7 @@
         "organizations-storage.organizations.collection.get",
         "organizations-storage.organizations.item.get",
         "isbn-utils.convert-to-13.get",
+        "consortia.user-tenants.collection.get",
         "user-tenants.collection.get",
         "consortia.sharing-instances.collection.get",
         "consortia.sharing-instances.item.post"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -270,6 +270,7 @@
             "invoice.invoice-lines.item.put",
             "invoices.acquisition-units.bypass.execute",
             "orders-storage.order-invoice-relationships.collection.get",
+            "orders-storage.settings.collection.get",
             "consortia.user-tenants.collection.get",
             "user-tenants.collection.get",
             "consortia.sharing-instances.item.post"
@@ -2078,6 +2079,7 @@
         "organizations-storage.organizations.collection.get",
         "organizations-storage.organizations.item.get",
         "isbn-utils.convert-to-13.get",
+        "orders-storage.settings.collection.get",
         "consortia.user-tenants.collection.get",
         "user-tenants.collection.get",
         "consortia.sharing-instances.collection.get",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>12.9.5</version>
+  <version>12.9.6-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v12.9.5</tag>
+    <tag>v12.9.0</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>12.9.5-SNAPSHOT</version>
+  <version>12.9.5</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v12.9.0</tag>
+    <tag>v12.9.5</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/org/folio/service/consortium/ConsortiumConfigurationService.java
+++ b/src/main/java/org/folio/service/consortium/ConsortiumConfigurationService.java
@@ -95,12 +95,16 @@ public class ConsortiumConfigurationService {
           return Future.succeededFuture(requestContext);
         }
         RequestContext centralContext = createContextWithNewTenantId(requestContext, configuration.centralTenantId());
-        return settingsRetriever.getSettingByKey(SettingKey.CENTRAL_ORDERING_ENABLED, centralContext)
-          .map(centralOrdering -> {
-            logger.info("overrideContextToCentralTenantIdNeeded:: central ordering enabled: {}", centralOrdering);
-            return centralOrdering.map(Setting::getValue).orElse(null);
-          })
-          .compose(orderingEnabled -> Future.succeededFuture(Boolean.parseBoolean(orderingEnabled) ? centralContext : requestContext));
+        return isCentralOrderingEnabled(requestContext)
+          .compose(isCentralOrderingEnabled -> Future.succeededFuture(isCentralOrderingEnabled ? centralContext : requestContext));
+      });
+  }
+
+  public Future<Boolean> isCentralOrderingEnabled(RequestContext requestContext) {
+    return settingsRetriever.getSettingByKey(SettingKey.CENTRAL_ORDERING_ENABLED, requestContext)
+      .map(centralOrdering -> {
+        logger.info("isCentralOrderingEnabled:: central ordering enabled: {}", centralOrdering);
+        return centralOrdering.map(setting -> Boolean.parseBoolean(setting.getValue())).orElse(false);
       });
   }
 }

--- a/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/CompositePoLineValidationService.java
@@ -366,7 +366,10 @@ public class CompositePoLineValidationService extends BaseValidationService {
     return consortiumConfigurationService.getConsortiumConfiguration(requestContext)
       .compose(consortiumConfiguration ->
         consortiumConfiguration
-          .map(configuration -> consortiumUserTenantsRetriever.getUserTenants(configuration.consortiumId(), configuration.centralTenantId(), requestContext))
+          .map(configuration -> consortiumConfigurationService.isCentralOrderingEnabled(requestContext)
+              .compose(isCentralOrderingEnabled -> isCentralOrderingEnabled
+                ? consortiumUserTenantsRetriever.getUserTenants(configuration.consortiumId(), configuration.centralTenantId(), requestContext)
+                : Future.succeededFuture()))
           .orElse(Future.succeededFuture())
       );
   }

--- a/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
+++ b/src/test/java/org/folio/service/orders/CompositePoLineValidationServiceTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -411,6 +412,8 @@ public class CompositePoLineValidationServiceTest {
 
     when(consortiumConfigurationService.getConsortiumConfiguration(eq(requestContext)))
       .thenReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))));
+    when(consortiumConfigurationService.isCentralOrderingEnabled(eq(requestContext)))
+      .thenReturn(Future.succeededFuture(true));
     when(consortiumUserTenantsRetriever.getUserTenants(eq("consortiumId"), anyString(), eq(requestContext)))
       .thenReturn(Future.succeededFuture(List.of("tenant1", "tenant2")));
 
@@ -428,11 +431,34 @@ public class CompositePoLineValidationServiceTest {
 
     when(consortiumConfigurationService.getConsortiumConfiguration(eq(requestContext)))
       .thenReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))));
+    when(consortiumConfigurationService.isCentralOrderingEnabled(eq(requestContext)))
+      .thenReturn(Future.succeededFuture(true));
     when(consortiumUserTenantsRetriever.getUserTenants(eq("consortiumId"), anyString(), eq(requestContext)))
       .thenReturn(Future.succeededFuture(List.of("tenant1", "tenant2")));
 
     compositePoLineValidationService.validateUserUnaffiliatedLocations(updatedPoLineId, locationsUpdated, requestContext)
       .onComplete(testContext.succeeding(result -> testContext.verify(testContext::completeNow)));
+  }
+
+  @Test
+  void testValidateUserUnaffiliatedLocationsWhenCentralOrderingIsDisabled(VertxTestContext testContext) {
+    var locationsUpdated = List.of(
+      new Location().withLocationId(UUID.randomUUID().toString()).withTenantId("tenant1"),
+      new Location().withLocationId(UUID.randomUUID().toString()).withTenantId("tenant2"));
+    var updatedPoLineId = UUID.randomUUID().toString();
+
+    when(consortiumConfigurationService.getConsortiumConfiguration(eq(requestContext)))
+      .thenReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))));
+    when(consortiumConfigurationService.isCentralOrderingEnabled(eq(requestContext)))
+      .thenReturn(Future.succeededFuture(false));
+    when(consortiumUserTenantsRetriever.getUserTenants(eq("consortiumId"), anyString(), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(List.of("tenant1")));
+
+    compositePoLineValidationService.validateUserUnaffiliatedLocations(updatedPoLineId, locationsUpdated, requestContext)
+      .onComplete(testContext.succeeding(result -> {
+        testContext.verify(testContext::completeNow);
+        verifyNoInteractions(consortiumUserTenantsRetriever);
+      }));
   }
 
   @Test
@@ -444,6 +470,8 @@ public class CompositePoLineValidationServiceTest {
 
     when(consortiumConfigurationService.getConsortiumConfiguration(eq(requestContext)))
       .thenReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))));
+    when(consortiumConfigurationService.isCentralOrderingEnabled(eq(requestContext)))
+      .thenReturn(Future.succeededFuture(true));
     when(consortiumUserTenantsRetriever.getUserTenants(eq("consortiumId"), anyString(), eq(requestContext)))
       .thenReturn(Future.succeededFuture(List.of("tenant1")));
 
@@ -464,6 +492,8 @@ public class CompositePoLineValidationServiceTest {
 
     when(consortiumConfigurationService.getConsortiumConfiguration(eq(requestContext)))
       .thenReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration("tenant1", "consortiumId"))));
+    when(consortiumConfigurationService.isCentralOrderingEnabled(eq(requestContext)))
+      .thenReturn(Future.succeededFuture(true));
     when(consortiumUserTenantsRetriever.getUserTenants(eq("consortiumId"), anyString(), eq(requestContext)))
       .thenReturn(Future.succeededFuture(List.of("tenant3")));
 


### PR DESCRIPTION
## Purpose
Release v12.9.5 to to add missed module permission and do some queries optimization for fetching user-tenants for validation
only when the Central Ordering feature is enabled.