### PR TITLE
[MODORDERS-1359] Encumbrance is pending after unopen-open

### DIFF
--- a/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbrancesProcessingHolderBuilder.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import org.folio.models.EncumbranceRelationsHolder;
 import org.folio.models.EncumbrancesProcessingHolder;
+import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Transaction;
 
 public class EncumbrancesProcessingHolderBuilder {
@@ -37,16 +38,22 @@ public class EncumbrancesProcessingHolderBuilder {
   private boolean isTransactionUpdated(EncumbranceRelationsHolder holder) {
     double amountBeforeUpdate = holder.getOldEncumbrance().getAmount();
     double updatedAmount = holder.getNewEncumbrance().getAmount();
+
     double initialAmountBeforeUpdate = holder.getOldEncumbrance()
       .getEncumbrance().getInitialAmountEncumbered();
     double updatedInitialAmount = holder.getNewEncumbrance()
       .getEncumbrance().getInitialAmountEncumbered();
+
     String newExpenseClassId = holder.getNewEncumbrance().getExpenseClassId();
     String oldExpenseClassId = holder.getOldEncumbrance().getExpenseClassId();
 
+    Encumbrance.Status oldStatus = holder.getOldEncumbrance().getEncumbrance().getStatus();
+    Encumbrance.Status newStatus = holder.getNewEncumbrance().getEncumbrance().getStatus();
+
     return Double.compare(amountBeforeUpdate, updatedAmount) != 0
       || Double.compare(initialAmountBeforeUpdate, updatedInitialAmount) != 0
-      || !Objects.equals(oldExpenseClassId, newExpenseClassId);
+      || !Objects.equals(oldExpenseClassId, newExpenseClassId)
+      || !Objects.equals(oldStatus, newStatus);
   }
 
   private List<EncumbranceRelationsHolder> getToBeCreatedHolders(List<EncumbranceRelationsHolder> encumbranceRelationsHolders) {


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1359] Encumbrance is pending after unopen-open](https://folio-org.atlassian.net/browse/MODORDERS-1359)

### **Approach**
- Add encumbrance status check when filtering updatable transactions
- Verified with a new karate test scenario: https://github.com/folio-org/folio-integration-tests/pull/2014

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.

---

### **Screenshots**
<img width="984" height="231" alt="image" src="https://github.com/user-attachments/assets/5ef6bf15-f1dd-4988-a10c-452a6f746a84" />
<img width="974" height="227" alt="image" src="https://github.com/user-attachments/assets/8cad0e5e-5fb3-4c44-bec2-3f113a228565" />

