### PR TITLE
MODORDERS-1290: data-import-processing-core 4.4.3, kafka-clients 3.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <mod-configuration-client.version>5.11.0</mod-configuration-client.version>
     <folio-di-support.version>3.0.0</folio-di-support.version>
     <mod-di-converter-storage-client.version>2.3.1</mod-di-converter-storage-client.version>
-    <data-import-processing-core.version>4.4.0</data-import-processing-core.version>
+    <data-import-processing-core.version>4.4.3</data-import-processing-core.version>
 
     <!--Maven plugin dependencies-->
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>

--- a/src/main/java/org/folio/models/pieces/PieceBatchStatusUpdateHolder.java
+++ b/src/main/java/org/folio/models/pieces/PieceBatchStatusUpdateHolder.java
@@ -2,7 +2,7 @@ package org.folio.models.pieces;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PieceCollection;
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDERS-1290


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Upgrade data-import-processing-core from 4.4.0 to 4.4.3.

The data-import-processing-core upgrade indirectly upgrades transitive dependency graal-sdk from 23.0.0 to 24.2.1 fixing

* CVE-2025-21587 – https://github.com/advisories/GHSA-7f6c-8chx-2vm5 – GraalVM timing attack
* CVE-2025-30691 – https://github.com/advisories/GHSA-qh4r-w9x4-6fq2 – GraalVM buffer overflow
* CVE-2025-30698 – https://github.com/advisories/GHSA-3fvx-r9r8-xq97 – GraalVM heap-based boffer overflow

The data-import-processing-core upgrade indirectly upgrades transitive dependency kafka-clients from 3.6.1 to 3.7.1 fixing

* CVE-2024-31141 – https://github.com/advisories/GHSA-2x2g-32r7-p4x8 – Apache Kafka Clients Privilege Escalation

## Approach
Bump data-import-processing-core patch version from 4.4.0 to 4.4.3 in pom.xml.

#### TODOS and Open Questions
- [x] Check logging.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.