### PR TITLE
[MODORDERS-1248] Use only invoice lines related to the order to calculate total expended

### DIFF
--- a/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
+++ b/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
@@ -1,5 +1,6 @@
 package org.folio.service.orders;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -15,6 +16,7 @@ import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.acq.model.invoice.Invoice;
 import org.folio.rest.acq.model.invoice.InvoiceLine;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.service.finance.FiscalYearService;
 import org.folio.service.finance.transaction.TransactionService;
 import org.folio.service.invoice.InvoiceLineService;
@@ -53,6 +55,7 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
     return invoiceService.getInvoicesByOrderId(holder.getOrderId(), requestContext)
       .compose(invoices -> getCurrentFiscalYearIds(invoices, holder.getFiscalYear(), requestContext)
         .compose(fiscalYears -> getInvoiceLinesByInvoiceIds(invoices, fiscalYears, requestContext))
+        .map(invoiceLines -> filterInvoiceLinesWithPoLines(invoiceLines, holder.getOrder().getCompositePoLines()))
         .map(invoiceLines -> groupInvoiceLinesByInvoices(invoices, invoiceLines))
         .compose(invoiceToInvoiceLinesMap -> transactionService.getTransactions(query, requestContext)
           .map(transactions -> populateTotalFields(holder, invoiceToInvoiceLinesMap, transactions))))
@@ -76,6 +79,11 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
       .filter(invoice -> invoice.getFiscalYearId() != null && fiscalYearIds.contains(invoice.getFiscalYearId()))
       .map(invoice -> invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(invoice.getId(), InvoiceLine.InvoiceLineStatus.PAID, requestContext)).toList())
       .map(invoiceLinesLists -> invoiceLinesLists.stream().flatMap(List::stream).toList());
+  }
+
+  private List<InvoiceLine> filterInvoiceLinesWithPoLines(List<InvoiceLine> invoiceLines, List<CompositePoLine> poLines) {
+    Set<String> poLineIds = poLines.stream().map(CompositePoLine::getId).collect(Collectors.toCollection(HashSet::new));
+    return invoiceLines.stream().filter(invoiceLine -> poLineIds.contains(invoiceLine.getPoLineId())).toList();
   }
 
   private Map<Invoice, List<InvoiceLine>> groupInvoiceLinesByInvoices(List<Invoice> invoices, List<InvoiceLine> invoiceLines) {

--- a/src/test/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateServiceTest.java
+++ b/src/test/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateServiceTest.java
@@ -18,11 +18,13 @@ import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.acq.model.invoice.Invoice;
 import org.folio.rest.acq.model.invoice.InvoiceLine;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.service.finance.FiscalYearService;
 import org.folio.service.finance.transaction.TransactionService;
 import org.folio.service.invoice.InvoiceLineService;
 import org.folio.service.invoice.InvoiceService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -48,32 +50,65 @@ public class CompositeOrderTotalFieldsPopulateServiceTest {
 
   @Mock
   private RequestContext requestContext;
+  private AutoCloseable mockitoMocks;
 
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.openMocks(this);
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockitoMocks.close();
   }
 
   @Test
   void shouldPopulateTotalFieldsWhenInvoicesInvoiceLinesAndTransactionsExist() {
     String fiscalYearId = UUID.randomUUID().toString();
-    Invoice invoice1 = new Invoice().withId(UUID.randomUUID().toString()).withCurrency("USD").withFiscalYearId(fiscalYearId);
-    Invoice invoice2 = new Invoice().withId(UUID.randomUUID().toString()).withCurrency("USD").withFiscalYearId(fiscalYearId);
-    InvoiceLine invoiceLine1 = new InvoiceLine().withInvoiceId(invoice1.getId()).withTotal(100.0).withInvoiceLineStatus(PAID);
-    InvoiceLine invoiceLine2 = new InvoiceLine().withInvoiceId(invoice2.getId()).withTotal(200.0).withInvoiceLineStatus(PAID);
-    InvoiceLine invoiceLine3 = new InvoiceLine().withInvoiceId(invoice2.getId()).withTotal(-500.0).withInvoiceLineStatus(PAID);
+    CompositePoLine poLine1 = new CompositePoLine().withId(UUID.randomUUID().toString());
+    CompositePoLine poLine2 = new CompositePoLine().withId(UUID.randomUUID().toString());
+    CompositePoLine poLine3 = new CompositePoLine().withId(UUID.randomUUID().toString());
+    Invoice invoice1 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withCurrency("USD")
+      .withFiscalYearId(fiscalYearId);
+    Invoice invoice2 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withCurrency("USD")
+      .withFiscalYearId(fiscalYearId);
+    InvoiceLine invoiceLine1 = new InvoiceLine()
+      .withInvoiceId(invoice1.getId())
+      .withTotal(100.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(poLine1.getId());
+    InvoiceLine invoiceLine2 = new InvoiceLine()
+      .withInvoiceId(invoice2.getId())
+      .withTotal(200.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(poLine2.getId());
+    InvoiceLine invoiceLine3 = new InvoiceLine()
+      .withInvoiceId(invoice2.getId())
+      .withTotal(-500.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(poLine3.getId());
     List<Invoice> invoices = List.of(invoice1, invoice2);
     Transaction transaction1 = new Transaction().withAmount(100.0).withCurrency("USD");
     Transaction transaction2 = new Transaction().withAmount(700.0).withCurrency("USD");
     List<Transaction> transactions = List.of(transaction1, transaction2);
-    CompositePurchaseOrder order = new CompositePurchaseOrder().withId(UUID.randomUUID().toString());
+    CompositePurchaseOrder order = new CompositePurchaseOrder()
+      .withId(UUID.randomUUID().toString())
+      .withCompositePoLines(List.of(poLine1, poLine2, poLine3));
     CompositeOrderRetrieveHolder holder = new CompositeOrderRetrieveHolder(order)
       .withFiscalYear(new FiscalYear().withId(fiscalYearId));
 
-    when(invoiceService.getInvoicesByOrderId(anyString(), any())).thenReturn(Future.succeededFuture(invoices));
-    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice1.getId()), eq(PAID), any())).thenReturn(Future.succeededFuture(List.of(invoiceLine1)));
-    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice2.getId()), eq(PAID), any())).thenReturn(Future.succeededFuture(List.of(invoiceLine2, invoiceLine3)));
-    when(transactionService.getTransactions(anyString(), any())).thenReturn(Future.succeededFuture(transactions));
+    when(invoiceService.getInvoicesByOrderId(anyString(), any()))
+      .thenReturn(Future.succeededFuture(invoices));
+    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice1.getId()), eq(PAID), any()))
+      .thenReturn(Future.succeededFuture(List.of(invoiceLine1)));
+    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice2.getId()), eq(PAID), any()))
+      .thenReturn(Future.succeededFuture(List.of(invoiceLine2, invoiceLine3)));
+    when(transactionService.getTransactions(anyString(), any()))
+      .thenReturn(Future.succeededFuture(transactions));
 
     CompositeOrderRetrieveHolder resultHolder = populateService.populate(holder, requestContext).result();
 
@@ -121,23 +156,101 @@ public class CompositeOrderTotalFieldsPopulateServiceTest {
   @Test
   void shouldHandleNullFiscalYearWithInvoicesInvoiceLinesAndNoTransactions() {
     String fiscalYearId = UUID.randomUUID().toString();
-    Invoice invoice1 = new Invoice().withId(UUID.randomUUID().toString()).withCurrency("USD").withFiscalYearId(fiscalYearId);
-    Invoice invoice2 = new Invoice().withId(UUID.randomUUID().toString()).withCurrency("USD").withFiscalYearId(fiscalYearId);
-    InvoiceLine invoiceLine1 = new InvoiceLine().withInvoiceId(invoice1.getId()).withTotal(100.0).withInvoiceLineStatus(PAID);
-    InvoiceLine invoiceLine2 = new InvoiceLine().withInvoiceId(invoice2.getId()).withTotal(-500.0).withInvoiceLineStatus(PAID);
+    CompositePoLine poLine1 = new CompositePoLine().withId(UUID.randomUUID().toString());
+    CompositePoLine poLine2 = new CompositePoLine().withId(UUID.randomUUID().toString());
+    Invoice invoice1 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withCurrency("USD")
+      .withFiscalYearId(fiscalYearId);
+    Invoice invoice2 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withCurrency("USD")
+      .withFiscalYearId(fiscalYearId);
+    InvoiceLine invoiceLine1 = new InvoiceLine()
+      .withInvoiceId(invoice1.getId())
+      .withTotal(100.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(poLine1.getId());
+    InvoiceLine invoiceLine2 = new InvoiceLine()
+      .withInvoiceId(invoice2.getId())
+      .withTotal(-500.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(poLine2.getId());
     List<Invoice> invoices = List.of(invoice1, invoice2);
-    CompositePurchaseOrder order = new CompositePurchaseOrder().withId(UUID.randomUUID().toString());
+    CompositePurchaseOrder order = new CompositePurchaseOrder()
+      .withId(UUID.randomUUID().toString())
+      .withCompositePoLines(List.of(poLine1, poLine2));
     CompositeOrderRetrieveHolder holder = new CompositeOrderRetrieveHolder(order);
 
-    when(invoiceService.getInvoicesByOrderId(anyString(), any())).thenReturn(Future.succeededFuture(invoices));
-    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice1.getId()), eq(PAID), any())).thenReturn(Future.succeededFuture(List.of(invoiceLine1)));
-    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice2.getId()), eq(PAID), any())).thenReturn(Future.succeededFuture(List.of(invoiceLine2)));
-    when(transactionService.getTransactions(anyString(), any())).thenReturn(Future.succeededFuture(List.of()));
-    when(fiscalYearService.getCurrentFYForSeriesByFYId(anyString(), any())).thenReturn(Future.succeededFuture(fiscalYearId));
+    when(invoiceService.getInvoicesByOrderId(anyString(), any()))
+      .thenReturn(Future.succeededFuture(invoices));
+    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice1.getId()), eq(PAID), any()))
+      .thenReturn(Future.succeededFuture(List.of(invoiceLine1)));
+    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice2.getId()), eq(PAID), any()))
+      .thenReturn(Future.succeededFuture(List.of(invoiceLine2)));
+    when(transactionService.getTransactions(anyString(), any()))
+      .thenReturn(Future.succeededFuture(List.of()));
+    when(fiscalYearService.getCurrentFYForSeriesByFYId(anyString(), any()))
+      .thenReturn(Future.succeededFuture(fiscalYearId));
 
     CompositeOrderRetrieveHolder resultHolder = populateService.populate(holder, requestContext).result();
 
     assertEquals(0.0, resultHolder.getOrder().getTotalEncumbered());
+    assertEquals(100.0, resultHolder.getOrder().getTotalExpended());
+    assertEquals(500.0, resultHolder.getOrder().getTotalCredited());
+  }
+
+  @Test
+  void shouldNotUseUnrelatedInvoiceLinesToCalculateOrderExpendedAmount() {
+    String fiscalYearId = UUID.randomUUID().toString();
+    CompositePoLine poLine1 = new CompositePoLine().withId(UUID.randomUUID().toString());
+    CompositePoLine poLine2 = new CompositePoLine().withId(UUID.randomUUID().toString());
+    Invoice invoice1 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withCurrency("USD")
+      .withFiscalYearId(fiscalYearId);
+    Invoice invoice2 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withCurrency("USD")
+      .withFiscalYearId(fiscalYearId);
+    InvoiceLine invoiceLine1 = new InvoiceLine()
+      .withInvoiceId(invoice1.getId())
+      .withTotal(100.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(poLine1.getId());
+    InvoiceLine invoiceLine2 = new InvoiceLine()
+      .withInvoiceId(invoice2.getId())
+      .withTotal(-500.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(poLine2.getId());
+    InvoiceLine invoiceLine3 = new InvoiceLine()
+      .withInvoiceId(invoice1.getId())
+      .withTotal(200.0)
+      .withInvoiceLineStatus(PAID)
+      .withPoLineId(UUID.randomUUID().toString());
+    InvoiceLine invoiceLine4 = new InvoiceLine()
+      .withInvoiceId(invoice2.getId())
+      .withTotal(-100.0)
+      .withInvoiceLineStatus(PAID);
+    List<Invoice> invoices = List.of(invoice1, invoice2);
+    CompositePurchaseOrder order = new CompositePurchaseOrder()
+      .withId(UUID.randomUUID().toString())
+      .withCompositePoLines(List.of(poLine1, poLine2));
+    CompositeOrderRetrieveHolder holder = new CompositeOrderRetrieveHolder(order);
+
+    when(invoiceService.getInvoicesByOrderId(anyString(), any()))
+      .thenReturn(Future.succeededFuture(invoices));
+    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice1.getId()), eq(PAID), any()))
+      .thenReturn(Future.succeededFuture(List.of(invoiceLine1, invoiceLine3)));
+    when(invoiceLineService.getInvoiceLinesByInvoiceIdAndStatus(eq(invoice2.getId()), eq(PAID), any()))
+      .thenReturn(Future.succeededFuture(List.of(invoiceLine2, invoiceLine4)));
+    when(transactionService.getTransactions(anyString(), any()))
+      .thenReturn(Future.succeededFuture(List.of()));
+    when(fiscalYearService.getCurrentFYForSeriesByFYId(anyString(), any()))
+      .thenReturn(Future.succeededFuture(fiscalYearId));
+
+    CompositeOrderRetrieveHolder resultHolder = populateService.populate(holder, requestContext).result();
+
     assertEquals(100.0, resultHolder.getOrder().getTotalExpended());
     assertEquals(500.0, resultHolder.getOrder().getTotalCredited());
   }


### PR DESCRIPTION
## Purpose
[MODORDERS-1248](https://folio-org.atlassian.net/browse/MODORDERS-1248) - Total expended value on order details pane contains invoice total value instead of invoice line total

## Approach
- Added a filter using invoice lines' poLineId to filter invoice lines used to calculate total expended amount.
- Fixed unit tests and added a new one.

[Integration test PR](https://github.com/folio-org/folio-integration-tests/pull/1680)