### PR TITLE
MODORDERS-1328. /mod-orders/orders/pieces?query=holdingId - Can return http 414

### DIFF
--- a/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/PieceStorageServiceTest.java
@@ -59,7 +59,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -110,7 +109,7 @@ public class PieceStorageServiceTest {
 
   @AfterEach
   void resetMocks() throws Exception {
-    reset(restClient);
+    reset(restClient, pieceStorageService);
     if (openMocks != null) {
       openMocks.close();
     }


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODORDERS-1328

### **Approach**
_Provide a brief technical summary of the changes._

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
