### PR TITLE
[MODORDERS-1283] Fixed bug with encumbrances when unopening/reopening an order

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -222,7 +222,7 @@ public class PurchaseOrderHelper {
     return purchaseOrderStorageService.getPurchaseOrderByIdAsJson(compPO.getId(), requestContext)
       .map(jsonPoFromStorage -> validateIfPOProtectedAndOngoingFieldsChanged(compPO, jsonPoFromStorage))
       .map(HelperUtils::convertToCompositePurchaseOrder)
-      .compose(lines -> purchaseOrderLineService.populateOrderLines(lines, requestContext))
+      .compose(poFromStorage -> purchaseOrderLineService.populateOrderLines(poFromStorage, requestContext))
       .compose(poFromStorage -> {
         CompositePurchaseOrder clonedPoFromStorage = JsonObject.mapFrom(poFromStorage).mapTo(CompositePurchaseOrder.class);
         boolean isTransitionToOpen = isTransitionToOpen(poFromStorage, compPO);

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -407,9 +407,10 @@ public class PurchaseOrderLineHelper {
     logger.debug("handlePoLines start");
     List<Future<?>> futures = new ArrayList<>(processPoLinesCreation(compOrder, poLinesFromStorage, requestContext));
     if (!poLinesFromStorage.isEmpty()) {
-      futures.addAll(processPoLinesUpdate(compOrder, poLinesFromStorage, requestContext));
+      List<PoLine> linesToProcess = new ArrayList<>(poLinesFromStorage);
+      futures.addAll(processPoLinesUpdate(compOrder, linesToProcess, requestContext));
       // The remaining unprocessed PoLines should be removed
-      poLinesFromStorage.forEach(poLine -> futures.add(
+      linesToProcess.forEach(poLine -> futures.add(
         orderInvoiceRelationService.checkOrderInvoiceRelationship(compOrder.getId(), requestContext)
           .compose(v -> encumbranceService.deletePoLineEncumbrances(poLine, requestContext))
           .compose(v -> purchaseOrderLineService.deletePoLine(poLine, requestContext))));


### PR DESCRIPTION
## Purpose
[MODORDERS-1283](https://folio-org.atlassian.net/browse/MODORDERS-1283) - Reopen an order creates an additional encumbrance

## Approach
- Fixed the bug. See comment in ticket.
The new implementation reflects the way it was working before [MODORDERS-1269](https://folio-org.atlassian.net/browse/MODORDERS-1269), preserving the lines of `poFromStorage` in `PurchaseOrderHelper.updateOrder()`, but with a clearer implementation. It still might not work well if someone opened an order at the same time as removing a line from the composite order, but thankfully this is not likely to happen.
- Renamed a poorly named variable in `PurchaseOrderHelper` (unrelated).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
