### PR TITLE
MODORDERS-1284: Replace net.mguenther.kafka:kafka-junit (EOL)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,31 +353,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>3.6.1</version>
-    </dependency>
-    <dependency>
-      <groupId>net.mguenther.kafka</groupId>
-      <artifactId>kafka-junit</artifactId>
-      <version>3.6.0</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.module</groupId>
-          <artifactId>jackson-module-scala_2.13</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-utils</artifactId>
       <version>1.12.1</version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDERS-1284

## Purpose
Replace the end-of-life net.mguenther.kafka:kafka-junit test dependency.

For details see https://folio-org.atlassian.net/browse/FOLIO-4283

## Approach
Remove net.mguenther.kafka:kafka-junit from pom.xml.
Change test code by using apache kafka client calls.
No change to production code is needed.

#### TODOS and Open Questions
- [x] Check logging.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.