### PR TITLE
[MODORDERS-1065] Validate checkinItems based on receiptStatus

### DIFF
--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -134,6 +134,7 @@ public enum ErrorCodes {
   ORDER_FORMAT_INCORRECT_FOR_BINDARY_ACTIVE("orderFormatIncorrectForBindaryActive", "When PoLine is bindery active, its format must be 'P/E Mix' or 'Physical Resource'"),
   CREATE_INVENTORY_INCORRECT_FOR_BINDARY_ACTIVE("createInventoryIncorrectForBindaryActive", "When PoLine is bindery active, Create Inventory must be 'Instance, Holding, Item'"),
   RECEIVING_WORKFLOW_INCORRECT_FOR_BINDARY_ACTIVE("receivingWorkflowIncorrectForBindaryActive", "When PoLine is bindery active, its receiving workflow must be set to 'Independent order and receipt quantity'"),
+  RECEIVING_WORKFLOW_INCORRECT_FOR_RECEIPT_NOT_REQUIRED("receivingWorkflowIncorrectForReceiptNotRequired", "When POL's receipt status is 'Receipt Not Required', its receiving workflow must be set to 'Independent order and receipt quantity'"),
   BIND_ITEM_MUST_INCLUDE_EITHER_HOLDING_ID_OR_LOCATION_ID("bindItemMustIncludeEitherHoldingIdOrLocationId", "During binding pieces, the bindItem object must have either holdingId or locationId field populated"),
   BUDGET_NOT_FOUND_FOR_FISCAL_YEAR("budgetNotFoundForFiscalYear", "Could not find an active budget for a fund with the current fiscal year of another fund in the fund distribution"),
   LAST_PIECE("lastPiece", "The piece cannot be deleted because it is the last piece for the poLine with Receiving Workflow 'Synchronized order and receipt quantity' and cost quantity '1'"),

--- a/src/main/java/org/folio/service/orders/PoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/PoLineValidationService.java
@@ -341,7 +341,7 @@ public class PoLineValidationService extends BaseValidationService {
   }
 
   private List<Error> validateReceivingWorkflowForReceiptNotRequired(PoLine poLine) {
-    return poLine.getReceiptStatus().equals(PoLine.ReceiptStatus.RECEIPT_NOT_REQUIRED) && BooleanUtils.isNotTrue(poLine.getCheckinItems())
+    return PoLine.ReceiptStatus.RECEIPT_NOT_REQUIRED.equals(poLine.getReceiptStatus()) && BooleanUtils.isNotTrue(poLine.getCheckinItems())
       ? List.of(RECEIVING_WORKFLOW_INCORRECT_FOR_RECEIPT_NOT_REQUIRED.toError())
       : Collections.emptyList();
   }

--- a/src/main/java/org/folio/service/orders/PoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/PoLineValidationService.java
@@ -12,6 +12,7 @@ import static org.folio.orders.utils.ResourcePathResolver.PO_LINE_NUMBER;
 import static org.folio.rest.core.exceptions.ErrorCodes.CREATE_INVENTORY_INCORRECT_FOR_BINDARY_ACTIVE;
 import static org.folio.rest.core.exceptions.ErrorCodes.ORDER_FORMAT_INCORRECT_FOR_BINDARY_ACTIVE;
 import static org.folio.rest.core.exceptions.ErrorCodes.RECEIVING_WORKFLOW_INCORRECT_FOR_BINDARY_ACTIVE;
+import static org.folio.rest.core.exceptions.ErrorCodes.RECEIVING_WORKFLOW_INCORRECT_FOR_RECEIPT_NOT_REQUIRED;
 import static org.folio.rest.jaxrs.model.PoLine.OrderFormat.ELECTRONIC_RESOURCE;
 import static org.folio.rest.jaxrs.model.PoLine.OrderFormat.P_E_MIX;
 
@@ -23,6 +24,7 @@ import java.util.Optional;
 
 import io.vertx.core.Future;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -70,6 +72,7 @@ public class PoLineValidationService extends BaseValidationService {
 
     return expenseClassValidationService.validateExpenseClasses(List.of(poLine), false, requestContext)
       .map(v -> errors.addAll(validatePoLineFormats(poLine)))
+      .map(v -> errors.addAll(validateReceivingWorkflowForReceiptNotRequired(poLine)))
       .map(v -> errors.addAll(validateForBinadryActive(poLine)))
       .map(b -> errors.addAll(validateLocations(poLine)))
       .map(b -> {
@@ -335,6 +338,12 @@ public class PoLineValidationService extends BaseValidationService {
       var error = CREATE_INVENTORY_INCORRECT_FOR_BINDARY_ACTIVE.toError().withParameters(List.of(param));
       errors.add(error);
     }
+  }
+
+  private List<Error> validateReceivingWorkflowForReceiptNotRequired(PoLine poLine) {
+    return poLine.getReceiptStatus().equals(PoLine.ReceiptStatus.RECEIPT_NOT_REQUIRED) && BooleanUtils.isNotTrue(poLine.getCheckinItems())
+      ? List.of(RECEIVING_WORKFLOW_INCORRECT_FOR_RECEIPT_NOT_REQUIRED.toError())
+      : Collections.emptyList();
   }
 
   private void validateReceivingWorkflowForBindary(PoLine poLine, List<Error> errors) {

--- a/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrdersApiTest.java
@@ -2693,6 +2693,7 @@ public class PurchaseOrdersApiTest {
     // Set CreateInventory value to create inventory instances and holdings
     reqData.getPoLines().get(0).getEresource().setCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING);
     reqData.getPoLines().get(0).setReceiptStatus(ReceiptStatus.RECEIPT_NOT_REQUIRED);
+    reqData.getPoLines().get(0).setCheckinItems(true);
 
     verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);
@@ -2738,6 +2739,7 @@ public class PurchaseOrdersApiTest {
     reqData.getPoLines().get(0).getPhysical().setCreateInventory(Physical.CreateInventory.NONE);
     reqData.getPoLines().get(0).getEresource().setCreateInventory(Eresource.CreateInventory.NONE);
     reqData.getPoLines().get(0).setReceiptStatus(ReceiptStatus.RECEIPT_NOT_REQUIRED);
+    reqData.getPoLines().get(0).setCheckinItems(true);
 
     verifyPostResponse(COMPOSITE_ORDERS_PATH, JsonObject.mapFrom(reqData).toString(),
       prepareHeaders(EXIST_CONFIG_X_OKAPI_TENANT_LIMIT_10, X_OKAPI_USER_ID), APPLICATION_JSON, 201).as(CompositePurchaseOrder.class);

--- a/src/test/resources/po_listed_print_serial_with_receipt_payment_not_required.json
+++ b/src/test/resources/po_listed_print_serial_with_receipt_payment_not_required.json
@@ -23,6 +23,7 @@
       "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
       "cancellationRestriction": false,
       "cancellationRestrictionNote": "ABCDEFGHIJKLMNOPQRSTUVW",
+      "checkinItems": true,
       "claims": [
         {
           "claimed": false,


### PR DESCRIPTION
## Purpose
[[MODORDERS-1065] Validate checkinItems based on receiptStatus](https://folio-org.atlassian.net/browse/MODORDERS-1065)

## Approach
Add validation on POL receiptStatus for creation and update
