### PR TITLE
MODORDERS-1328. Do not update existing item statuses in case of new bind item failure

### DIFF
--- a/src/main/java/org/folio/helper/BindHelper.java
+++ b/src/main/java/org/folio/helper/BindHelper.java
@@ -123,10 +123,10 @@ public class BindHelper extends CheckinReceivePiecesHelper<BindPiecesCollection>
       .compose(bindPiecesHolder -> checkRequestsForPieceItems(bindPiecesHolder, requestContext))
       // 4. Update piece isBound flag
       .map(this::updatePieceRecords)
-      // 5. Update currently associated items
-      .compose(bindPiecesHolder -> updateItemStatus(bindPiecesHolder, requestContext))
-      // 6. Crate item for pieces with specific fields
+      // 5. Crate item for pieces with specific fields
       .compose(bindPiecesHolder -> createItemForPieces(bindPiecesHolder, requestContext))
+      // 6. Update currently associated items
+      .compose(bindPiecesHolder -> updateItemStatus(bindPiecesHolder, requestContext))
       // 7. Update received piece records in the storage
       .compose(bindPiecesHolder -> storeUpdatedPieces(bindPiecesHolder, requestContext))
       // 8. Update Title with new bind items


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODORDERS-1289

### **Approach**
Swap order of creating new bind item and update statuses for existing items. In this case if new bind item creation would be failed then we do not need to update status of existing items to Unavailable

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
