### PR TITLE
[MODFIN-434]. Update Treasury exchange rate provider handler to allow using the same exchange rate in both directions

### DIFF
--- a/src/main/java/org/folio/service/exchange/CacheableExchangeRateService.java
+++ b/src/main/java/org/folio/service/exchange/CacheableExchangeRateService.java
@@ -59,7 +59,7 @@ public class CacheableExchangeRateService {
             from, to, exchangeRate.getExchangeRate(), exchangeRate.getOperationMode());
           return Future.succeededFuture(exchangeRate);
         })
-        .orElseGet(() -> Future.failedFuture("Cannot retrieve exchange rate from API")));
+        .orElseThrow(() -> new IllegalStateException("Cannot retrieve exchange rate from API using from=%s, and to=%s currencies".formatted(from, to))));
     } catch (Exception e) {
       log.error("Error when retrieving cacheable exchange rate", e);
       return Future.failedFuture(e);

--- a/src/main/java/org/folio/service/exchange/CacheableExchangeRateService.java
+++ b/src/main/java/org/folio/service/exchange/CacheableExchangeRateService.java
@@ -55,7 +55,8 @@ public class CacheableExchangeRateService {
       var cacheKey = String.format("%s-%s", from, to);
       return Future.fromCompletionStage(asyncCache.get(cacheKey, (key, executor) -> getExchangeRateFromRemote(from, to, requestContext)))
         .compose(exchangeRateOptional -> exchangeRateOptional.map(exchangeRate -> {
-          log.info("getExchangeRate:: Retrieving an exchange rate, {} -> {}, exchangeRate: {}", from, to, exchangeRate.getExchangeRate());
+          log.info("getExchangeRate:: Retrieving an exchange rate, {} -> {}, exchangeRate: {}, operationMode: {}",
+            from, to, exchangeRate.getExchangeRate(), exchangeRate.getOperationMode());
           return Future.succeededFuture(exchangeRate);
         })
         .orElseGet(() -> Future.failedFuture("Cannot retrieve exchange rate from API")));

--- a/src/main/java/org/folio/service/exchange/CustomExchangeRateProvider.java
+++ b/src/main/java/org/folio/service/exchange/CustomExchangeRateProvider.java
@@ -12,6 +12,7 @@ import javax.money.convert.ExchangeRateProvider;
 import javax.money.convert.ProviderContext;
 import javax.money.convert.ProviderContextBuilder;
 import javax.money.convert.RateType;
+import org.folio.rest.acq.model.finance.ExchangeRate.OperationMode;
 
 public class CustomExchangeRateProvider implements ExchangeRateProvider {
 
@@ -20,13 +21,13 @@ public class CustomExchangeRateProvider implements ExchangeRateProvider {
     .build();
   public static final String RATE_KEY = "factor";
 
-  private final org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode;
+  private final OperationMode operationMode;
 
   public CustomExchangeRateProvider() {
-    this.operationMode = org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
+    this.operationMode = OperationMode.MULTIPLY;
   }
 
-  public CustomExchangeRateProvider(org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode) {
+  public CustomExchangeRateProvider(OperationMode operationMode) {
     this.operationMode = operationMode;
   }
 

--- a/src/main/java/org/folio/service/exchange/CustomExchangeRateProvider.java
+++ b/src/main/java/org/folio/service/exchange/CustomExchangeRateProvider.java
@@ -20,13 +20,13 @@ public class CustomExchangeRateProvider implements ExchangeRateProvider {
     .build();
   public static final String RATE_KEY = "factor";
 
-  private final ManualCurrencyConversion.OperationMode operationMode;
+  private final org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode;
 
   public CustomExchangeRateProvider() {
-    this.operationMode = ManualCurrencyConversion.OperationMode.MULTIPLY;
+    this.operationMode = org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
   }
 
-  public CustomExchangeRateProvider(ManualCurrencyConversion.OperationMode operationMode) {
+  public CustomExchangeRateProvider(org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode) {
     this.operationMode = operationMode;
   }
 

--- a/src/main/java/org/folio/service/exchange/ManualCurrencyConversion.java
+++ b/src/main/java/org/folio/service/exchange/ManualCurrencyConversion.java
@@ -24,10 +24,7 @@ public class ManualCurrencyConversion extends AbstractCurrencyConversion {
 
   public ManualCurrencyConversion(ConversionQuery conversionQuery, ExchangeRateProvider rateProvider,
                                   ConversionContext conversionContext) {
-    super(conversionQuery.getCurrency(), conversionContext);
-    this.conversionQuery = conversionQuery;
-    this.rateProvider = rateProvider;
-    this.operationMode = OperationMode.MULTIPLY;
+    this(conversionQuery, rateProvider, conversionContext, OperationMode.MULTIPLY);
   }
 
   public ManualCurrencyConversion(ConversionQuery conversionQuery, ExchangeRateProvider rateProvider,

--- a/src/main/java/org/folio/service/exchange/ManualCurrencyConversion.java
+++ b/src/main/java/org/folio/service/exchange/ManualCurrencyConversion.java
@@ -19,27 +19,22 @@ public class ManualCurrencyConversion extends AbstractCurrencyConversion {
 
   private final ExchangeRateProvider rateProvider;
   private final ConversionQuery conversionQuery;
-  private final OperationMode operationMode;
+  private final org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode;
 
   public ManualCurrencyConversion(ConversionQuery conversionQuery, ExchangeRateProvider rateProvider,
                                   ConversionContext conversionContext) {
     super(conversionQuery.getCurrency(), conversionContext);
     this.conversionQuery = conversionQuery;
     this.rateProvider = rateProvider;
-    this.operationMode = OperationMode.MULTIPLY;
+    this.operationMode = org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
   }
 
   public ManualCurrencyConversion(ConversionQuery conversionQuery, ExchangeRateProvider rateProvider,
-                                  ConversionContext conversionContext, OperationMode operationMode) {
+                                  ConversionContext conversionContext, org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode) {
     super(conversionQuery.getCurrency(), conversionContext);
     this.conversionQuery = conversionQuery;
     this.rateProvider = rateProvider;
     this.operationMode = operationMode;
-  }
-
-  public enum OperationMode {
-    MULTIPLY,
-    DIVIDE
   }
 
   @Override
@@ -70,7 +65,7 @@ public class ManualCurrencyConversion extends AbstractCurrencyConversion {
    */
   @Override
   public MonetaryAmount apply(MonetaryAmount amount) {
-    if (this.operationMode == OperationMode.MULTIPLY) {
+    if (this.operationMode == org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY) {
       return super.apply(amount);
     }
     if (super.getCurrency().equals(Objects.requireNonNull(amount).getCurrency())) {

--- a/src/main/java/org/folio/service/exchange/ManualCurrencyConversion.java
+++ b/src/main/java/org/folio/service/exchange/ManualCurrencyConversion.java
@@ -12,6 +12,7 @@ import javax.money.convert.ExchangeRateProvider;
 
 import org.javamoney.moneta.function.MonetaryOperators;
 import org.javamoney.moneta.spi.AbstractCurrencyConversion;
+import org.folio.rest.acq.model.finance.ExchangeRate.OperationMode;
 
 public class ManualCurrencyConversion extends AbstractCurrencyConversion {
 
@@ -19,18 +20,18 @@ public class ManualCurrencyConversion extends AbstractCurrencyConversion {
 
   private final ExchangeRateProvider rateProvider;
   private final ConversionQuery conversionQuery;
-  private final org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode;
+  private final OperationMode operationMode;
 
   public ManualCurrencyConversion(ConversionQuery conversionQuery, ExchangeRateProvider rateProvider,
                                   ConversionContext conversionContext) {
     super(conversionQuery.getCurrency(), conversionContext);
     this.conversionQuery = conversionQuery;
     this.rateProvider = rateProvider;
-    this.operationMode = org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
+    this.operationMode = OperationMode.MULTIPLY;
   }
 
   public ManualCurrencyConversion(ConversionQuery conversionQuery, ExchangeRateProvider rateProvider,
-                                  ConversionContext conversionContext, org.folio.rest.acq.model.finance.ExchangeRate.OperationMode operationMode) {
+                                  ConversionContext conversionContext, OperationMode operationMode) {
     super(conversionQuery.getCurrency(), conversionContext);
     this.conversionQuery = conversionQuery;
     this.rateProvider = rateProvider;
@@ -65,7 +66,7 @@ public class ManualCurrencyConversion extends AbstractCurrencyConversion {
    */
   @Override
   public MonetaryAmount apply(MonetaryAmount amount) {
-    if (this.operationMode == org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY) {
+    if (this.operationMode == OperationMode.MULTIPLY) {
       return super.apply(amount);
     }
     if (super.getCurrency().equals(Objects.requireNonNull(amount).getCurrency())) {

--- a/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
+++ b/src/main/java/org/folio/service/finance/FinanceHoldersBuilder.java
@@ -118,7 +118,7 @@ public class FinanceHoldersBuilder {
         poLineCurrency, fyCurrency.get(), fixedExchangeRate);
       encumbranceConversionHolderFutures.add(cacheableExchangeRateService.getExchangeRate(poLineCurrency, fyCurrency.get(), fixedExchangeRate, requestContext)
         .compose(exchangeRate -> {
-          var provider = new CustomExchangeRateProvider();
+          var provider = new CustomExchangeRateProvider(exchangeRate.getOperationMode());
           var query = buildConversionQuery(poLineCurrency, fyCurrency.get(), exchangeRate.getExchangeRate());
           var conversion = provider.getCurrencyConversion(query);
           return Future.succeededFuture(new EncumbranceConversionHolder().withHolders(holders).withConversion(conversion));

--- a/src/main/java/org/folio/service/inventory/InventoryItemManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemManager.java
@@ -268,7 +268,7 @@ public class InventoryItemManager {
   private List<Piece> buildPieces(Location location, PoLine poLine, Piece.Format pieceFormat, List<String> createdItemIds,
                                   List<String> existingItemIds) {
     List<String> itemIds = ListUtils.union(createdItemIds, existingItemIds);
-    logger.info(BUILDING_PIECE_MESSAGE, itemIds.size(), pieceFormat, poLine);
+    logger.info(BUILDING_PIECE_MESSAGE, itemIds.size(), pieceFormat, poLine.getId());
     return StreamEx.of(itemIds).map(itemId -> openOrderBuildPiece(poLine, itemId, pieceFormat, location)).toList();
   }
 

--- a/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
+++ b/src/main/java/org/folio/service/orders/CompositeOrderTotalFieldsPopulateService.java
@@ -191,7 +191,6 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
 
   private <T> double getTotalAmount(List<T> entities, Function<T, String> currencyExtractor,
       Function<T, Double> amountExtractor, Function<T, ExchangeRate> exchangeRateExtractor) {
-    var provider = new CustomExchangeRateProvider();
     return StreamEx.of(entities)
       .map(entity -> {
         String currency = currencyExtractor.apply(entity);
@@ -200,6 +199,7 @@ public class CompositeOrderTotalFieldsPopulateService implements CompositeOrderD
         if (currency.equals(exchangeRate.getTo())) {
           return amount;
         } else {
+          var provider = new CustomExchangeRateProvider(exchangeRate.getOperationMode());
           ConversionQuery query = buildConversionQuery(currency, exchangeRate.getTo(), exchangeRate.getExchangeRate());
           CurrencyConversion conversion = provider.getCurrencyConversion(query);
           return amount.with(conversion);

--- a/src/main/java/org/folio/service/orders/OrderLinesSummaryPopulateService.java
+++ b/src/main/java/org/folio/service/orders/OrderLinesSummaryPopulateService.java
@@ -94,7 +94,7 @@ public class OrderLinesSummaryPopulateService implements CompositeOrderDynamicDa
         if (StringUtils.equals(exchangeRate.getFrom(), exchangeRate.getTo())) {
           return amount;
         } else {
-          var provider = new CustomExchangeRateProvider();
+          var provider = new CustomExchangeRateProvider(exchangeRate.getOperationMode());
           var query = buildConversionQuery(poLine.getCost().getCurrency(), toCurrency, exchangeRate.getExchangeRate());
           var conversion = provider.getCurrencyConversion(query);
           return amount.with(conversion);

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -9,7 +9,6 @@ import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ_15;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.DIVIDE;
-import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
 import static org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER;
 import static org.folio.rest.jaxrs.model.RolloverStatus.ERROR;
 import static org.folio.rest.jaxrs.model.RolloverStatus.SUCCESS;
@@ -376,7 +375,7 @@ public class OrderRolloverService {
 
   protected CurrencyConversion retrieveCurrencyConversion(ExchangeRate exchangeRate, boolean isCustomExchangeRate) {
     var query = buildConversionQuery(exchangeRate.getFrom(), exchangeRate.getTo(), exchangeRate.getExchangeRate());
-    var operationMode = isCustomExchangeRate || exchangeRate.getOperationMode() == DIVIDE ? DIVIDE : MULTIPLY;
+    var operationMode = isCustomExchangeRate ? DIVIDE : exchangeRate.getOperationMode();
     logger.info("retrieveCurrencyConversion:: Using operationMode: {}", operationMode);
     var provider = new CustomExchangeRateProvider(operationMode);
     return provider.getCurrencyConversion(query);

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -376,7 +376,9 @@ public class OrderRolloverService {
 
   protected CurrencyConversion retrieveCurrencyConversion(ExchangeRate exchangeRate, boolean isCustomExchangeRate) {
     var query = buildConversionQuery(exchangeRate.getFrom(), exchangeRate.getTo(), exchangeRate.getExchangeRate());
-    var provider = new CustomExchangeRateProvider(isCustomExchangeRate || exchangeRate.getOperationMode() == DIVIDE ? DIVIDE : MULTIPLY);
+    var operationMode = isCustomExchangeRate || exchangeRate.getOperationMode() == DIVIDE ? DIVIDE : MULTIPLY;
+    logger.info("retrieveCurrencyConversion:: Using operationMode: {}", operationMode);
+    var provider = new CustomExchangeRateProvider(operationMode);
     return provider.getCurrencyConversion(query);
   }
 

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -8,11 +8,11 @@ import static org.folio.orders.utils.HelperUtils.calculateCostUnitsTotal;
 import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ_15;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.DIVIDE;
+import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
 import static org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverError.ErrorType.ORDER_ROLLOVER;
 import static org.folio.rest.jaxrs.model.RolloverStatus.ERROR;
 import static org.folio.rest.jaxrs.model.RolloverStatus.SUCCESS;
-import static org.folio.service.exchange.ManualCurrencyConversion.OperationMode.DIVIDE;
-import static org.folio.service.exchange.ManualCurrencyConversion.OperationMode.MULTIPLY;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -42,6 +42,7 @@ import org.folio.models.PoLineEncumbrancesHolder;
 import org.folio.models.RolloverConversionHolder;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.acq.model.finance.Encumbrance;
+import org.folio.rest.acq.model.finance.ExchangeRate;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverProgress;
 import org.folio.rest.acq.model.finance.Transaction;
@@ -373,9 +374,9 @@ public class OrderRolloverService {
     return BigDecimal.valueOf(totalAmountAfterConversion.doubleValue());
   }
 
-  protected CurrencyConversion retrieveCurrencyConversion(String fromCurrency, String toCurrency, Number exchangeRate, boolean isCustomExchangeRate) {
-    var query = buildConversionQuery(fromCurrency, toCurrency, exchangeRate);
-    var provider = new CustomExchangeRateProvider(Boolean.TRUE.equals(isCustomExchangeRate) ? DIVIDE : MULTIPLY);
+  protected CurrencyConversion retrieveCurrencyConversion(ExchangeRate exchangeRate, boolean isCustomExchangeRate) {
+    var query = buildConversionQuery(exchangeRate.getFrom(), exchangeRate.getTo(), exchangeRate.getExchangeRate());
+    var provider = new CustomExchangeRateProvider(isCustomExchangeRate || exchangeRate.getOperationMode() == DIVIDE ? DIVIDE : MULTIPLY);
     return provider.getCurrencyConversion(query);
   }
 
@@ -393,7 +394,7 @@ public class OrderRolloverService {
     poLines.forEach(poLine -> {
       var rolloverConversion = getRolloverConversionByPoLineId(poLine, poLineExchangeRates);
       var exchangeRate = rolloverConversion.getExchangeRate();
-      var conversion = retrieveCurrencyConversion(exchangeRate.getFrom(), exchangeRate.getTo(), exchangeRate.getExchangeRate(), rolloverConversion.isCustomExchangeRate());
+      var conversion = retrieveCurrencyConversion(exchangeRate, rolloverConversion.isCustomExchangeRate());
       var holder = new PoLineEncumbrancesHolder(poLine)
         .withCurrencyConversion(conversion)
         .withSystemCurrency(exchangeRate.getFrom());

--- a/src/main/java/org/folio/service/orders/ReEncumbranceHoldersBuilder.java
+++ b/src/main/java/org/folio/service/orders/ReEncumbranceHoldersBuilder.java
@@ -103,7 +103,7 @@ public class ReEncumbranceHoldersBuilder extends FinanceHoldersBuilder {
         poLineCurrency, fyCurrency.get(), fixedExchangeRate);
       encumbranceConversionHolderFutures.add(cacheableExchangeRateService.getExchangeRate(poLineCurrency, fyCurrency.get(), fixedExchangeRate, requestContext)
         .compose(exchangeRate -> {
-          var provider = new CustomExchangeRateProvider();
+          var provider = new CustomExchangeRateProvider(exchangeRate.getOperationMode());
           var poLineToFYQuery = buildConversionQuery(poLineCurrency, fyCurrency.get(), exchangeRate.getExchangeRate());
           var poLineToFYConversion = provider.getCurrencyConversion(poLineToFYQuery);
           var fixedExchangeRateConverted = poLineToFYConversion.getExchangeRate(Money.of(0d, poLineCurrency)).getFactor().doubleValue();

--- a/src/test/java/org/folio/TestConfig.java
+++ b/src/test/java/org/folio/TestConfig.java
@@ -44,7 +44,6 @@ public final class TestConfig {
   private TestConfig() {}
 
   public static void deployVerticle() throws InterruptedException, ExecutionException, TimeoutException {
-
     int okapiPort = NetworkUtils.nextFreePort();
     RestAssured.baseURI = "http://localhost:" + okapiPort;
     RestAssured.port = okapiPort;

--- a/src/test/java/org/folio/service/exchange/ManualCurrencyConversionTest.java
+++ b/src/test/java/org/folio/service/exchange/ManualCurrencyConversionTest.java
@@ -1,13 +1,14 @@
 package org.folio.service.exchange;
 
+import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.DIVIDE;
+import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
 import static org.folio.service.exchange.CustomExchangeRateProvider.RATE_KEY;
-import static org.folio.service.exchange.ManualCurrencyConversion.OperationMode.DIVIDE;
-import static org.folio.service.exchange.ManualCurrencyConversion.OperationMode.MULTIPLY;
 
 import javax.money.Monetary;
 import javax.money.convert.ConversionContext;
 import javax.money.convert.ConversionQueryBuilder;
 
+import org.folio.rest.acq.model.finance.ExchangeRate;
 import org.javamoney.moneta.Money;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -17,8 +18,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 public class ManualCurrencyConversionTest {
 
   @ParameterizedTest
-  @EnumSource(ManualCurrencyConversion.OperationMode.class)
-  void testApplyWithOperationModes(ManualCurrencyConversion.OperationMode operationMode) {
+  @EnumSource(ExchangeRate.OperationMode.class)
+  void testApplyWithOperationModes(ExchangeRate.OperationMode operationMode) {
     var totalAmount = 10;
     var fromCurrency = "USD";
     var toCurrency = "AUD";

--- a/src/test/java/org/folio/service/exchange/ManualCurrencyConversionTest.java
+++ b/src/test/java/org/folio/service/exchange/ManualCurrencyConversionTest.java
@@ -1,63 +1,171 @@
 package org.folio.service.exchange;
 
-import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.DIVIDE;
-import static org.folio.rest.acq.model.finance.ExchangeRate.OperationMode.MULTIPLY;
-import static org.folio.service.exchange.CustomExchangeRateProvider.RATE_KEY;
+import org.folio.CopilotGenerated;
+import org.javamoney.moneta.Money;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.money.Monetary;
 import javax.money.convert.ConversionContext;
+import javax.money.convert.ConversionQuery;
 import javax.money.convert.ConversionQueryBuilder;
+import javax.money.convert.CurrencyConversionException;
+import javax.money.convert.ExchangeRate;
+import javax.money.convert.ExchangeRateProvider;
+import javax.money.convert.RateType;
+import org.folio.rest.acq.model.finance.ExchangeRate.OperationMode;
 
-import org.folio.rest.acq.model.finance.ExchangeRate;
-import org.javamoney.moneta.Money;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@CopilotGenerated(model = "Claude Sonnet 3.5")
 public class ManualCurrencyConversionTest {
 
-  @ParameterizedTest
-  @EnumSource(ExchangeRate.OperationMode.class)
-  void testApplyWithOperationModes(ExchangeRate.OperationMode operationMode) {
-    var totalAmount = 10;
-    var fromCurrency = "USD";
-    var toCurrency = "AUD";
+  private ExchangeRateProvider rateProvider;
+  private ConversionQuery conversionQuery;
+  private ConversionContext conversionContext;
+  private ExchangeRate exchangeRate;
 
-    var provider = new CustomExchangeRateProvider(operationMode);
-    var query = ConversionQueryBuilder.of()
-      .setBaseCurrency(fromCurrency)
-      .setTermCurrency(toCurrency)
-      .set(RATE_KEY, operationMode == MULTIPLY ? 1.58d : 0.63d)
+  @BeforeEach
+  void setUp() {
+    rateProvider = mock(ExchangeRateProvider.class);
+    conversionQuery = ConversionQueryBuilder.of()
+      .setBaseCurrency(Monetary.getCurrency("USD"))
+      .setTermCurrency(Monetary.getCurrency("EUR"))
       .build();
-    var conversion = provider.getCurrencyConversion(query);
+    conversionContext = ConversionContext.of(RateType.ANY);
+    exchangeRate = mock(ExchangeRate.class);
 
-    var totalAmountBeforeConversion = Money.of(totalAmount, fromCurrency).with(conversion).with(Monetary.getDefaultRounding());
-    var manualCurrencyConversion = new ManualCurrencyConversion(query, provider, ConversionContext.of(), operationMode);
-    var totalAmountAfterConversion = manualCurrencyConversion.apply(totalAmountBeforeConversion).getNumber();
-
-    System.out.println(totalAmountAfterConversion.doubleValue());
-
-    Assertions.assertTrue(totalAmountAfterConversion.doubleValue() > 0);
+    when(exchangeRate.getBaseCurrency()).thenReturn(Monetary.getCurrency("USD"));
+    when(exchangeRate.getCurrency()).thenReturn(Monetary.getCurrency("EUR"));
+    when(exchangeRate.getFactor()).thenReturn(Money.of(0.9, "USD").getNumber());
+    when(exchangeRate.getContext()).thenReturn(ConversionContext.of(RateType.ANY));
   }
 
   @Test
-  void testApplyWithSameCurrencies() {
-    var totalAmount = 10d;
-    var fromCurrency = "USD";
-    var toCurrency = "USD";
+  void testGetExchangeRate() {
+    var amount = Money.of(10, "USD");
+    when(rateProvider.getExchangeRate(any(ConversionQuery.class))).thenReturn(exchangeRate);
 
-    var provider = new CustomExchangeRateProvider();
-    var query = ConversionQueryBuilder.of()
-      .setBaseCurrency(fromCurrency)
-      .setTermCurrency(toCurrency)
-      .build();
-    var conversion = provider.getCurrencyConversion(query);
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext);
+    var rate = conversion.getExchangeRate(amount);
 
-    var totalAmountBeforeConversion = Money.of(totalAmount, fromCurrency).with(conversion).with(Monetary.getDefaultRounding());
-    var manualCurrencyConversion = new ManualCurrencyConversion(query, provider, ConversionContext.of(), DIVIDE);
-    var totalAmountAfterConversion = manualCurrencyConversion.apply(totalAmountBeforeConversion).getNumber();
+    assertNotNull(rate);
+    assertEquals(exchangeRate, rate);
+  }
 
-    Assertions.assertEquals(totalAmount, totalAmountAfterConversion.doubleValue());
+  @Test
+  void testGetExchangeRateProvider() {
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext);
+    assertEquals(rateProvider, conversion.getExchangeRateProvider());
+  }
+
+  @Test
+  void testWithConversionContext() {
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext);
+    var newContext = ConversionContext.of(RateType.DEFERRED);
+    var newConversion = conversion.with(newContext);
+
+    assertNotNull(newConversion);
+    assertNotSame(conversion, newConversion);
+  }
+
+  @Test
+  void testApplyMultiplyMode() {
+    var amount = Money.of(10, "USD");
+    when(rateProvider.getExchangeRate(any(ConversionQuery.class))).thenReturn(exchangeRate);
+
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext, OperationMode.MULTIPLY);
+    var result = conversion.apply(amount);
+
+    assertNotNull(result);
+    assertEquals("EUR", result.getCurrency().getCurrencyCode());
+  }
+
+  @Test
+  void testApplyDivideModeWithSameCurrency() {
+    var amount = Money.of(10, "EUR");
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext, OperationMode.DIVIDE);
+
+    var result = conversion.apply(amount);
+
+    assertEquals(amount, result);
+  }
+
+  @Test
+  void testApplyDivideModeWithDifferentCurrency() {
+    var amount = Money.of(10, "USD");
+    when(rateProvider.getExchangeRate(any(ConversionQuery.class))).thenReturn(exchangeRate);
+
+    var contextWithScale = ConversionContext.of(RateType.ANY).toBuilder().set("exchangeRateScale", 2).build();
+    when(exchangeRate.getContext()).thenReturn(contextWithScale);
+
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext, OperationMode.DIVIDE);
+    var result = conversion.apply(amount);
+
+    assertNotNull(result);
+    assertEquals("EUR", result.getCurrency().getCurrencyCode());
+  }
+
+  @Test
+  void testApplyDivideModeWithNullExchangeRate() {
+    var amount = Money.of(10, "USD");
+    when(rateProvider.getExchangeRate(any(ConversionQuery.class))).thenReturn(null);
+
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext, OperationMode.DIVIDE);
+
+    assertThrows(CurrencyConversionException.class, () -> conversion.apply(amount));
+  }
+
+  @Test
+  void testApplyDivideModeWithCurrencyMismatch() {
+    var amount = Money.of(10, "GBP");
+    when(rateProvider.getExchangeRate(any(ConversionQuery.class))).thenReturn(exchangeRate);
+    when(exchangeRate.getBaseCurrency()).thenReturn(Monetary.getCurrency("USD")); // Different from amount currency
+
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext, OperationMode.DIVIDE);
+
+    assertThrows(CurrencyConversionException.class, () -> conversion.apply(amount));
+  }
+
+  @Test
+  void testApplyDivideModeWithNegativeScale() {
+    var amount = Money.of(10, "USD");
+    when(rateProvider.getExchangeRate(any(ConversionQuery.class))).thenReturn(exchangeRate);
+    var contextWithNegativeScale = ConversionContext.of(RateType.ANY).toBuilder().set("exchangeRateScale", -1).build();
+    when(exchangeRate.getContext()).thenReturn(contextWithNegativeScale);
+
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext, OperationMode.DIVIDE);
+    var result = conversion.apply(amount);
+
+    assertNotNull(result);
+    assertEquals("EUR", result.getCurrency().getCurrencyCode());
+  }
+
+  @Test
+  void testApplyDivideModeWithNullScale() {
+    var amount = Money.of(10, "USD");
+    when(rateProvider.getExchangeRate(any(ConversionQuery.class))).thenReturn(exchangeRate);
+    var contextWithoutScale = ConversionContext.of(RateType.ANY);
+    when(exchangeRate.getContext()).thenReturn(contextWithoutScale);
+
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext, OperationMode.DIVIDE);
+    var result = conversion.apply(amount);
+
+    assertNotNull(result);
+    assertEquals("EUR", result.getCurrency().getCurrencyCode());
+  }
+
+  @Test
+  void testToString() {
+    var conversion = new ManualCurrencyConversion(conversionQuery, rateProvider, conversionContext);
+    var str = conversion.toString();
+    assertTrue(str.contains("CurrencyConversion"));
   }
 }

--- a/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 
 import org.folio.models.PoLineEncumbrancesHolder;
 import org.folio.rest.acq.model.finance.Encumbrance;
+import org.folio.rest.acq.model.finance.ExchangeRate;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverError;
 import org.folio.rest.acq.model.finance.LedgerFiscalYearRolloverErrorCollection;
@@ -720,7 +721,12 @@ public class OrderRolloverServiceTest {
 
     conversionHelper.mockExchangeRateProviderResolver(fromCurrency, toCurrency, exchangeRateAmount);
 
-    var currencyConversion = orderRolloverService.retrieveCurrencyConversion(fromCurrency, poLine.getCost().getCurrency(), exchangeRateAmount, customExchangeRate);
+    var exchangeRate = new ExchangeRate()
+      .withFrom(fromCurrency)
+      .withTo(toCurrency)
+      .withExchangeRate(exchangeRateAmount)
+      .withOperationMode(ExchangeRate.OperationMode.MULTIPLY);
+    var currencyConversion = orderRolloverService.retrieveCurrencyConversion(exchangeRate, customExchangeRate);
 
     var holder = new PoLineEncumbrancesHolder(poLine)
       .withEncumbrances(singletonList(transaction))

--- a/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
@@ -724,8 +724,7 @@ public class OrderRolloverServiceTest {
     var exchangeRate = new ExchangeRate()
       .withFrom(fromCurrency)
       .withTo(toCurrency)
-      .withExchangeRate(exchangeRateAmount)
-      .withOperationMode(ExchangeRate.OperationMode.MULTIPLY);
+      .withExchangeRate(exchangeRateAmount);
     var currencyConversion = orderRolloverService.retrieveCurrencyConversion(exchangeRate, customExchangeRate);
 
     var holder = new PoLineEncumbrancesHolder(poLine)


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODFIN-434>

## Approach

- Update CacheableExchangeRateService to support a new operationMode field
- Update Order Totals, Order Opening, Rollover and Re-encumber Encumbrances by setting the new operationMode field