### PR TITLE
ECS | Piece could not be moved to "Claim sent" status in member tenant when related order was created in Central tenant

### DIFF
--- a/src/test/java/org/folio/rest/impl/PiecesClaimingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PiecesClaimingApiTest.java
@@ -216,7 +216,7 @@ public class PiecesClaimingApiTest {
           .getJsonObject(VENDOR_EDI_ORDERS_EXPORT_CONFIG.getValue())
           .getJsonArray(CLAIM_PIECE_IDS.getValue()).size())
         .mapToInt(value -> value).sum();
-      assertThat(claimedPieceIds, equalTo(request.getClaimingPieceIds().size()));
+      assertThat(claimedPieceIds, equalTo(request.getClaimingPieces().size()));
 
       claimingResults.getClaimingPieceResults()
         .forEach(result -> {

--- a/src/test/java/org/folio/service/pieces/PiecesClaimingServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/PiecesClaimingServiceTest.java
@@ -14,6 +14,7 @@ import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.service.caches.ConfigurationEntriesCache;
+import org.folio.service.consortium.ConsortiumConfigurationService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 import org.folio.service.organization.OrganizationService;
@@ -57,6 +58,7 @@ public class PiecesClaimingServiceTest {
   @Mock private PurchaseOrderStorageService purchaseOrderStorageService;
   @Mock private OrganizationService organizationService;
   @Mock private PieceUpdateFlowManager pieceUpdateFlowManager;
+  @Mock private ConsortiumConfigurationService consortiumConfigurationService;
   @Mock private RestClient restClient;
   @InjectMocks private PiecesClaimingService piecesClaimingService;
 
@@ -77,9 +79,11 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of());
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
+
     var throwable = Assertions.assertThrows(HttpException.class, () -> piecesClaimingService.sendClaims(claimingCollection, requestContext));
     Assertions.assertInstanceOf(HttpException.class, throwable);
-    var error = throwable.getErrors().getErrors().get(0);
+    var error = throwable.getErrors().getErrors().getFirst();
     assertEquals(CANNOT_SEND_CLAIMS_PIECE_IDS_ARE_EMPTY.getCode(), error.getCode());
     assertEquals(CANNOT_SEND_CLAIMS_PIECE_IDS_ARE_EMPTY.getDescription(), error.getMessage());
     Assertions.assertTrue(error.getParameters().isEmpty());
@@ -92,17 +96,18 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId1)).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()));
 
     piecesClaimingService.sendClaims(claimingCollection, requestContext)
       .onComplete(testContext.failing(throwable -> testContext.verify(() -> {
         Assertions.assertInstanceOf(HttpException.class, throwable);
         var httpException = (HttpException) throwable;
-        var error = httpException.getErrors().getErrors().get(0);
+        var error = httpException.getErrors().getErrors().getFirst();
         assertEquals(CANNOT_RETRIEVE_CONFIG_ENTRIES.getCode(), error.getCode());
         assertEquals(CANNOT_RETRIEVE_CONFIG_ENTRIES.getDescription(), error.getMessage());
         Assertions.assertEquals(1, error.getParameters().size());
-        var parameter = error.getParameters().get(0);
+        var parameter = error.getParameters().getFirst();
         Assertions.assertEquals("pieceId", parameter.getKey());
         Assertions.assertEquals(pieceId1, parameter.getValue());
         testContext.completeNow();
@@ -115,6 +120,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId1)).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("key", "value")));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of()));
 
@@ -122,11 +128,11 @@ public class PiecesClaimingServiceTest {
       .onComplete(testContext.failing(throwable -> testContext.verify(() -> {
         Assertions.assertInstanceOf(HttpException.class, throwable);
         var httpException = (HttpException) throwable;
-        var error = httpException.getErrors().getErrors().get(0);
+        var error = httpException.getErrors().getErrors().getFirst();
         assertEquals(CANNOT_FIND_PIECES_WITH_LATE_STATUS_TO_PROCESS.getCode(), error.getCode());
         assertEquals(CANNOT_FIND_PIECES_WITH_LATE_STATUS_TO_PROCESS.getDescription(), error.getMessage());
         Assertions.assertEquals(1, error.getParameters().size());
-        var parameter = error.getParameters().get(0);
+        var parameter = error.getParameters().getFirst();
         Assertions.assertEquals("pieceId", parameter.getKey());
         Assertions.assertEquals(pieceId1, parameter.getValue());
         testContext.completeNow();
@@ -138,6 +144,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1")).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("CLAIMS_vendorId", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(new Piece().withId("pieceId1").withPoLineId("poLineId1").withReceivingStatus(Piece.ReceivingStatus.RECEIVED))));
     when(purchaseOrderLineService.getOrderLineById(any(), any())).thenReturn(Future.succeededFuture(new PoLine().withPurchaseOrderId("orderId1")));
@@ -151,11 +158,11 @@ public class PiecesClaimingServiceTest {
      .onComplete(testContext.failing(throwable -> testContext.verify(() -> {
         Assertions.assertInstanceOf(HttpException.class, throwable);
         var httpException = (HttpException) throwable;
-        var error = httpException.getErrors().getErrors().get(0);
+        var error = httpException.getErrors().getErrors().getFirst();
         assertEquals(CANNOT_FIND_PIECES_WITH_LATE_STATUS_TO_PROCESS.getCode(), error.getCode());
         assertEquals(CANNOT_FIND_PIECES_WITH_LATE_STATUS_TO_PROCESS.getDescription(), error.getMessage());
         Assertions.assertEquals(1, error.getParameters().size());
-        var parameter = error.getParameters().get(0);
+        var parameter = error.getParameters().getFirst();
         Assertions.assertEquals("pieceId", parameter.getKey());
         Assertions.assertEquals("pieceId1", parameter.getValue());
         testContext.completeNow();
@@ -169,6 +176,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId));
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(piece)));
@@ -180,11 +188,11 @@ public class PiecesClaimingServiceTest {
       .onComplete(testContext.failing(throwable -> testContext.verify(() -> {
         Assertions.assertInstanceOf(HttpException.class, throwable);
         var httpException = (HttpException) throwable;
-        var error = httpException.getErrors().getErrors().get(0);
+        var error = httpException.getErrors().getErrors().getFirst();
         assertEquals(UNABLE_TO_GENERATE_CLAIMS_FOR_ORG_NO_INTEGRATION_DETAILS.getCode(), error.getCode());
         assertEquals(String.format(UNABLE_TO_GENERATE_CLAIMS_FOR_ORG_NO_INTEGRATION_DETAILS.getDescription(), "VENDOR2"), error.getMessage());
         Assertions.assertEquals(2, error.getParameters().size());
-        var parameter1 = error.getParameters().get(0);
+        var parameter1 = error.getParameters().getFirst();
         Assertions.assertEquals("pieceId", parameter1.getKey());
         Assertions.assertEquals(pieceId, parameter1.getValue());
         var parameter2 = error.getParameters().get(1);
@@ -205,6 +213,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId1, pieceId2, pieceId3));
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(piece1, piece2, piece3)));
@@ -225,11 +234,11 @@ public class PiecesClaimingServiceTest {
       .onComplete(testContext.failing(throwable -> testContext.verify(() -> {
         Assertions.assertInstanceOf(HttpException.class, throwable);
         var httpException = (HttpException) throwable;
-        var error = httpException.getErrors().getErrors().get(0);
+        var error = httpException.getErrors().getErrors().getFirst();
         assertEquals(UNABLE_TO_GENERATE_CLAIMS_FOR_ORG_NO_INTEGRATION_DETAILS.getCode(), error.getCode());
         assertEquals(String.format(UNABLE_TO_GENERATE_CLAIMS_FOR_ORG_NO_INTEGRATION_DETAILS.getDescription(), "VENDOR2"), error.getMessage());
         Assertions.assertEquals(4, error.getParameters().size());
-        var parameter1 = error.getParameters().get(0);
+        var parameter1 = error.getParameters().getFirst();
         Assertions.assertEquals("pieceId", parameter1.getKey());
         Assertions.assertEquals(pieceId1, parameter1.getValue());
         var parameter2 = error.getParameters().get(1);
@@ -250,6 +259,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1")).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("CLAIMS_vendorId", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(new Piece().withId("pieceId1").withPoLineId("poLineId1").withReceivingStatus(Piece.ReceivingStatus.LATE))));
     when(purchaseOrderLineService.getOrderLineById(any(), any())).thenReturn(Future.succeededFuture(new PoLine().withPurchaseOrderId("orderId1")));
@@ -262,8 +272,8 @@ public class PiecesClaimingServiceTest {
     piecesClaimingService.sendClaims(claimingCollection, requestContext)
       .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
         assertEquals(1, result.getClaimingPieceResults().size());
-        assertEquals("pieceId1", result.getClaimingPieceResults().get(0).getPieceId());
-        assertEquals(ClaimingPieceResult.Status.SUCCESS, result.getClaimingPieceResults().get(0).getStatus());
+        assertEquals("pieceId1", result.getClaimingPieceResults().getFirst().getPieceId());
+        assertEquals(ClaimingPieceResult.Status.SUCCESS, result.getClaimingPieceResults().getFirst().getStatus());
         testContext.completeNow();
       })));
   }
@@ -273,6 +283,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1", "pieceId2")).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("CLAIMS_vendorId", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(
       new Piece().withId("pieceId1").withPoLineId("poLineId1").withReceivingStatus(Piece.ReceivingStatus.LATE),
@@ -288,8 +299,8 @@ public class PiecesClaimingServiceTest {
     piecesClaimingService.sendClaims(claimingCollection, requestContext)
       .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
         assertEquals(2, result.getClaimingPieceResults().size());
-        assertEquals("pieceId1", result.getClaimingPieceResults().get(0).getPieceId());
-        assertEquals(ClaimingPieceResult.Status.SUCCESS, result.getClaimingPieceResults().get(0).getStatus());
+        assertEquals("pieceId1", result.getClaimingPieceResults().getFirst().getPieceId());
+        assertEquals(ClaimingPieceResult.Status.SUCCESS, result.getClaimingPieceResults().getFirst().getStatus());
         assertEquals("pieceId2", result.getClaimingPieceResults().get(1).getPieceId());
         assertEquals(ClaimingPieceResult.Status.SUCCESS, result.getClaimingPieceResults().get(1).getStatus());
         testContext.completeNow();
@@ -301,6 +312,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1", "pieceId2", "pieceId3", "pieceId4", "pieceId5")).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())
       .put("CLAIMS_vendorId2", createIntegrationDetail())));
@@ -337,8 +349,8 @@ public class PiecesClaimingServiceTest {
         assertEquals(5, result.getClaimingPieceResults().size());
         var copiedSortedResults = new ArrayList<>(result.getClaimingPieceResults());
         copiedSortedResults.sort(Comparator.comparing(ClaimingPieceResult::getPieceId));
-        assertEquals("pieceId1", copiedSortedResults.get(0).getPieceId());
-        assertEquals(ClaimingPieceResult.Status.SUCCESS, copiedSortedResults.get(0).getStatus());
+        assertEquals("pieceId1", copiedSortedResults.getFirst().getPieceId());
+        assertEquals(ClaimingPieceResult.Status.SUCCESS, copiedSortedResults.getFirst().getStatus());
         assertEquals("pieceId2", copiedSortedResults.get(1).getPieceId());
         assertEquals(ClaimingPieceResult.Status.SUCCESS, copiedSortedResults.get(1).getStatus());
         assertEquals("pieceId3", copiedSortedResults.get(2).getPieceId());
@@ -356,6 +368,7 @@ public class PiecesClaimingServiceTest {
     var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1", "pieceId2", "pieceId3", "pieceId4", "pieceId5")).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
+    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())
       .put("CLAIMS_vendorId2", createIntegrationDetail())
@@ -393,8 +406,8 @@ public class PiecesClaimingServiceTest {
         assertEquals(5, result.getClaimingPieceResults().size());
         var copiedSortedResults = new ArrayList<>(result.getClaimingPieceResults());
         copiedSortedResults.sort(Comparator.comparing(ClaimingPieceResult::getPieceId));
-        assertEquals("pieceId1", copiedSortedResults.get(0).getPieceId());
-        assertEquals(ClaimingPieceResult.Status.SUCCESS, copiedSortedResults.get(0).getStatus());
+        assertEquals("pieceId1", copiedSortedResults.getFirst().getPieceId());
+        assertEquals(ClaimingPieceResult.Status.SUCCESS, copiedSortedResults.getFirst().getStatus());
         assertEquals("pieceId2", copiedSortedResults.get(1).getPieceId());
         assertEquals(ClaimingPieceResult.Status.SUCCESS, copiedSortedResults.get(1).getStatus());
         assertEquals("pieceId3", copiedSortedResults.get(2).getPieceId());

--- a/src/test/java/org/folio/service/pieces/PiecesClaimingServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/PiecesClaimingServiceTest.java
@@ -9,6 +9,7 @@ import org.folio.rest.acq.model.Organization;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.ClaimingCollection;
+import org.folio.rest.jaxrs.model.ClaimingPiece;
 import org.folio.rest.jaxrs.model.ClaimingPieceResult;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
@@ -76,10 +77,8 @@ public class PiecesClaimingServiceTest {
 
   @Test
   void testSendClaims_emptyClaimingPieceIds(VertxTestContext testContext) {
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of());
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of());
     var requestContext = mock(RequestContext.class);
-
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
 
     var throwable = Assertions.assertThrows(HttpException.class, () -> piecesClaimingService.sendClaims(claimingCollection, requestContext));
     Assertions.assertInstanceOf(HttpException.class, throwable);
@@ -93,10 +92,9 @@ public class PiecesClaimingServiceTest {
   @Test
   void testSendClaims_noConfigEntries(VertxTestContext testContext) {
     var pieceId1 = UUID.randomUUID().toString();
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId1)).withClaimingInterval(1);
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId(pieceId1))).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()));
 
     piecesClaimingService.sendClaims(claimingCollection, requestContext)
@@ -117,10 +115,9 @@ public class PiecesClaimingServiceTest {
   @Test
   void testSendClaims_noPiecesFound(VertxTestContext testContext) {
     var pieceId1 = UUID.randomUUID().toString();
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId1)).withClaimingInterval(1);
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId(pieceId1))).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("key", "value")));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of()));
 
@@ -141,10 +138,9 @@ public class PiecesClaimingServiceTest {
 
   @Test
   void testSendClaims_pieceStatusNotLate(VertxTestContext testContext) {
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1")).withClaimingInterval(1);
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId("pieceId1"))).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("CLAIMS_vendorId", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(new Piece().withId("pieceId1").withPoLineId("poLineId1").withReceivingStatus(Piece.ReceivingStatus.RECEIVED))));
     when(purchaseOrderLineService.getOrderLineById(any(), any())).thenReturn(Future.succeededFuture(new PoLine().withPurchaseOrderId("orderId1")));
@@ -173,10 +169,9 @@ public class PiecesClaimingServiceTest {
   void testSendClaims_missingOrganizationIntegrationDetailsForTwoOrganizations(VertxTestContext testContext) {
     var pieceId = UUID.randomUUID().toString();
     var piece = new Piece().withId(pieceId).withPoLineId("poLineId").withReceivingStatus(Piece.ReceivingStatus.LATE);
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId));
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId(pieceId)));
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(piece)));
@@ -210,10 +205,9 @@ public class PiecesClaimingServiceTest {
     var piece1 = new Piece().withId(pieceId1).withPoLineId("poLineId1").withReceivingStatus(Piece.ReceivingStatus.LATE);
     var piece2 = new Piece().withId(pieceId2).withPoLineId("poLineId2").withReceivingStatus(Piece.ReceivingStatus.LATE);
     var piece3 = new Piece().withId(pieceId3).withPoLineId("poLineId3").withReceivingStatus(Piece.ReceivingStatus.LATE);
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of(pieceId1, pieceId2, pieceId3));
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId(pieceId1), new ClaimingPiece().withId(pieceId2), new ClaimingPiece().withId(pieceId3)));
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(piece1, piece2, piece3)));
@@ -256,7 +250,30 @@ public class PiecesClaimingServiceTest {
 
   @Test
   void testSendClaims_success(VertxTestContext testContext) {
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1")).withClaimingInterval(1);
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId("pieceId1"))).withClaimingInterval(1);
+    var requestContext = mock(RequestContext.class);
+
+    when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("CLAIMS_vendorId", createIntegrationDetail())));
+    when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(new Piece().withId("pieceId1").withPoLineId("poLineId1").withReceivingStatus(Piece.ReceivingStatus.LATE))));
+    when(purchaseOrderLineService.getOrderLineById(any(), any())).thenReturn(Future.succeededFuture(new PoLine().withPurchaseOrderId("orderId1")));
+    when(purchaseOrderStorageService.getPurchaseOrderById(any(), any())).thenReturn(Future.succeededFuture(new PurchaseOrder().withVendor("vendorId")));
+    when(organizationService.getVendorById(any(), any())).thenReturn(Future.succeededFuture(new Organization().withId("vendorId").withCode("VENDOR").withIsVendor(true)));
+    when(pieceUpdateFlowManager.updatePiecesStatuses(any(), any(), any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+    when(restClient.post(eq(resourcesPath(DATA_EXPORT_SPRING_CREATE_JOB)), any(), any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("status", "CREATED")));
+    when(restClient.postEmptyResponse(any(), any(), any())).thenReturn(Future.succeededFuture());
+
+    piecesClaimingService.sendClaims(claimingCollection, requestContext)
+      .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+        assertEquals(1, result.getClaimingPieceResults().size());
+        assertEquals("pieceId1", result.getClaimingPieceResults().getFirst().getPieceId());
+        assertEquals(ClaimingPieceResult.Status.SUCCESS, result.getClaimingPieceResults().getFirst().getStatus());
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  void testSendClaims_successWithReceivingTenantId(VertxTestContext testContext) {
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId("pieceId1").withReceivingTenantId("receivingTenantId"))).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
     when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
@@ -280,10 +297,9 @@ public class PiecesClaimingServiceTest {
 
   @Test
   void testSendClaims_successWithTwoPieces(VertxTestContext testContext) {
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1", "pieceId2")).withClaimingInterval(1);
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId("pieceId1"), new ClaimingPiece().withId("pieceId2"))).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject().put("CLAIMS_vendorId", createIntegrationDetail())));
     when(pieceStorageService.getPiecesByIds(any(), any())).thenReturn(Future.succeededFuture(List.of(
       new Piece().withId("pieceId1").withPoLineId("poLineId1").withReceivingStatus(Piece.ReceivingStatus.LATE),
@@ -309,10 +325,10 @@ public class PiecesClaimingServiceTest {
 
   @Test
   void testSendClaims_successWithMultipleOrganizations(VertxTestContext testContext) {
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1", "pieceId2", "pieceId3", "pieceId4", "pieceId5")).withClaimingInterval(1);
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId("pieceId1"), new ClaimingPiece().withId("pieceId2"),
+      new ClaimingPiece().withId("pieceId3"), new ClaimingPiece().withId("pieceId4"), new ClaimingPiece().withId("pieceId5"))).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())
       .put("CLAIMS_vendorId2", createIntegrationDetail())));
@@ -365,10 +381,10 @@ public class PiecesClaimingServiceTest {
 
   @Test
   void testSendClaims_successWithMultipleOrganizationsAndOneIntegrationDetail(VertxTestContext testContext) {
-    var claimingCollection = new ClaimingCollection().withClaimingPieceIds(List.of("pieceId1", "pieceId2", "pieceId3", "pieceId4", "pieceId5")).withClaimingInterval(1);
+    var claimingCollection = new ClaimingCollection().withClaimingPieces(List.of(new ClaimingPiece().withId("pieceId1"), new ClaimingPiece().withId("pieceId2"),
+      new ClaimingPiece().withId("pieceId3"), new ClaimingPiece().withId("pieceId4"), new ClaimingPiece().withId("pieceId5"))).withClaimingInterval(1);
     var requestContext = mock(RequestContext.class);
 
-    when(consortiumConfigurationService.overrideContextToCentralTenantIfNeeded(eq(requestContext))).thenReturn(Future.succeededFuture(requestContext));
     when(configurationEntriesCache.loadConfiguration(any(), any())).thenReturn(Future.succeededFuture(new JsonObject()
       .put("CLAIMS_vendorId1", createIntegrationDetail())
       .put("CLAIMS_vendorId2", createIntegrationDetail())

--- a/src/test/resources/mockdata/claiming/send-claims-1-piece-1-vendor-1-job.json
+++ b/src/test/resources/mockdata/claiming/send-claims-1-piece-1-vendor-1-job.json
@@ -1,6 +1,8 @@
 {
-  "claimingPieceIds": [
-    "dcd0ba36-b660-4751-b9fe-c8ac61ff6f99"
+  "claimingPieces": [
+    {
+      "id": "dcd0ba36-b660-4751-b9fe-c8ac61ff6f99"
+    }
   ],
   "claimingInterval": 1,
   "internalNote": "internal",


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1262>

## Approach

- Add override request context in during Send Claims action if Central Ordering is enabled