### PR TITLE
intermittent order receiving issue - wrong name recorded in audit record, nullPointer logged

### DIFF
--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -356,7 +356,7 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
           .filter(poLine -> !PoLineCommonUtil.isCancelledOrOngoingStatus(poLine))
           .toList();
         updateOrderStatus.accept(notCancelledOrOngoingPoLines);
-        return null;
+        return Future.succeededFuture();
       }));
   }
 


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1296>

## Approach

- Fixed an NPE by returning and empty Future
- Tested with 2 users where diku_admin was Creating a PO+POL and Opening an Order, while diku_user was Quick Receiving the Piece, and in all cases I didn't see an incorrect user being set in the metadata
- Below is the attached audit logs joining with a POL and User, we expect the 3 last records for each POL to be of diku_user, because diku_user was Quick Receiving the Piece:

![image](https://github.com/user-attachments/assets/aecac7cb-c63b-4512-8d23-5bff1441706d)

(ignoreTest3 POL title, I forgot to re-login)