### PR TITLE
[MODORDERS-1211] ECS | User in member tenant cannot bind pieces related to order from Central tenant

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1158,6 +1158,7 @@
             "circulation.requests.item.move.post",
             "circulation.requests.item.put",
             "user-tenants.collection.get",
+            "orders-storage.settings.collection.get",
             "consortia.sharing-instances.item.post"
           ]
         },

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -21,6 +21,7 @@ import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.ReceivedItem;
 import org.folio.rest.jaxrs.model.Title;
 import org.folio.rest.tools.utils.TenantTool;
+import org.folio.service.consortium.ConsortiumConfigurationService;
 import org.folio.service.inventory.InventoryInstanceManager;
 import org.folio.service.inventory.InventoryItemRequestService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,9 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
 
   @Autowired
   private InventoryInstanceManager inventoryInstanceManager;
+
+  @Autowired
+  private ConsortiumConfigurationService consortiumConfigurationService;
 
   public BindHelper(BindPiecesCollection bindPiecesCollection,
                     Map<String, String> okapiHeaders, Context ctx) {
@@ -111,8 +115,9 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
   }
 
   public Future<BindPiecesResult> bindPieces(BindPiecesCollection bindPiecesCollection, RequestContext requestContext) {
-    return removeForbiddenEntities(requestContext)
-        .compose(vVoid -> processBindPieces(bindPiecesCollection, requestContext));
+    return consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(requestContext)
+      .compose(ctx -> removeForbiddenEntities(ctx)
+        .compose(vVoid -> processBindPieces(bindPiecesCollection, ctx)));
   }
 
   private Future<BindPiecesResult> processBindPieces(BindPiecesCollection bindPiecesCollection, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/consortium/ConsortiumConfigurationService.java
+++ b/src/main/java/org/folio/service/consortium/ConsortiumConfigurationService.java
@@ -89,13 +89,13 @@ public class ConsortiumConfigurationService {
         }
         String tenantId = TenantTool.tenantId(requestContext.getHeaders());
         var configuration = consortiumConfiguration.get();
-        logger.info("overrideContextToCentralTenantIdNeeded:: tenantId from request: {}, centralTenantId: {}",
+        logger.info("overrideContextToCentralTenantIfNeeded:: tenantId from request: {}, centralTenantId: {}",
           tenantId, configuration.centralTenantId());
         if (StringUtils.equals(tenantId, configuration.centralTenantId())) {
           return Future.succeededFuture(requestContext);
         }
         RequestContext centralContext = createContextWithNewTenantId(requestContext, configuration.centralTenantId());
-        return isCentralOrderingEnabled(requestContext)
+        return isCentralOrderingEnabled(centralContext)
           .compose(isCentralOrderingEnabled -> Future.succeededFuture(isCentralOrderingEnabled ? centralContext : requestContext));
       });
   }


### PR DESCRIPTION
## Purpose
[[MODORDERS-1211] ECS | User in member tenant cannot bind pieces related to order from Central tenant](https://folio-org.atlassian.net/browse/MODORDERS-1211)

## Approach
- Switch context to central tenant if needed before binding
- Use correct context to fetch settings
