### PR TITLE
[MODORDERS-1295] Not received pieces in statuses different from "Expected" are not deleted after related order was unopened

### DIFF
--- a/src/main/java/org/folio/service/orders/flows/update/unopen/UnOpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/unopen/UnOpenCompositeOrderManager.java
@@ -149,7 +149,7 @@ public class UnOpenCompositeOrderManager {
    * deleteHoldings == true && workflow independent => delete holdings
    * deleteHoldings == false && workflow independent => do nothing
    *
-   * @param poLine        the purchase order
+   * @param poLine         the purchase order
    * @param deleteHoldings delete holdings flag
    * @param requestContext the request context
    * @return future with void
@@ -169,17 +169,24 @@ public class UnOpenCompositeOrderManager {
     }
     if (PoLineCommonUtil.isItemsUpdateRequired(poLine)) {
       if (poLine.getCheckinItems()) { // independent workflow
-        return (deleteHoldings) ? processInventoryOnlyWithHolding(poLine, requestContext) : Future.succeededFuture();
+        return (deleteHoldings)
+          ? processInventoryOnlyWithHolding(poLine, requestContext)
+          : Future.succeededFuture();
       } else { // synchronized workflow
-        return (deleteHoldings) ? processInventoryHoldingWithItems(poLine, requestContext) : processInventoryOnlyWithItems(poLine, requestContext);
+        return (deleteHoldings)
+          ? processInventoryHoldingWithItems(poLine, requestContext)
+          : processInventoryOnlyWithItems(poLine, requestContext);
       }
     }
     if (PoLineCommonUtil.isHoldingsUpdateRequired(poLine)) {
       if (poLine.getCheckinItems()) { // independent workflow
-        return (deleteHoldings) ? processInventoryOnlyWithHolding(poLine, requestContext) : Future.succeededFuture();
+        return (deleteHoldings)
+          ? processInventoryOnlyWithHolding(poLine, requestContext)
+          : Future.succeededFuture();
       } else { // synchronized workflow
-        return (deleteHoldings) ? processInventoryOnlyWithHolding(poLine, requestContext) :
-          deleteExpectedPieces(poLine, requestContext).mapEmpty();
+        return (deleteHoldings)
+          ? processInventoryOnlyWithHolding(poLine, requestContext)
+          : deleteExpectedPieces(poLine, requestContext).mapEmpty();
       }
     }
 

--- a/src/main/java/org/folio/service/pieces/PieceStorageService.java
+++ b/src/main/java/org/folio/service/pieces/PieceStorageService.java
@@ -37,7 +37,7 @@ import org.folio.service.settings.util.SettingKey;
 @Log4j2
 public class PieceStorageService {
 
-  private static final String PIECES_BY_POL_ID_AND_STATUS_QUERY = "poLineId==%s and receivingStatus==%s";
+  private static final String PIECES_BY_POL_ID_AND_NOT_STATUS_QUERY = "poLineId==%s and receivingStatus<>%s";
   private static final String PIECES_BY_HOLDING_ID_QUERY = "holdingId==%s";
   private static final String PIECE_STORAGE_ENDPOINT = resourcesPath(PIECES_STORAGE);
   private static final String PIECE_STORAGE_BY_ID_ENDPOINT = PIECE_STORAGE_ENDPOINT + "/{id}";
@@ -136,7 +136,7 @@ public class PieceStorageService {
   }
 
   public Future<PieceCollection> getExpectedPiecesByLineId(String poLineId, RequestContext requestContext) {
-    String query = String.format(PIECES_BY_POL_ID_AND_STATUS_QUERY, poLineId, Piece.ReceivingStatus.EXPECTED.value());
+    String query = String.format(PIECES_BY_POL_ID_AND_NOT_STATUS_QUERY, poLineId, Piece.ReceivingStatus.RECEIVED.value());
     return getAllPieces(query, requestContext);
   }
 

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -1930,7 +1930,7 @@ public class MockServer {
         try {
           List<Piece> piecesList = getMockEntries(PIECES_STORAGE, Piece.class).get();
           if (!isClaimingTenant) {
-            pieces = requestQuery != null && requestQuery.contains("poLineId")
+            pieces = requestQuery != null && requestQuery.contains("poLineId") && requestQuery.contains("receivingStatus")
               ? getPiecesByPolAndStatus(requestQuery, polId -> piecesList.stream().filter(piece -> piece.getPoLineId().equals(polId)).collect(Collectors.toList()))
               : new PieceCollection().withPieces(piecesList);
           } else {

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -76,6 +76,7 @@ import static org.folio.rest.impl.MockServer.getInstancesSearches;
 import static org.folio.rest.impl.MockServer.getItemUpdates;
 import static org.folio.rest.impl.MockServer.getItemsSearches;
 import static org.folio.rest.impl.MockServer.getLoanTypesSearches;
+import static org.folio.rest.impl.MockServer.getPieceDeletions;
 import static org.folio.rest.impl.MockServer.getPieceSearches;
 import static org.folio.rest.impl.MockServer.getPurchaseOrderUpdates;
 import static org.folio.rest.impl.MockServer.getQueryParams;
@@ -115,7 +116,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import io.vertx.core.Vertx;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -152,6 +155,7 @@ import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.Physical.CreateInventory;
 import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.PieceCollection;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLine.OrderFormat;
 import org.folio.rest.jaxrs.model.PoLine.ReceiptStatus;
@@ -179,7 +183,6 @@ import io.restassured.http.Headers;
 import io.restassured.response.Response;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -223,6 +226,7 @@ public class PurchaseOrdersApiTest {
   // API paths
   public static final String COMPOSITE_ORDERS_PATH = "/orders/composite-orders";
   private static final String COMPOSITE_ORDERS_BY_ID_PATH = COMPOSITE_ORDERS_PATH + "/%s";
+  private static final String PIECES_PATH = "/orders/pieces";
 
   static final String LISTED_PRINT_MONOGRAPH_PATH = "po_listed_print_monograph.json";
   static final String LISTED_PRINT_SERIAL_RECEIPT_NOT_REQUIRED_PATH = "po_listed_print_serial_with_receipt_payment_not_required.json";
@@ -284,6 +288,7 @@ public class PurchaseOrdersApiTest {
     okapiHeaders.put(X_OKAPI_USER_ID.getName(), X_OKAPI_USER_ID.getValue());
     requestContext = new RequestContext(context, okapiHeaders);
   }
+
   @BeforeAll
   static void before() throws InterruptedException, ExecutionException, TimeoutException {
     if (isVerticleNotDeployed()) {
@@ -2991,6 +2996,35 @@ public class PurchaseOrdersApiTest {
     });
   }
 
+  @Test
+  void testOpenAndUnopenSynchronizedOrderDeletesNonReceivedPieces() throws Exception {
+    logger.info("=== testOpenAndUnopenSynchronizedOrderDeletedNonReceivedPieces ===");
+    var order = new JsonObject(getMockData(MINIMAL_ORDER_PATH)).mapTo(CompositePurchaseOrder.class)
+      .withId(UUID.randomUUID().toString())
+      .withWorkflowStatus(WorkflowStatus.OPEN);
+    var pol = order.getPoLines().getFirst()
+      .withId(UUID.randomUUID().toString());
+
+    // Create order
+    addMockEntry(PURCHASE_ORDER_STORAGE, JsonObject.mapFrom(order));
+    addMockEntry(PO_LINES_STORAGE, JsonObject.mapFrom(pol));
+    preparePiecesForCompositePo(order);
+    assertThat(getPiecesByLineId(pol.getId()), hasSize(2));
+
+    // Add received piece
+    addMockEntry(PIECES_STORAGE, new Piece().withId(UUID.randomUUID().toString()).withPoLineId(pol.getId())
+      .withLocationId(pol.getLocations().getFirst().getLocationId()).withFormat(OTHER)
+      .withReceivingStatus(Piece.ReceivingStatus.RECEIVED).withTitleId(SAMPLE_TITLE_ID));
+    assertThat(getPiecesByLineId(pol.getId()), hasSize(3));
+
+    // Unopen order
+    order.setWorkflowStatus(WorkflowStatus.PENDING);
+    verifyPut(String.format(COMPOSITE_ORDERS_BY_ID_PATH, order.getId()), JsonObject.mapFrom(order).toString(),
+      prepareHeaders(NON_EXIST_CONFIG_X_OKAPI_TENANT, X_OKAPI_USER_ID, UNOPEN_PERMISSIONS_HEADER),"", 204);
+
+    assertThat(getPieceDeletions(), hasSize(2));
+  }
+
   private CompositePurchaseOrder prepareCompositeOrderOpenRequest(CompositePurchaseOrder po) {
     CompositePurchaseOrder compositeOrderPutRequest = new CompositePurchaseOrder();
     compositeOrderPutRequest.setId(ORDER_WITHOUT_MATERIAL_TYPES_ID);
@@ -3021,11 +3055,19 @@ public class PurchaseOrdersApiTest {
 
     return order;
   }
+
   private static JsonObject getMockOrderWithStatusPaymentNotRequired() throws Exception {
     JsonObject order = new JsonObject(getMockData(LISTED_PRINT_SERIAL_RECEIPT_NOT_REQUIRED_PATH));
     order.put("workflowStatus", "Pending");
 
     return order;
+  }
+
+  private static List<Piece> getPiecesByLineId(String poLineId) {
+    var pieces = verifySuccessGet(PIECES_PATH, PieceCollection.class);
+    return pieces.getPieces().stream()
+      .filter(piece -> poLineId.equals(piece.getPoLineId()))
+      .collect(Collectors.toList());
   }
 
   private void preparePiecesForCompositePo(CompositePurchaseOrder reqData) {
@@ -3035,7 +3077,8 @@ public class PurchaseOrdersApiTest {
           .withTitle(poLine.getTitleOrPackage()).withPoLineId(poLine.getId());
         addMockEntry(TITLES, JsonObject.mapFrom(title));
         addMockEntry(PIECES_STORAGE,
-          new Piece().withPoLineId(poLine.getId())
+          new Piece().withId(UUID.randomUUID().toString())
+            .withPoLineId(poLine.getId())
             .withLocationId(location.getLocationId()).withFormat(OTHER)
             .withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
             .withTitleId(title.getId()));

--- a/src/test/resources/minimal_order.json
+++ b/src/test/resources/minimal_order.json
@@ -23,11 +23,13 @@
       "locations": [
         {
           "locationId": "758258bc-ecc1-41b8-abca-f7b610822ffd",
-          "quantityPhysical": 1
+          "quantityPhysical": 1,
+          "quantity": 1
         },
         {
           "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
-          "quantityPhysical": 1
+          "quantityPhysical": 1,
+          "quantity": 1
         }
       ],
       "orderFormat" : "Physical Resource",


### PR DESCRIPTION
## Purpose
[[MODORDERS-1295] Not received pieces in statuses different from "Expected" are not deleted after related order was unopened](https://folio-org.atlassian.net/browse/MODORDERS-1295)

## Approach
Delete pieces with status other than 'Received' after unopening the order