### PR TITLE
[MODORDERS-1310] Avoid creating unnecessary shadow instances

### DIFF
--- a/src/main/java/org/folio/service/inventory/InventoryInstanceManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryInstanceManager.java
@@ -95,6 +95,53 @@ public class InventoryInstanceManager {
     this.consortiumConfigurationService = consortiumConfigurationService;
   }
 
+  public Future<SharingInstance> createShadowInstanceIfNeeded(String instanceId, RequestContext requestContext) {
+    return consortiumConfigurationService.getConsortiumConfiguration(requestContext)
+      .compose(consortiumConfiguration -> createShadowInstanceIfNeeded(instanceId, consortiumConfiguration.orElse(null), requestContext));
+  }
+
+  public Future<String> getOrCreateInstanceRecord(Title title, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
+    logger.debug("InventoryInstanceManager.getOrCreateInstanceRecord title.id={}", title.getId());
+    if (CollectionUtils.isEmpty(title.getProductIds()) || isInstanceMatchingDisabled) {
+      return createInstanceRecord(title, requestContext);
+    }
+
+    return searchInstancesByProducts(title.getProductIds(), requestContext)
+      .compose(instances -> {
+        if (!instances.getJsonArray(INSTANCES).isEmpty()) {
+          String instanceId = getFirstObjectFromResponse(instances, INSTANCES).getString(ID);
+          return Future.succeededFuture(instanceId);
+        }
+        return createInstanceRecord(title, requestContext);
+      });
+  }
+
+  public Future<PoLine> openOrderHandleInstance(PoLine poLine, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
+    logger.debug("InventoryInstanceManager.openOrderHandleInstance");
+    return consortiumConfigurationService.getConsortiumConfiguration(requestContext)
+      .compose(configuration ->
+        getOrCreateInstanceRecordForPoLine(poLine, isInstanceMatchingDisabled, configuration.orElse(null), requestContext))
+      .map(poLine::withInstanceId);
+  }
+
+  public Future<String> createInstanceRecord(Title title, RequestContext requestContext) {
+    logger.debug("InventoryInstanceManager.createInstanceRecord title.id={}", title.getId());
+    JsonObject lookupObj = new JsonObject();
+    Future<Void> instanceTypeFuture = InventoryUtils.getEntryId(configurationEntriesCache, inventoryCache, INSTANCE_TYPES, MISSING_INSTANCE_TYPE, requestContext)
+      .onSuccess(lookupObj::mergeIn)
+      .mapEmpty();
+
+    Future<Void> statusFuture = InventoryUtils.getEntryId(configurationEntriesCache, inventoryCache, INSTANCE_STATUSES, MISSING_INSTANCE_STATUS, requestContext)
+      .onSuccess(lookupObj::mergeIn)
+      .mapEmpty();
+
+    Future<Void> contributorNameTypeIdFuture = verifyContributorNameTypesExist(title.getContributors(), requestContext);
+
+    return GenericCompositeFuture.join(List.of(instanceTypeFuture, statusFuture, contributorNameTypeIdFuture))
+      .map(cf -> buildInstanceRecordJsonObject(title, lookupObj))
+      .compose(instanceJson -> createInstance(instanceJson, requestContext));
+  }
+
   Future<JsonObject> searchInstancesByProducts(List<ProductId> productIds, RequestContext requestContext) {
     String query = productIds.stream()
       .map(this::buildProductIdQuery)
@@ -153,41 +200,73 @@ public class InventoryInstanceManager {
     return instance;
   }
 
-  Future<JsonObject> getInstanceById(String instanceId, boolean skipNotFoundException, RequestContext requestContext) {
-    RequestEntry requestEntry = new RequestEntry(INVENTORY_LOOKUP_ENDPOINTS.get(INSTANCE_RECORDS_BY_ID_ENDPOINT)).withId(instanceId);
-    return restClient.getAsJsonObject(requestEntry, skipNotFoundException, requestContext);
-  }
-
   /**
-   * Returns Id of the Instance Record corresponding to given PO line.
-   * Instance record is either retrieved from Inventory or a new one is created if no corresponding Record exists.
+   * Returns the id of the instance record corresponding to given PO line.
+   * The instance record is either retrieved from inventory or a new one is created if no corresponding record exists.
+   * If the instance is not found in the member tenant but is found in the central tenant, create shadow copies
+   * in tenants where it is missing.
    *
-   * @param poLine PO line to retrieve Instance Record Id for
-   * @return future with Instance Id
+   * @param poLine - PO line to retrieve instance record id for
+   * @param isInstanceMatchingDisabled - If true, do not look for instance in inventory, always create it if missing
+   * @param configuration - consortium configuration (null in a non-ECS environment)
+   * @return Future with instance id
    */
-  private Future<String> getInstanceRecord(PoLine poLine, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
-    logger.debug("InventoryInstanceManager.getInstanceRecord poLine.id={}", poLine.getId());
+  private Future<String> getOrCreateInstanceRecordForPoLine(PoLine poLine, boolean isInstanceMatchingDisabled,
+      ConsortiumConfiguration configuration, RequestContext requestContext) {
+    logger.debug("getOrCreateInstanceRecordForPoLine:: poLine.id={}", poLine.getId());
     if (poLine.getInstanceId() != null) {
       return Future.succeededFuture(poLine.getInstanceId());
     }
-    // proceed with new Instance Record creation if no productId is provided
+    // proceed with new instance record creation if no productId is provided
     if (!isProductIdsExist(poLine) || isInstanceMatchingDisabled) {
-      logger.debug("getInstanceRecord:: no productId is provided - create instance record");
+      logger.debug("getOrCreateInstanceRecordForPoLine:: no productId is provided - create instance record");
       return createInstanceRecord(poLine, requestContext);
     }
-
     String query = poLine.getDetails().getProductIds().stream()
       .map(this::buildProductIdQuery)
       .collect(joining(" or "));
+    return getInstanceRecordAndShareIfNeeded(query, poLine, configuration, requestContext)
+      .compose(id -> {
+        if (id != null) {
+          return Future.succeededFuture(id);
+        }
+        logger.debug("getOrCreateInstanceRecordForPoLine:: instance not found - create it");
+        return createInstanceRecord(poLine, requestContext);
+      });
+  }
+
+  private Future<String> getInstanceRecordAndShareIfNeeded(String query, PoLine poLine,
+      ConsortiumConfiguration configuration, RequestContext requestContext) {
+    return getInstanceIdByQuery(query, requestContext)
+      .compose(instanceId1 -> {
+        if (instanceId1 != null) {
+          logger.debug("getInstanceRecordAndShareIfNeeded:: instance found in local tenant: {}", instanceId1);
+          return Future.succeededFuture(instanceId1);
+        }
+        if (configuration == null) {
+          return Future.succeededFuture(null);
+        }
+        logger.debug("getInstanceRecordAndShareIfNeeded:: instance not found - look for it in central tenant");
+        return getInstanceIdByQuery(query, createContextWithNewTenantId(requestContext, configuration.centralTenantId()))
+          .compose(instanceId2 -> {
+            if (instanceId2 == null) {
+              return Future.succeededFuture(null);
+            }
+            logger.debug("getInstanceRecordAndShareIfNeeded:: instance found in central tenant: {}", instanceId2);
+            return shareInstanceAmongTenantsIfNeeded(instanceId2, configuration, poLine.getLocations(), requestContext);
+          });
+      });
+  }
+
+  private Future<String> getInstanceIdByQuery(String query, RequestContext requestContext) {
     RequestEntry requestEntry = new RequestEntry(INVENTORY_LOOKUP_ENDPOINTS.get(INSTANCES))
       .withQuery(query).withOffset(0).withLimit(Integer.MAX_VALUE);
     return restClient.getAsJsonObject(requestEntry, requestContext)
-      .compose(instances -> {
-        if (!instances.getJsonArray(INSTANCES).isEmpty()) {
-          return Future.succeededFuture(extractId(getFirstObjectFromResponse(instances, INSTANCES)));
+      .map(instances -> {
+        if (instances.getJsonArray(INSTANCES).isEmpty()) {
+          return null;
         }
-        logger.debug("getInstanceRecord:: instance not found - create it");
-        return createInstanceRecord(poLine, requestContext);
+        return extractId(getFirstObjectFromResponse(instances, INSTANCES));
       });
   }
 
@@ -273,7 +352,7 @@ public class InventoryInstanceManager {
       productId.getProductIdType(), productId.getProductId());
   }
 
-  public Future<Void> verifyContributorNameTypesExist(List<Contributor> contributors, RequestContext requestContext) {
+  private Future<Void> verifyContributorNameTypesExist(List<Contributor> contributors, RequestContext requestContext) {
     List<String> ids = contributors.stream()
       .map(contributor -> contributor.getContributorNameTypeId().toLowerCase())
       .distinct()
@@ -315,40 +394,6 @@ public class InventoryInstanceManager {
       });
   }
 
-  public Future<String> getOrCreateInstanceRecord(Title title, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
-    logger.debug("InventoryInstanceManager.getOrCreateInstanceRecord title.id={}", title.getId());
-    if (CollectionUtils.isEmpty(title.getProductIds()) || isInstanceMatchingDisabled) {
-      return createInstanceRecord(title, requestContext);
-    }
-
-    return searchInstancesByProducts(title.getProductIds(), requestContext)
-      .compose(instances -> {
-        if (!instances.getJsonArray(INSTANCES).isEmpty()) {
-          String instanceId = getFirstObjectFromResponse(instances, INSTANCES).getString(ID);
-          return Future.succeededFuture(instanceId);
-        }
-        return createInstanceRecord(title, requestContext);
-      });
-  }
-
-  public Future<String> createInstanceRecord(Title title, RequestContext requestContext) {
-    logger.debug("InventoryInstanceManager.createInstanceRecord title.id={}", title.getId());
-    JsonObject lookupObj = new JsonObject();
-    Future<Void> instanceTypeFuture = InventoryUtils.getEntryId(configurationEntriesCache, inventoryCache, INSTANCE_TYPES, MISSING_INSTANCE_TYPE, requestContext)
-      .onSuccess(lookupObj::mergeIn)
-      .mapEmpty();
-
-    Future<Void> statusFuture = InventoryUtils.getEntryId(configurationEntriesCache, inventoryCache, INSTANCE_STATUSES, MISSING_INSTANCE_STATUS, requestContext)
-      .onSuccess(lookupObj::mergeIn)
-      .mapEmpty();
-
-    Future<Void> contributorNameTypeIdFuture = verifyContributorNameTypesExist(title.getContributors(), requestContext);
-
-    return GenericCompositeFuture.join(List.of(instanceTypeFuture, statusFuture, contributorNameTypeIdFuture))
-      .map(cf -> buildInstanceRecordJsonObject(title, lookupObj))
-      .compose(instanceJson -> createInstance(instanceJson, requestContext));
-  }
-
   private Future<String> createInstance(JsonObject instanceRecJson, RequestContext requestContext) {
     RequestEntry requestEntry = new RequestEntry(INVENTORY_LOOKUP_ENDPOINTS.get(INSTANCES));
     return restClient.postJsonObjectAndGetId(requestEntry, instanceRecJson, requestContext)
@@ -356,19 +401,9 @@ public class InventoryInstanceManager {
       .onFailure(t -> logger.error("createInstance:: Failed to create instance", t));
   }
 
-  public Future<PoLine> openOrderHandleInstance(PoLine poLine, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
-    logger.debug("InventoryInstanceManager.openOrderHandleInstance");
-    return consortiumConfigurationService.getConsortiumConfiguration(requestContext)
-      .compose(configuration ->
-        getInstanceRecord(poLine, isInstanceMatchingDisabled, requestContext)
-          .compose(instanceId -> configuration
-            .map(consortiumConfiguration -> shareInstanceAmongTenantsIfNeeded(instanceId, consortiumConfiguration, poLine.getLocations(), requestContext))
-            .orElse(Future.succeededFuture(instanceId))))
-      .map(poLine::withInstanceId);
-  }
-
   private Future<String> shareInstanceAmongTenantsIfNeeded(String instanceId, ConsortiumConfiguration consortiumConfiguration,
                                                            List<Location> locations, RequestContext requestContext) {
+    logger.debug("InventoryInstanceManager.shareInstanceAmongTenantsIfNeeded");
     return getTenantIdsWithoutShadowInstances(instanceId, consortiumConfiguration, locations, requestContext)
       .map(tenantIds -> tenantIds.stream()
         .map(tenantId -> createShadowInstanceIfNeeded(instanceId, consortiumConfiguration, createContextWithNewTenantId(requestContext, tenantId)))
@@ -400,11 +435,6 @@ public class InventoryInstanceManager {
       });
   }
 
-  public Future<SharingInstance> createShadowInstanceIfNeeded(String instanceId, RequestContext requestContext) {
-    return consortiumConfigurationService.getConsortiumConfiguration(requestContext)
-      .compose(consortiumConfiguration -> createShadowInstanceIfNeeded(instanceId, consortiumConfiguration.orElse(null), requestContext));
-  }
-
   private Future<SharingInstance> createShadowInstanceIfNeeded(String instanceId, ConsortiumConfiguration consortiumConfiguration, RequestContext requestContext) {
     if (consortiumConfiguration == null) {
       logger.debug("createShadowInstanceIfNeeded:: Skipping creating shadow instance for non ECS mode.");
@@ -425,6 +455,11 @@ public class InventoryInstanceManager {
         logger.info("createShadowInstanceIfNeeded:: Creating shadow instance with instanceId: {} in tenant: {}", instanceId, targetTenant);
         return sharingInstanceService.createShadowInstance(instanceId, consortiumConfiguration, requestContext);
       });
+  }
+
+  private Future<JsonObject> getInstanceById(String instanceId, boolean skipNotFoundException, RequestContext requestContext) {
+    RequestEntry requestEntry = new RequestEntry(INVENTORY_LOOKUP_ENDPOINTS.get(INSTANCE_RECORDS_BY_ID_ENDPOINT)).withId(instanceId);
+    return restClient.getAsJsonObject(requestEntry, skipNotFoundException, requestContext);
   }
 
 }

--- a/src/test/java/org/folio/service/inventory/InventoryInstanceManagerTest.java
+++ b/src/test/java/org/folio/service/inventory/InventoryInstanceManagerTest.java
@@ -1,18 +1,23 @@
 package org.folio.service.inventory;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.folio.models.consortium.ConsortiumConfiguration;
 import org.folio.models.consortium.SharingInstance;
 import org.folio.models.consortium.SharingInstanceCollection;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.Details;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.Location;
+import org.folio.rest.jaxrs.model.ProductId;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.caches.ConfigurationEntriesCache;
 import org.folio.service.caches.InventoryCache;
 import org.folio.service.consortium.ConsortiumConfigurationService;
 import org.folio.service.consortium.SharingInstanceService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -65,13 +70,36 @@ public class InventoryInstanceManagerTest {
     inventoryInstanceManager = new InventoryInstanceManager(restClient, configurationEntriesCache, inventoryCache, sharingInstanceService, consortiumConfigurationService);
   }
 
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockitoMocks.close();
+  }
+
   @Test
-  void shouldNoShareInstanceWhenNonEcsMode() {
+  void shouldUseExistingInstanceId() {
     String instanceId = UUID.randomUUID().toString();
     PoLine poLine = getPoLine(instanceId, List.of(
       new Location().withTenantId(MEMBER_TENANT_1),
       new Location().withTenantId(CENTRAL_TENANT)));
     doReturn(succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
+
+    inventoryInstanceManager.openOrderHandleInstance(poLine, false, requestContext).result();
+
+    verifyNoInteractions(restClient);
+    verifyNoInteractions(sharingInstanceService);
+  }
+
+  @Test
+  void shouldNotShareInstanceWhenNonEcsMode() {
+    PoLine poLine = getPoLine(null, List.of(
+      new Location().withTenantId(MEMBER_TENANT_1),
+      new Location().withTenantId(CENTRAL_TENANT)));
+    doReturn(succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
+
+    JsonObject emptyInstanceCollection = new JsonObject();
+    emptyInstanceCollection.put("instances", new JsonArray());
+    doReturn(succeededFuture(emptyInstanceCollection))
+      .when(restClient).getAsJsonObject(any(RequestEntry.class), any(RequestContext.class));
 
     inventoryInstanceManager.openOrderHandleInstance(poLine, false, requestContext).result();
 
@@ -81,11 +109,22 @@ public class InventoryInstanceManagerTest {
   @Test
   void shouldNotShareInstanceAmongTenantsWhenInstancesAlreadyShared() {
     String instanceId = UUID.randomUUID().toString();
-    PoLine poLine = getPoLine(instanceId, List.of(
+    PoLine poLine = getPoLine(null, List.of(
       new Location().withTenantId(MEMBER_TENANT_1),
       new Location().withTenantId(CENTRAL_TENANT)));
     Optional<ConsortiumConfiguration> configuration = Optional.of(new ConsortiumConfiguration(CENTRAL_TENANT, UUID.randomUUID().toString()));
     doReturn(succeededFuture(configuration)).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
+
+    JsonObject emptyInstanceCollection = new JsonObject();
+    emptyInstanceCollection.put("instances", new JsonArray());
+    JsonObject instanceCollection = new JsonObject();
+    JsonObject instanceAsJson = new JsonObject();
+    instanceAsJson.put("id", instanceId);
+    instanceCollection.put("instances", JsonArray.of(instanceAsJson));
+    doReturn(succeededFuture(emptyInstanceCollection))
+      .doReturn(succeededFuture(instanceCollection))
+      .when(restClient).getAsJsonObject(any(RequestEntry.class), any(RequestContext.class));
+
 
     SharingInstanceCollection collection = getSharingInstanceCollection(instanceId, MEMBER_TENANT_1, CENTRAL_TENANT);
     doReturn(succeededFuture(collection)).when(sharingInstanceService).getSharingInstances(instanceId, configuration.get(), requestContext);
@@ -96,36 +135,54 @@ public class InventoryInstanceManagerTest {
   }
 
   @Test
-  void shouldShareInstance() {
-    String instanceId = UUID.randomUUID().toString();
-    PoLine poLine = getPoLine(instanceId, List.of(
+  void shouldShareInstanceWhenFoundInCentralTenant() {
+    String centralInstanceId = UUID.randomUUID().toString();
+    PoLine poLine = getPoLine(null, List.of(
       new Location().withTenantId(MEMBER_TENANT_1),
       new Location().withTenantId(MEMBER_TENANT_2)));
+    JsonObject emptyInstanceCollection = new JsonObject();
+    emptyInstanceCollection.put("instances", new JsonArray());
+    JsonObject instanceCollection = new JsonObject();
+    JsonObject instanceAsJson = new JsonObject();
+    instanceAsJson.put("id", centralInstanceId);
+    instanceCollection.put("instances", JsonArray.of(instanceAsJson));
     Optional<ConsortiumConfiguration> configuration = Optional.of(new ConsortiumConfiguration(CENTRAL_TENANT, UUID.randomUUID().toString()));
-    doReturn(succeededFuture(configuration)).when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
-    doReturn(succeededFuture(null)).when(restClient).getAsJsonObject(any(RequestEntry.class), eq(true), any(RequestContext.class));
+
+    doReturn(succeededFuture(configuration))
+      .when(consortiumConfigurationService).getConsortiumConfiguration(requestContext);
+    doReturn(succeededFuture(emptyInstanceCollection))
+      .doReturn(succeededFuture(instanceCollection))
+      .when(restClient).getAsJsonObject(any(RequestEntry.class), any(RequestContext.class));
+    doReturn(succeededFuture(null))
+      .when(restClient).getAsJsonObject(any(RequestEntry.class), eq(true), any(RequestContext.class));
 
     SharingInstanceCollection collection = new SharingInstanceCollection();
-    SharingInstance sharingInstance = new SharingInstance(UUID.fromString(instanceId), MEMBER_TENANT_1, CENTRAL_TENANT);
+    SharingInstance sharingInstance = new SharingInstance(UUID.fromString(centralInstanceId), MEMBER_TENANT_2, CENTRAL_TENANT);
     collection.setSharingInstances(List.of(sharingInstance));
 
-    doReturn(succeededFuture(collection)).when(sharingInstanceService).getSharingInstances(instanceId, configuration.get(), requestContext);
+    doReturn(succeededFuture(collection))
+      .when(sharingInstanceService).getSharingInstances(centralInstanceId, configuration.get(), requestContext);
 
     ArgumentCaptor<RequestContext> requestContextCaptor = ArgumentCaptor.forClass(RequestContext.class);
 
     inventoryInstanceManager.openOrderHandleInstance(poLine, false, requestContext).result();
 
-    verify(sharingInstanceService, times(1)).createShadowInstance(eq(instanceId), eq(configuration.get()), requestContextCaptor.capture());
+    verify(sharingInstanceService, times(1))
+      .createShadowInstance(eq(centralInstanceId), eq(configuration.get()), requestContextCaptor.capture());
 
     RequestContext requestContextForSharing = requestContextCaptor.getValue();
     String tenantId = TenantTool.tenantId(requestContextForSharing.getHeaders());
-    assertEquals(MEMBER_TENANT_2, tenantId);
+    assertEquals(MEMBER_TENANT_1, tenantId);
   }
 
   private PoLine getPoLine(String instanceId, List<Location> locations) {
     PoLine result = getMockAsJson(PO_LINE_MIN_CONTENT_PATH).mapTo(PoLine.class);
     result.setInstanceId(instanceId);
     result.setLocations(locations);
+    result.setDetails(
+      new Details().withProductIds(
+        List.of(
+          new ProductId().withProductId("10407849").withProductIdType("913300b2-03ed-469a-8179-c1092c991227"))));
     return result;
   }
 


### PR DESCRIPTION
## Purpose
[MODORDERS-1310](https://folio-org.atlassian.net/browse/MODORDERS-1310) - Make Local order matching ECS aware such that shadows will be created for shared instances before local instances will be created.

## Approach
- Changed the logic when an order is opened, to get an instance record and possibly create one and shadow instances.
- Only create shadow instances when the po line does not already have an instance id, the product ids are present, there is no matching instance in the member tenant, but there is a matching instance in the central tenant.
- Moved public methods to the top
- Updated tests

## TODOS and Open Questions
Integration tests

## Related PR
[integration test PR](https://github.com/folio-org/folio-integration-tests/pull/1911)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
