### PR TITLE
[MODORDERS-1333] Do not delete used holdings during instance connection change

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -806,11 +806,14 @@ public class ApplicationConfig {
       purchaseOrderLineService, inventoryInstanceManager);
   }
 
-  @Bean OrderLineUpdateInstanceStrategy withHoldingOrderLineUpdateInstanceStrategy(InventoryInstanceManager inventoryInstanceManager,
-                                                                                   InventoryItemManager inventoryItemManager,
-                                                                                   InventoryHoldingManager inventoryHoldingManager,
-                                                                                   PieceStorageService pieceStorageService) {
-    return new WithHoldingOrderLineUpdateInstanceStrategy(inventoryInstanceManager, inventoryItemManager, inventoryHoldingManager, pieceStorageService);
+  @Bean
+  OrderLineUpdateInstanceStrategy withHoldingOrderLineUpdateInstanceStrategy(InventoryInstanceManager inventoryInstanceManager,
+                                                                             InventoryItemManager inventoryItemManager,
+                                                                             InventoryHoldingManager inventoryHoldingManager,
+                                                                             PieceStorageService pieceStorageService,
+                                                                             PurchaseOrderLineService purchaseOrderLineService) {
+    return new WithHoldingOrderLineUpdateInstanceStrategy(inventoryInstanceManager, inventoryItemManager,
+      inventoryHoldingManager, pieceStorageService, purchaseOrderLineService);
   }
 
   @Bean

--- a/src/main/java/org/folio/service/orders/lines/update/instance/BaseOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/BaseOrderLineUpdateInstanceStrategy.java
@@ -41,10 +41,7 @@ public abstract class BaseOrderLineUpdateInstanceStrategy implements OrderLineUp
     return processHoldings(holder, requestContext);
   }
 
-  Future<List<String>> deleteAbandonedHoldings(boolean isDeleteAbandonedHoldings, List<Location> locations, RequestContext requestContext) {
-    if (!isDeleteAbandonedHoldings) {
-      return Future.succeededFuture(Collections.emptyList());
-    }
+  Future<List<String>> deleteAbandonedHoldings(List<Location> locations, RequestContext requestContext) {
     var deleteHoldingFutures = locations.stream()
       .filter(location -> StringUtils.isNotEmpty(location.getHoldingId()))
       .map(location -> {

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -24,9 +24,11 @@ import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.inventory.InventoryHoldingManager;
 import org.folio.service.inventory.InventoryInstanceManager;
 import org.folio.service.inventory.InventoryItemManager;
+import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.pieces.PieceStorageService;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,13 +50,16 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
   private static final String HOLDINGS_ITEMS = "holdingsItems";
   private static final String BARE_HOLDINGS_ITEMS = "bareHoldingsItems";
   private final PieceStorageService pieceStorageService;
+  private final PurchaseOrderLineService purchaseOrderLineService;
 
   public WithHoldingOrderLineUpdateInstanceStrategy(InventoryInstanceManager inventoryInstanceManager,
                                                     InventoryItemManager inventoryItemManager,
                                                     InventoryHoldingManager inventoryHoldingManager,
-                                                    PieceStorageService pieceStorageService) {
+                                                    PieceStorageService pieceStorageService,
+                                                    PurchaseOrderLineService purchaseOrderLineService) {
     super(inventoryInstanceManager, inventoryItemManager, inventoryHoldingManager);
     this.pieceStorageService = pieceStorageService;
+    this.purchaseOrderLineService = purchaseOrderLineService;
   }
 
   Future<Void> processHoldings(OrderLineUpdateInstanceHolder holder, RequestContext requestContext) {
@@ -257,9 +262,30 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
   }
 
   private Future<Void> deleteAbandonedHoldingsAndUpdateHolder(OrderLineUpdateInstanceHolder holder, RequestContext requestContext) {
-    return deleteAbandonedHoldings(holder.getPatchOrderLineRequest().getReplaceInstanceRef().getDeleteAbandonedHoldings(), holder.getProcessedLocations(), requestContext)
+    return getDeletableHoldings(holder, requestContext)
+      .compose(deletableHoldings -> deleteAbandonedHoldings(holder.getPatchOrderLineRequest().getReplaceInstanceRef().getDeleteAbandonedHoldings(), deletableHoldings, requestContext))
       .compose(deletedHoldings -> asFuture(() -> holder.getDeletedHoldingIds().addAll(deletedHoldings)))
       .mapEmpty();
+  }
+
+  private Future<List<Location>> getDeletableHoldings(OrderLineUpdateInstanceHolder holder, RequestContext requestContext) {
+    var holdingIds = StreamEx.of(holder.getProcessedLocations()).map(Location::getHoldingId).nonNull().distinct().toList();
+    var poLinesHoldingIds = purchaseOrderLineService.getPoLinesByHoldingIds(holdingIds, requestContext)
+      .map(poLines -> poLines.stream()
+        .filter(poLine -> !Objects.equals(poLine.getId(), holder.getStoragePoLine().getId()))
+        .flatMap(poLine -> StreamEx.of(poLine.getLocations()).map(Location::getHoldingId).nonNull().distinct())
+        .toList());
+    var piecesHoldingIds = pieceStorageService.getPiecesByHoldingIds(holdingIds, requestContext)
+      .map(pieces -> StreamEx.of(pieces)
+        .filter(piece -> !Objects.equals(piece.getPoLineId(), holder.getStoragePoLine().getId()))
+        .map(Piece::getHoldingId)
+        .nonNull().distinct()
+        .toList());
+    return collectResultsOnSuccess(List.of(poLinesHoldingIds, piecesHoldingIds))
+      .map(results -> results.stream().flatMap(Collection::stream).toList())
+      .map(usedHoldingIds -> holder.getProcessedLocations().stream()
+        .filter(location -> !usedHoldingIds.contains(location.getHoldingId()))
+        .toList());
   }
 
 }

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -6,6 +6,7 @@ import io.vertx.core.json.JsonObject;
 import lombok.extern.log4j.Log4j2;
 import one.util.streamex.StreamEx;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.models.orders.lines.update.OrderLineUpdateInstanceHolder;
 import org.folio.okapi.common.GenericCompositeFuture;
@@ -262,8 +263,11 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
   }
 
   private Future<Void> deleteAbandonedHoldingsAndUpdateHolder(OrderLineUpdateInstanceHolder holder, RequestContext requestContext) {
+    if (BooleanUtils.isNotTrue(holder.getPatchOrderLineRequest().getReplaceInstanceRef().getDeleteAbandonedHoldings())) {
+      return Future.succeededFuture();
+    }
     return getDeletableHoldings(holder, requestContext)
-      .compose(deletableHoldings -> deleteAbandonedHoldings(holder.getPatchOrderLineRequest().getReplaceInstanceRef().getDeleteAbandonedHoldings(), deletableHoldings, requestContext))
+      .compose(deletableHoldings -> deleteAbandonedHoldings(deletableHoldings, requestContext))
       .compose(deletedHoldings -> asFuture(() -> holder.getDeletedHoldingIds().addAll(deletedHoldings)))
       .mapEmpty();
   }

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -1,6 +1,7 @@
 package org.folio.service.orders.lines.update.instance;
 
 import io.vertx.core.Future;
+import org.apache.commons.lang3.BooleanUtils;
 import org.folio.models.orders.lines.update.OrderLineUpdateInstanceHolder;
 import org.folio.rest.acq.model.StoragePatchOrderLineRequest;
 import org.folio.rest.core.models.RequestContext;
@@ -26,8 +27,9 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLine
 
     holder.createStoragePatchOrderLineRequest(StoragePatchOrderLineRequest.PatchOrderLineOperationType.REPLACE_INSTANCE_REF, newInstanceId);
 
-    return deleteAbandonedHoldings(replaceInstanceRef.getDeleteAbandonedHoldings(), holder.getStoragePoLine().getLocations(), requestContext)
-      .mapEmpty();
+    return BooleanUtils.isNotTrue(holder.getPatchOrderLineRequest().getReplaceInstanceRef().getDeleteAbandonedHoldings())
+      ? Future.succeededFuture()
+      : deleteAbandonedHoldings(holder.getStoragePoLine().getLocations(), requestContext).mapEmpty();
   }
 
 }

--- a/src/main/java/org/folio/service/orders/utils/PoLineFields.java
+++ b/src/main/java/org/folio/service/orders/utils/PoLineFields.java
@@ -1,0 +1,16 @@
+package org.folio.service.orders.utils;
+
+import lombok.Getter;
+
+@Getter
+public enum PoLineFields {
+
+  LOCATIONS("locations");
+
+  private final String value;
+
+  PoLineFields(String value) {
+    this.value = value;
+  }
+
+}

--- a/src/main/java/org/folio/service/pieces/util/PieceFields.java
+++ b/src/main/java/org/folio/service/pieces/util/PieceFields.java
@@ -1,0 +1,18 @@
+package org.folio.service.pieces.util;
+
+import lombok.Getter;
+
+@Getter
+public enum PieceFields {
+
+  HOLDING_ID("holdingId"),
+  PO_LINE_ID("poLineId"),
+  RECEIVING_TENANT_ID("receivingTenantId");
+
+  private final String value;
+
+  PieceFields(String value) {
+    this.value = value;
+  }
+
+}

--- a/src/test/java/org/folio/service/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
+++ b/src/test/java/org/folio/service/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
@@ -302,31 +302,30 @@ public class OrderLineUpdateInstanceHandlerTest {
       return new CommonSettingsCache(commonSettingsRetriever);
     }
 
-    @Bean OrderLinePatchOperationService orderLinePatchOperationService(
-        RestClient restClient,
-        OrderLineUpdateInstanceStrategyResolver orderLineUpdateInstanceStrategyResolver,
-        PurchaseOrderLineService purchaseOrderLineService,
-        InventoryCache inventoryCache,
-        InventoryInstanceManager inventoryInstanceManager) {
+    @Bean
+    OrderLinePatchOperationService orderLinePatchOperationService(RestClient restClient, OrderLineUpdateInstanceStrategyResolver orderLineUpdateInstanceStrategyResolver,
+                                                                  PurchaseOrderLineService purchaseOrderLineService, InventoryInstanceManager inventoryInstanceManager) {
       return new OrderLinePatchOperationService(restClient, orderLineUpdateInstanceStrategyResolver, purchaseOrderLineService, inventoryInstanceManager);
     }
 
-    @Bean OrderLineUpdateInstanceStrategy withHoldingOrderLineUpdateInstanceStrategy(InventoryInstanceManager inventoryInstanceManager,
-                                                                                     InventoryItemManager inventoryItemManager,
-                                                                                     InventoryHoldingManager inventoryHoldingManager,
-                                                                                     PieceStorageService pieceStorageService) {
-      return new WithHoldingOrderLineUpdateInstanceStrategy(inventoryInstanceManager, inventoryItemManager, inventoryHoldingManager, pieceStorageService);
+    @Bean
+    OrderLineUpdateInstanceStrategy withHoldingOrderLineUpdateInstanceStrategy(InventoryInstanceManager inventoryInstanceManager,
+                                                                               InventoryItemManager inventoryItemManager,
+                                                                               InventoryHoldingManager inventoryHoldingManager,
+                                                                               PieceStorageService pieceStorageService,
+                                                                               PurchaseOrderLineService purchaseOrderLineService) {
+      return new WithHoldingOrderLineUpdateInstanceStrategy(inventoryInstanceManager, inventoryItemManager,
+        inventoryHoldingManager, pieceStorageService, purchaseOrderLineService);
     }
 
-    @Bean OrderLineUpdateInstanceStrategyResolver updateInstanceStrategyResolver(OrderLineUpdateInstanceStrategy withHoldingOrderLineUpdateInstanceStrategy,
-        OrderLineUpdateInstanceStrategy withoutHoldingOrderLineUpdateInstanceStrategy) {
+    @Bean
+    OrderLineUpdateInstanceStrategyResolver updateInstanceStrategyResolver(OrderLineUpdateInstanceStrategy withHoldingOrderLineUpdateInstanceStrategy,
+                                                                                 OrderLineUpdateInstanceStrategy withoutHoldingOrderLineUpdateInstanceStrategy) {
       Map<CreateInventoryType, OrderLineUpdateInstanceStrategy> strategies = new HashMap<>();
-
       strategies.put(CreateInventoryType.INSTANCE_HOLDING_ITEM, withHoldingOrderLineUpdateInstanceStrategy);
       strategies.put(CreateInventoryType.INSTANCE_HOLDING, withHoldingOrderLineUpdateInstanceStrategy);
       strategies.put(CreateInventoryType.INSTANCE, withoutHoldingOrderLineUpdateInstanceStrategy);
       strategies.put(CreateInventoryType.NONE, withoutHoldingOrderLineUpdateInstanceStrategy);
-
       return new OrderLineUpdateInstanceStrategyResolver(strategies);
     }
 


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1333] Do not delete used holdings during instance connection change](https://folio-org.atlassian.net/browse/MODORDERS-1333) 

### **Approach**
- Add methods to fetch Pieces and POLs by holding IDs
- Filter out used holdings when deleting abandoned ones
- Update existing tests to cover new cases

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
