### PR TITLE
MODDICORE-465 - Update di-core library to snapshot version to pick up the location schema updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <mod-configuration-client.version>5.11.0</mod-configuration-client.version>
     <folio-di-support.version>3.0.0</folio-di-support.version>
     <mod-di-converter-storage-client.version>2.3.1</mod-di-converter-storage-client.version>
-    <data-import-processing-core.version>4.4.3</data-import-processing-core.version>
+    <data-import-processing-core.version>4.5.0-SNAPSHOT</data-import-processing-core.version>
 
     <!--Maven plugin dependencies-->
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
## Purpose
the location schema has already been expanded with new "isShadow" field in the inventory-storage [(1240)](https://github.com/folio-org/mod-inventory-storage/pull/1240/files). Such changes have already been reflected in the location schema placed in the data-import-processing-core library.
It's needed to update the data-import-processing-core library to the snapshot version to prevent errors during orders import.


## Learning
[MODDICORE-465](https://issues.folio.org/browse/MODDICORE-465)
https://github.com/folio-org/mod-inventory-storage/pull/1240