### PR TITLE
[MODORDERS-1300] Holdings duplicated in new instance after selecting "Create new" during changing instance connection for P/E mix order

### DIFF
--- a/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
+++ b/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import lombok.Getter;
+import one.util.streamex.StreamEx;
 import org.folio.rest.acq.model.StoragePatchOrderLineRequest;
 import org.folio.rest.acq.model.StoragePatchOrderLineRequest.PatchOrderLineOperationType;
 import org.folio.rest.acq.model.StorageReplaceOrderLineHoldingRefs;
@@ -42,4 +43,13 @@ public class OrderLineUpdateInstanceHolder {
     this.storagePatchOrderLineRequest.getReplaceInstanceRef().getHoldings()
       .add(new StorageReplaceOrderLineHoldingRefs().withFromHoldingId(holdingId).withToHoldingId(newHoldingId));
   }
+
+  public boolean shouldProcessHolding(String holdingId) {
+    // Check if the holding is deleted or found/created that results into storing the holding ref (toHoldingId)
+    return !deletedHoldingIds.contains(holdingId) &&
+      StreamEx.of(storagePatchOrderLineRequest.getReplaceInstanceRef().getHoldings())
+        .map(StorageReplaceOrderLineHoldingRefs::getToHoldingId)
+        .noneMatch(holdingId::equals);
+  }
+
 }


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1300] Holdings duplicated in new instance after selecting "Create new" during changing instance connection for P/E mix order](https://folio-org.atlassian.net/browse/MODORDERS-1300)

### **Approach**
Do not fetch locations to process that have been recreated already

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
