### PR TITLE
[MODORDERS-1278]. Display the fiscal year in which the Order was opened based on "Date opened"

### DIFF
--- a/src/main/java/org/folio/service/finance/transaction/EncumbranceWorkflowStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbranceWorkflowStrategy.java
@@ -15,7 +15,9 @@ public interface EncumbranceWorkflowStrategy {
       CompositePurchaseOrder compPO, CompositePurchaseOrder poAndLinesFromStorage, RequestContext requestContext) {
     return Future.succeededFuture();
   }
+
   Future<Void> processEncumbrances(CompositePurchaseOrder compPO, CompositePurchaseOrder poAndLinesFromStorage,
     RequestContext requestContext);
+
   OrderWorkflowType getStrategyName();
 }

--- a/src/main/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/OpenToPendingEncumbranceStrategy.java
@@ -24,9 +24,12 @@ public class OpenToPendingEncumbranceStrategy implements EncumbranceWorkflowStra
   @Override
   public Future<Void> processEncumbrances(CompositePurchaseOrder compPO, CompositePurchaseOrder poAndLinesFromStorage,
       RequestContext requestContext) {
-
     return getOrderEncumbrances(compPO, poAndLinesFromStorage, requestContext)
       .map(this::makeEncumbrancesPending)
+      .map(encumbrances -> {
+        compPO.withFiscalYearId(null);
+        return encumbrances;
+      })
       .compose(transactions -> encumbranceService.updateEncumbrances(transactions, requestContext));
   }
 

--- a/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
@@ -56,8 +56,8 @@ public class PendingToOpenEncumbranceStrategy implements EncumbranceWorkflowStra
         holders.stream()
           .filter(Objects::nonNull)
           .filter(holder -> Objects.nonNull(holder.getCurrentFiscalYearId()))
-          .findFirst()
-          .ifPresent(fiscalYearId -> compPO.withFiscalYearId(holders.getFirst().getCurrentFiscalYearId()));
+          .findFirst().map(EncumbranceRelationsHolder::getCurrentFiscalYearId)
+          .ifPresent(compPO::withFiscalYearId);
         return encumbranceRelationsHoldersBuilder.withExistingTransactions(holders, poAndLinesFromStorage, requestContext);
       })
       .map(v -> fundsDistributionService.distributeFunds(holders))

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManager.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManager.java
@@ -160,7 +160,7 @@ public class OpenCompositeOrderManager {
 
   private void updateIncomingOrder(CompositePurchaseOrder compPO, CompositePurchaseOrder poFromStorage, RequestContext requestContext) {
     compPO.setWorkflowStatus(OPEN);
-    compPO.setOrderedById(getCurrentUserId(requestContext.getHeaders()));
+    compPO.setOpenedById(getCurrentUserId(requestContext.getHeaders()));
     compPO.setDateOrdered(new Date());
     if (CollectionUtils.isEmpty(compPO.getPoLines())) {
       CompositePurchaseOrder clonedPoFromStorage = JsonObject.mapFrom(poFromStorage).mapTo(CompositePurchaseOrder.class);

--- a/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManagerTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderManagerTest.java
@@ -1,5 +1,6 @@
 package org.folio.service.orders.flows.update.open;
 
+import static io.vertx.core.Future.succeededFuture;
 import static org.folio.TestConfig.autowireDependencies;
 import static org.folio.TestConfig.clearServiceInteractions;
 import static org.folio.TestConfig.clearVertxContext;
@@ -7,22 +8,40 @@ import static org.folio.TestConfig.getFirstContextFromVertx;
 import static org.folio.TestConfig.getVertx;
 import static org.folio.TestConfig.initSpringContext;
 import static org.folio.TestConfig.isVerticleNotDeployed;
-import static org.folio.rest.impl.MockServer.BASE_MOCK_DATA_PATH;
+import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
+import static org.folio.service.orders.flows.update.open.OpenCompositeOrderManager.DISABLE_INSTANCE_MARCHING_CONFIG_KEY;
+import static org.folio.service.orders.flows.update.open.OpenCompositeOrderManager.DISABLE_INSTANCE_MARCHING_CONFIG_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import org.folio.ApiTestSuite;
+import org.folio.CopilotGenerated;
 import org.folio.helper.PurchaseOrderLineHelper;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.Title;
 import org.folio.service.AcquisitionsUnitsService;
 import org.folio.service.ProtectionService;
 import org.folio.service.configuration.ConfigurationEntriesService;
 import org.folio.service.finance.expenceclass.ExpenseClassValidationService;
 import org.folio.service.finance.transaction.EncumbranceService;
+import org.folio.service.finance.transaction.EncumbranceWorkflowStrategy;
 import org.folio.service.finance.transaction.EncumbranceWorkflowStrategyFactory;
 import org.folio.service.finance.transaction.ReceivingEncumbranceStrategy;
 import org.folio.service.inventory.InventoryItemManager;
@@ -39,16 +58,19 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 
 import io.vertx.core.Context;
 
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(VertxExtension.class)
 public class OpenCompositeOrderManagerTest {
-  public static final String LINE_ID = "c0d08448-347b-418a-8c2f-5fb50248d67e";
-  private static final String COMPOSITE_LINES_PATH = BASE_MOCK_DATA_PATH + "compositeLines/";
 
   @Autowired
   private OpenCompositeOrderManager openCompositeOrderManager;
@@ -86,7 +108,7 @@ public class OpenCompositeOrderManagerTest {
   }
 
   @BeforeAll
-  public static void before() throws InterruptedException, ExecutionException, TimeoutException {
+  static void before() throws InterruptedException, ExecutionException, TimeoutException {
     if (isVerticleNotDeployed()) {
       ApiTestSuite.before();
       runningOnOwn = true;
@@ -95,7 +117,7 @@ public class OpenCompositeOrderManagerTest {
   }
 
   @AfterAll
-  public static void after() {
+  static void after() {
     clearVertxContext();
     if (runningOnOwn) {
       ApiTestSuite.after();
@@ -105,6 +127,52 @@ public class OpenCompositeOrderManagerTest {
   @AfterEach
   void resetMocks() {
     clearServiceInteractions();
+  }
+
+  @Test
+  @CopilotGenerated(model = "Claude 3.5 Sonnet")
+  void testUpdateIncomingOrderShouldSetOpenedById(VertxTestContext vertxTestContext) {
+    // Given
+    var userId = UUID.randomUUID().toString();
+    var compPO = new CompositePurchaseOrder()
+      .withId(UUID.randomUUID().toString())
+      .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.PENDING);
+    var poFromStorage = JsonObject.mapFrom(compPO).mapTo(CompositePurchaseOrder.class);
+    var config = new JsonObject().put(DISABLE_INSTANCE_MARCHING_CONFIG_NAME,
+      new JsonObject().put(DISABLE_INSTANCE_MARCHING_CONFIG_KEY, true).encode());
+
+    // Mock headers to return specific user ID
+    when(okapiHeadersMock.get(anyString())).thenReturn(userId);
+
+    // Setup other required mocks
+    when(openCompositeOrderFlowValidator.validate(any(), any(), any()))
+      .thenReturn(succeededFuture());
+
+    Map<String, List<Title>> emptyTitles = new HashMap<>();
+    when(titlesService.fetchNonPackageTitles(any(), any()))
+      .thenReturn(succeededFuture(emptyTitles));
+
+    when(openCompositeOrderInventoryService.processInventory(any(), any(), anyBoolean(), any()))
+      .thenReturn(succeededFuture());
+
+    var mockStrategy = mock(EncumbranceWorkflowStrategy.class);
+    when(mockStrategy.processEncumbrances(any(), any(), any()))
+      .thenReturn(succeededFuture());
+    when(encumbranceWorkflowStrategyFactory.getStrategy(any()))
+      .thenReturn(mockStrategy);
+
+    // When
+    var future = openCompositeOrderManager.process(compPO, poFromStorage, config, requestContext);
+
+    // Then
+    vertxTestContext.assertComplete(future)
+      .onSuccess(v -> vertxTestContext.verify(() -> {
+        assertEquals(OPEN, compPO.getWorkflowStatus());
+        assertEquals(userId, compPO.getOpenedById());
+        assertNotNull(compPO.getDateOrdered());
+        vertxTestContext.completeNow();
+      }))
+      .onFailure(vertxTestContext::failNow);
   }
 
   private static class ContextConfiguration {
@@ -186,6 +254,10 @@ public class OpenCompositeOrderManagerTest {
       return mock(RestClient.class);
     }
 
+    @Bean
+    UnOpenCompositeOrderManager unOpenCompositeOrderManager() {
+      return mock(UnOpenCompositeOrderManager.class);
+    }
 
     @Bean OpenCompositeOrderManager openCompositeOrderManager(PurchaseOrderLineService purchaseOrderLineService,
       EncumbranceWorkflowStrategyFactory encumbranceWorkflowStrategyFactory,


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1278>

## Approach

- Add mapping of `fiscalYearId` on Purchase Order Open/Unopen operation
- Add mapping of `openedById` on Purchase Order Open operation
- Cover new fields with unit tests