### PR TITLE
[MODORDERS-1231] ECS | List of requests previously related to bound pieces is displayed in wrong order

### DIFF
--- a/src/main/java/org/folio/service/inventory/util/RequestFields.java
+++ b/src/main/java/org/folio/service/inventory/util/RequestFields.java
@@ -6,6 +6,7 @@ public enum RequestFields {
   REQUESTER_ID("requesterId"),
   STATUS("status"),
   DESTINATION_ITEM_ID("destinationItemId"),
+  POSITION("position"),
   COLLECTION_RECORDS("requests");
 
   private final String value;


### PR DESCRIPTION
## Purpose
[[MODORDERS-1231] ECS | List of requests previously related to bound pieces is displayed in wrong order](https://folio-org.atlassian.net/browse/MODORDERS-1231)

## Approach
- Improve logging
- Add sorting for request transfer