### PR TITLE
[MODORDSTOR-458]. Invalid reference is displayed in PO line after changing instance connection for the P/E mix order

### DIFF
--- a/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
+++ b/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
@@ -1,6 +1,7 @@
 package org.folio.models.orders.lines.update;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.folio.rest.acq.model.StoragePatchOrderLineRequest;
 import org.folio.rest.acq.model.StorageReplaceOrderLineHoldingRefs;
@@ -9,9 +10,11 @@ import org.folio.rest.jaxrs.model.PatchOrderLineRequest;
 import org.folio.rest.jaxrs.model.PoLine;
 
 public class OrderLineUpdateInstanceHolder {
+
   private PoLine storagePoLine;
   private PatchOrderLineRequest patchOrderLineRequest;
   private StoragePatchOrderLineRequest storagePatchOrderLineRequest;
+  private final List<String> deletedHoldingIds = new ArrayList<>();
 
   public OrderLineUpdateInstanceHolder withStoragePoLine(PoLine storagePoLine) {
     this.storagePoLine = storagePoLine;
@@ -27,6 +30,10 @@ public class OrderLineUpdateInstanceHolder {
     return this;
   }
 
+  public void addDeletedHoldingId(String holdingId) {
+    this.deletedHoldingIds.add(holdingId);
+  }
+
   public PatchOrderLineRequest getPatchOrderLineRequest() {
     return patchOrderLineRequest;
   }
@@ -35,17 +42,16 @@ public class OrderLineUpdateInstanceHolder {
     return storagePatchOrderLineRequest;
   }
 
-  public OrderLineUpdateInstanceHolder withStoragePathOrderLineRequest(StoragePatchOrderLineRequest storagePathOrderLineRequest) {
-    this.storagePatchOrderLineRequest = storagePathOrderLineRequest;
-    return this;
+  public List<String> getDeletedHoldingIds() {
+    return deletedHoldingIds;
   }
 
   public OrderLineUpdateInstanceHolder createStoragePatchOrderLineRequest(StoragePatchOrderLineRequest.PatchOrderLineOperationType patchOrderLineOperationType,
       String newInstanceId) {
     this.storagePatchOrderLineRequest = new StoragePatchOrderLineRequest()
-        .withOperation(patchOrderLineOperationType)
-        .withReplaceInstanceRef(new StorageReplaceOrderLineInstanceRef()
-            .withNewInstanceId(newInstanceId));
+      .withOperation(patchOrderLineOperationType)
+      .withReplaceInstanceRef(new StorageReplaceOrderLineInstanceRef()
+        .withNewInstanceId(newInstanceId));
     return this;
   }
 
@@ -54,10 +60,10 @@ public class OrderLineUpdateInstanceHolder {
       this.storagePatchOrderLineRequest.getReplaceInstanceRef().withHoldings(new ArrayList<>());
     }
     this.storagePatchOrderLineRequest
-        .getReplaceInstanceRef()
-        .getHoldings()
-        .add(new StorageReplaceOrderLineHoldingRefs()
-            .withFromHoldingId(holdingId)
-            .withToHoldingId(newHoldingId));
+      .getReplaceInstanceRef()
+      .getHoldings()
+      .add(new StorageReplaceOrderLineHoldingRefs()
+        .withFromHoldingId(holdingId)
+        .withToHoldingId(newHoldingId));
   }
 }

--- a/src/main/java/org/folio/service/inventory/InventoryHoldingManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryHoldingManager.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
-import static java.util.stream.Collectors.toList;
 import static one.util.streamex.StreamEx.ofSubLists;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
@@ -190,7 +189,7 @@ public class InventoryHoldingManager {
         String deletedIds = holdings.stream().map(holding -> holding.getString(ID)).collect(Collectors.joining(","));
         logger.debug("Holding ids: {}", deletedIds);
       }
-      return holdings.stream().filter(Objects::nonNull).collect(toList());
+      return holdings.stream().filter(Objects::nonNull).toList();
     });
   }
 
@@ -240,7 +239,7 @@ public class InventoryHoldingManager {
   private Future<Void> updateHoldingRecords(List<JsonObject> holdingRecords, RequestContext requestContext) {
     return GenericCompositeFuture.join(holdingRecords.stream()
         .map(holdingRecord -> updateHolding(holdingRecord, requestContext))
-        .collect(toList()))
+        .toList())
       .mapEmpty();
   }
 
@@ -253,6 +252,9 @@ public class InventoryHoldingManager {
     if (Objects.isNull(location.getLocationId())) {
       return getHoldingById(location.getHoldingId(), true, requestContext)
         .compose(holding -> {
+          if (Objects.isNull(holding)) {
+            return Future.succeededFuture();
+          }
           String locationId = holding.getString(HOLDING_PERMANENT_LOCATION_ID);
           return getFirstHoldingRecord(instanceId, locationId, requestContext)
             .compose(jsonHolding -> {

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -26,7 +26,7 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLine
 
     holder.createStoragePatchOrderLineRequest(StoragePatchOrderLineRequest.PatchOrderLineOperationType.REPLACE_INSTANCE_REF, newInstanceId);
 
-    return deleteAbandonedHoldings(replaceInstanceRef.getDeleteAbandonedHoldings(), holder.getStoragePoLine(), requestContext);
+    return deleteAbandonedHoldings(holder, replaceInstanceRef.getDeleteAbandonedHoldings(), requestContext);
   }
 
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDSTOR-458>

## Approach

- Refactor holding patch operation to avoid retrieving a holding that we just deleted with the "Delete Holdings" option 