### PR TITLE
[MODORDERS-1299-2] Prevent overwriting POL patch request object

### DIFF
--- a/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
+++ b/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
@@ -1,8 +1,6 @@
 package org.folio.models.orders.lines.update;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import lombok.Getter;
@@ -32,16 +30,16 @@ public class OrderLineUpdateInstanceHolder {
   }
 
   public void createStoragePatchOrderLineRequest(PatchOrderLineOperationType patchOrderLineOperationType, String newInstanceId) {
+    if (storagePatchOrderLineRequest != null) {
+      return;
+    }
     this.storagePatchOrderLineRequest = new StoragePatchOrderLineRequest()
       .withOperation(patchOrderLineOperationType)
-      .withReplaceInstanceRef(new StorageReplaceOrderLineInstanceRef()
-        .withNewInstanceId(newInstanceId));
+      .withReplaceInstanceRef(new StorageReplaceOrderLineInstanceRef().withNewInstanceId(newInstanceId));
   }
 
   public void addHoldingRefsToStoragePatchOrderLineRequest(String holdingId, String newHoldingId) {
-    var instanceRef = this.storagePatchOrderLineRequest.getReplaceInstanceRef();
-    var holdings = Optional.ofNullable(instanceRef.getHoldings())
-      .orElseGet(() -> instanceRef.withHoldings(new ArrayList<>()).getHoldings());
-    holdings.add(new StorageReplaceOrderLineHoldingRefs().withFromHoldingId(holdingId).withToHoldingId(newHoldingId));
+    this.storagePatchOrderLineRequest.getReplaceInstanceRef().getHoldings()
+      .add(new StorageReplaceOrderLineHoldingRefs().withFromHoldingId(holdingId).withToHoldingId(newHoldingId));
   }
 }


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1299] After changing instance in P/E mix order, new instance is not displayed and locations show "Invalid reference"](https://folio-org.atlassian.net/browse/MODORDERS-1299)

### **Approach**
Prevent overwriting POL patch request object and losing data saved after physical resource processing when processing instance update for eresource
---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
