### PR TITLE
UIREC-422. Revert logic to override to centralTenantContext

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1223,7 +1223,6 @@
             "circulation.requests.item.move.post",
             "circulation.requests.item.put",
             "user-tenants.collection.get",
-            "orders-storage.settings.collection.get",
             "consortia.sharing-instances.item.post"
           ]
         },

--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -21,7 +21,6 @@ import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.ReceivedItem;
 import org.folio.rest.jaxrs.model.Title;
 import org.folio.rest.tools.utils.TenantTool;
-import org.folio.service.consortium.ConsortiumConfigurationService;
 import org.folio.service.inventory.InventoryInstanceManager;
 import org.folio.service.inventory.InventoryItemRequestService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,9 +48,6 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
 
   @Autowired
   private InventoryInstanceManager inventoryInstanceManager;
-
-  @Autowired
-  private ConsortiumConfigurationService consortiumConfigurationService;
 
   public BindHelper(BindPiecesCollection bindPiecesCollection,
                     Map<String, String> okapiHeaders, Context ctx) {
@@ -115,9 +111,8 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
   }
 
   public Future<BindPiecesResult> bindPieces(BindPiecesCollection bindPiecesCollection, RequestContext requestContext) {
-    return consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(requestContext)
-      .compose(ctx -> removeForbiddenEntities(ctx)
-        .compose(vVoid -> processBindPieces(bindPiecesCollection, ctx)));
+    return removeForbiddenEntities(requestContext)
+        .compose(vVoid -> processBindPieces(bindPiecesCollection, requestContext));
   }
 
   private Future<BindPiecesResult> processBindPieces(BindPiecesCollection bindPiecesCollection, RequestContext requestContext) {


### PR DESCRIPTION
## Purpose
Support story https://folio-org.atlassian.net/browse/UIREC-422
Now ovveride logic to central tenant is not needed because UI will send correct tenant to bind pieces in correct tenant 