### PR TITLE
MODORDERS-1289. Holding is created despite an error about non-unique barcode during binding process

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1211,6 +1211,7 @@
             "inventory-storage.items.item.post",
             "inventory-storage.holdings-sources.collection.get",
             "inventory-storage.holdings.item.post",
+            "inventory-storage.holdings.item.delete",
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get",
             "circulation.requests.collection.get",

--- a/src/main/java/org/folio/helper/BaseHelper.java
+++ b/src/main/java/org/folio/helper/BaseHelper.java
@@ -105,7 +105,7 @@ public abstract class BaseHelper {
 
   public Response buildErrorResponse(int code) {
     final Response.ResponseBuilder responseBuilder = switch (code) {
-      case 400, 403, 404, 422 -> Response.status(code);
+      case 400, 403, 404, 422, 409 -> Response.status(code);
       default -> Response.status(INTERNAL_SERVER_ERROR);
     };
 


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODORDERS-1289

### **Approach**
Delete holding(if it was created previously) due to errors connected with item creation

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
