### PR TITLE
[MODORDERS-1297] Holding remains after changing instance connection with "Delete holdings" if piece was received in a new location

### DIFF
--- a/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
+++ b/src/main/java/org/folio/models/orders/lines/update/OrderLineUpdateInstanceHolder.java
@@ -1,6 +1,8 @@
 package org.folio.models.orders.lines.update;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -10,6 +12,7 @@ import org.folio.rest.acq.model.StoragePatchOrderLineRequest;
 import org.folio.rest.acq.model.StoragePatchOrderLineRequest.PatchOrderLineOperationType;
 import org.folio.rest.acq.model.StorageReplaceOrderLineHoldingRefs;
 import org.folio.rest.acq.model.StorageReplaceOrderLineInstanceRef;
+import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.PatchOrderLineRequest;
 import org.folio.rest.jaxrs.model.PoLine;
 
@@ -19,6 +22,7 @@ public class OrderLineUpdateInstanceHolder {
   private PoLine storagePoLine;
   private PatchOrderLineRequest patchOrderLineRequest;
   private StoragePatchOrderLineRequest storagePatchOrderLineRequest;
+  private final List<Location> processedLocations = new ArrayList<>();
   private final Set<String> deletedHoldingIds = new HashSet<>();
 
   public OrderLineUpdateInstanceHolder withStoragePoLine(PoLine storagePoLine) {

--- a/src/main/java/org/folio/service/orders/lines/update/instance/BaseOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/BaseOrderLineUpdateInstanceStrategy.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.models.orders.lines.update.OrderLineUpdateInstanceHolder;
 import org.folio.orders.utils.RequestContextUtil;
 import org.folio.rest.core.models.RequestContext;
-import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.Location;
 import org.folio.service.inventory.InventoryHoldingManager;
 import org.folio.service.inventory.InventoryInstanceManager;
 import org.folio.service.inventory.InventoryItemManager;
@@ -41,11 +41,11 @@ public abstract class BaseOrderLineUpdateInstanceStrategy implements OrderLineUp
     return processHoldings(holder, requestContext);
   }
 
-  Future<List<String>> deleteAbandonedHoldings(boolean isDeleteAbandonedHoldings, PoLine poLine, RequestContext requestContext) {
+  Future<List<String>> deleteAbandonedHoldings(boolean isDeleteAbandonedHoldings, List<Location> locations, RequestContext requestContext) {
     if (!isDeleteAbandonedHoldings) {
       return Future.succeededFuture(Collections.emptyList());
     }
-    var deleteHoldingFutures = poLine.getLocations().stream()
+    var deleteHoldingFutures = locations.stream()
       .filter(location -> StringUtils.isNotEmpty(location.getHoldingId()))
       .map(location -> {
         var locationContext = RequestContextUtil.createContextWithNewTenantId(requestContext, location.getTenantId());

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -26,7 +26,7 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLine
 
     holder.createStoragePatchOrderLineRequest(StoragePatchOrderLineRequest.PatchOrderLineOperationType.REPLACE_INSTANCE_REF, newInstanceId);
 
-    return deleteAbandonedHoldings(replaceInstanceRef.getDeleteAbandonedHoldings(), holder.getStoragePoLine(), requestContext)
+    return deleteAbandonedHoldings(replaceInstanceRef.getDeleteAbandonedHoldings(), holder.getStoragePoLine().getLocations(), requestContext)
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/service/pieces/PieceUtil.java
+++ b/src/main/java/org/folio/service/pieces/PieceUtil.java
@@ -116,4 +116,14 @@ public class PieceUtil {
       ? poLine.getPhysical().getExpectedReceiptDate()
       : null;
   }
+
+  public static List<Location> getPiecesLocations(List<Piece> pieces) {
+    return pieces.stream()
+      .map(piece -> new Location()
+        .withHoldingId(piece.getHoldingId())
+        .withLocationId(piece.getLocationId())
+        .withTenantId(piece.getReceivingTenantId()))
+      .toList();
+  }
+
 }


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1297] Holding remains after changing instance connection with "Delete holdings" if piece was received in a new location](https://folio-org.atlassian.net/browse/MODORDERS-1297)

### **Approach**
Store all processed locations in holder and use these to delete abandoned holdings

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
