### PR TITLE
[MODEXPW-578]. New claiming job erases the old ones in "Export manager"

### DIFF
--- a/src/main/java/org/folio/models/claiming/IntegrationDetailField.java
+++ b/src/main/java/org/folio/models/claiming/IntegrationDetailField.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum IntegrationDetailField {
+  JOB_ID("id"),
   TENANT("tenant"),
   EXPORT_TYPE_SPECIFIC_PARAMETERS("exportTypeSpecificParameters"),
   VENDOR_EDI_ORDERS_EXPORT_CONFIG("vendorEdiOrdersExportConfig"),

--- a/src/main/java/org/folio/service/pieces/PiecesClaimingService.java
+++ b/src/main/java/org/folio/service/pieces/PiecesClaimingService.java
@@ -33,12 +33,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.folio.models.claiming.IntegrationDetailField.CLAIM_PIECE_IDS;
 import static org.folio.models.claiming.IntegrationDetailField.EXPORT_TYPE_SPECIFIC_PARAMETERS;
+import static org.folio.models.claiming.IntegrationDetailField.JOB_ID;
 import static org.folio.models.claiming.IntegrationDetailField.VENDOR_EDI_ORDERS_EXPORT_CONFIG;
 import static org.folio.orders.utils.HelperUtils.DATA_EXPORT_SPRING_CONFIG_MODULE_NAME;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
@@ -225,7 +227,9 @@ public class PiecesClaimingService {
   private Future<Void> createJob(String configKey, Object configValue, List<String> pieceIds, RequestContext requestContext) {
     log.info("createJob:: Creating a job, job key: {}, pieces: {}", configKey, pieceIds.size());
     var integrationDetail = new JsonObject(String.valueOf(configValue));
-    integrationDetail.getJsonObject(EXPORT_TYPE_SPECIFIC_PARAMETERS.getValue())
+    var jobId = UUID.randomUUID().toString();
+    integrationDetail.put(JOB_ID.getValue(), jobId)
+      .getJsonObject(EXPORT_TYPE_SPECIFIC_PARAMETERS.getValue())
       .getJsonObject(VENDOR_EDI_ORDERS_EXPORT_CONFIG.getValue())
       .put(CLAIM_PIECE_IDS.getValue(), pieceIds);
     return restClient.post(resourcesPath(DATA_EXPORT_SPRING_CREATE_JOB), integrationDetail, Object.class, requestContext)

--- a/src/test/java/org/folio/rest/impl/PiecesClaimingApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PiecesClaimingApiTest.java
@@ -43,6 +43,7 @@ import static org.folio.TestUtils.getMinimalOrder;
 import static org.folio.TestUtils.getMockAsJson;
 import static org.folio.models.claiming.IntegrationDetailField.CLAIM_PIECE_IDS;
 import static org.folio.models.claiming.IntegrationDetailField.EXPORT_TYPE_SPECIFIC_PARAMETERS;
+import static org.folio.models.claiming.IntegrationDetailField.JOB_ID;
 import static org.folio.models.claiming.IntegrationDetailField.VENDOR_EDI_ORDERS_EXPORT_CONFIG;
 import static org.folio.orders.utils.ResourcePathResolver.ORGANIZATION_STORAGE;
 import static org.folio.orders.utils.ResourcePathResolver.PIECES_STORAGE;
@@ -217,6 +218,11 @@ public class PiecesClaimingApiTest {
           .getJsonArray(CLAIM_PIECE_IDS.getValue()).size())
         .mapToInt(value -> value).sum();
       assertThat(claimedPieceIds, equalTo(request.getClaimingPieceIds().size()));
+
+      var jobId = jobCreations.stream().findFirst()
+        .map(entry -> entry.getString(JOB_ID.getValue()))
+        .orElse(null);
+      assertThat(jobId, is(notNullValue()));
 
       claimingResults.getClaimingPieceResults()
         .forEach(result -> {


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODEXPW-578>

## Approach

- Add a missing Job id into the Claiming integration detail to prevent the newly created job from overwriting the existing one
- Some proof of change from Thunderjet edev running Telepresense:

> 4 Claiming jobs (3 Successful & 1 Scheduled/debug terminated) 
![image](https://github.com/user-attachments/assets/a12596d2-99fc-4c61-8b67-0570e9d3c7fd)

> 4 Claiming jobs with their individual Job ids correctly populated, and resembling the jobs of Ordering type
![image](https://github.com/user-attachments/assets/aee9661e-8d05-477d-b004-0061ae33f84f)

