### PR TITLE
[MODORDERS-1356] BE - Create Sequence field in receiving

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -39,7 +39,8 @@
             "orders-storage.configuration.suffixes.collection.get",
             "finance.funds.item.get",
             "finance.transactions.collection.get",
-            "finance.transactions.batch.execute"
+            "finance.transactions.batch.execute",
+            "orders-storage.titles.sequence-number.post"
           ]
         },
         {
@@ -108,7 +109,8 @@
             "orders-storage.po-lines.item.delete",
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get",
-            "orders-storage.order-invoice-relationships.collection.get"
+            "orders-storage.order-invoice-relationships.collection.get",
+            "orders-storage.titles.sequence-number.post"
           ]
         },
         {
@@ -538,6 +540,7 @@
             "orders-storage.purchase-orders.item.get",
             "orders-storage.titles.item.get",
             "orders-storage.titles.item.put",
+            "orders-storage.titles.sequence-number.post",
             "user-tenants.collection.get",
             "consortia.sharing-instances.item.post"
           ]
@@ -659,6 +662,7 @@
             "orders-storage.purchase-orders.item.get",
             "orders-storage.titles.item.get",
             "orders-storage.titles.item.put",
+            "orders-storage.titles.sequence-number.post",
             "user-tenants.collection.get",
             "consortia.sharing-instances.item.post",
             "orders-storage.pieces-batch.collection.post"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -40,7 +40,7 @@
             "finance.funds.item.get",
             "finance.transactions.collection.get",
             "finance.transactions.batch.execute",
-            "orders-storage.titles.sequence-number.post"
+            "orders-storage.titles.sequence-number.get"
           ]
         },
         {
@@ -110,7 +110,7 @@
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get",
             "orders-storage.order-invoice-relationships.collection.get",
-            "orders-storage.titles.sequence-number.post"
+            "orders-storage.titles.sequence-number.get"
           ]
         },
         {
@@ -540,7 +540,7 @@
             "orders-storage.purchase-orders.item.get",
             "orders-storage.titles.item.get",
             "orders-storage.titles.item.put",
-            "orders-storage.titles.sequence-number.post",
+            "orders-storage.titles.sequence-number.get",
             "user-tenants.collection.get",
             "consortia.sharing-instances.item.post"
           ]
@@ -662,7 +662,7 @@
             "orders-storage.purchase-orders.item.get",
             "orders-storage.titles.item.get",
             "orders-storage.titles.item.put",
-            "orders-storage.titles.sequence-number.post",
+            "orders-storage.titles.sequence-number.get",
             "user-tenants.collection.get",
             "consortia.sharing-instances.item.post",
             "orders-storage.pieces-batch.collection.post"

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -546,12 +546,13 @@ public class ApplicationConfig {
   }
 
   @Bean
-  PieceCreateFlowManager pieceCreationService(PieceStorageService pieceStorageService, ProtectionService protectionService,
+  PieceCreateFlowManager pieceCreationService(PieceStorageService pieceStorageService, TitlesService titlesService,
+                                              ProtectionService protectionService,
                                               PieceCreateFlowInventoryManager pieceCreateFlowInventoryManager,
                                               DefaultPieceFlowsValidator defaultPieceFlowsValidator,
                                               PieceCreateFlowPoLineService pieceCreateFlowPoLineService,
                                               BasePieceFlowHolderBuilder basePieceFlowHolderBuilder) {
-    return new PieceCreateFlowManager(pieceStorageService, protectionService, pieceCreateFlowInventoryManager,
+    return new PieceCreateFlowManager(pieceStorageService, titlesService, protectionService, pieceCreateFlowInventoryManager,
       defaultPieceFlowsValidator, pieceCreateFlowPoLineService, basePieceFlowHolderBuilder);
   }
 
@@ -778,8 +779,8 @@ public class ApplicationConfig {
       titlesService, openCompositeOrderInventoryService, openCompositeOrderFlowValidator, unOpenCompositeOrderManager);
   }
 
-  @Bean OpenCompositeOrderHolderBuilder openCompositeOrderHolderBuilder(PieceStorageService pieceStorageService) {
-    return new OpenCompositeOrderHolderBuilder(pieceStorageService);
+  @Bean OpenCompositeOrderHolderBuilder openCompositeOrderHolderBuilder(PieceStorageService pieceStorageService, TitlesService titlesService) {
+    return new OpenCompositeOrderHolderBuilder(pieceStorageService, titlesService);
   }
 
   @Bean ProcessInventoryStrategyResolver resolver(ConsortiumConfigurationService consortiumConfigurationService) {

--- a/src/main/java/org/folio/models/pieces/OpenOrderPieceHolder.java
+++ b/src/main/java/org/folio/models/pieces/OpenOrderPieceHolder.java
@@ -3,19 +3,21 @@ package org.folio.models.pieces;
 import java.util.Collections;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.Title;
 
+@RequiredArgsConstructor
+@Getter
 public class OpenOrderPieceHolder {
-  private final String titleId;
+
+  private final Title title;
   private List<Piece> existingPieces = Collections.emptyList();
   private List<Piece> piecesWithLocationToProcess = Collections.emptyList();
   private List<Piece> piecesWithHoldingToProcess = Collections.emptyList();
   private List<Piece> piecesWithChangedLocation = Collections.emptyList();
   private List<Piece> piecesWithoutLocationId = Collections.emptyList();
-
-  public OpenOrderPieceHolder(String titleId) {
-    this.titleId = titleId;
-  }
 
   public OpenOrderPieceHolder withExistingPieces(List<Piece> existingPieces) {
     this.existingPieces = existingPieces;
@@ -42,27 +44,4 @@ public class OpenOrderPieceHolder {
     return this;
   }
 
-  public List<Piece> getPiecesWithLocationToProcess() {
-    return piecesWithLocationToProcess;
-  }
-
-  public List<Piece> getPiecesWithHoldingToProcess() {
-    return piecesWithHoldingToProcess;
-  }
-
-  public List<Piece> getPiecesWithChangedLocation() {
-    return piecesWithChangedLocation;
-  }
-
-  public List<Piece> getPiecesWithoutLocationId() {
-    return piecesWithoutLocationId;
-  }
-
-  public List<Piece> getExistingPieces() {
-    return existingPieces;
-  }
-
-  public String getTitleId() {
-    return titleId;
-  }
 }

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -113,6 +113,7 @@ public enum ErrorCodes {
   PIECE_FORMAT_IS_NOT_VALID_ERROR("pieceFormatIsNotValid", "Piece format %s is not compatible with purchase line %s"),
   PIECE_DISPLAY_ON_HOLDINGS_IS_NOT_CONSISTENT("pieceDisplayOnHoldingsIsNotConsistent", "Display On Holdings could not be set to false when Display To Public is true"),
   PIECE_RELATED_ORDER_DATA_IS_NOT_VALID("pieceRelatedOrderDataIsNotValid", "Adding piece for pending order with synchronized workflow is not allowed"),
+  PIECE_SEQUENCE_NUMBER_IS_INVALID("pieceSequenceNumberIsInvalid", "Piece sequence number must be a positive integer and within the correct range"),
   CREATE_PIECE_FOR_PENDING_ORDER_ERROR("createPiecePendingOrderError", "Creating piece for pending order is not possible. Please open order."),
   CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR("createItemForPieceIsNotAllowedError", "Create item for piece format %s is not allowed. Please check inventory option in the purchase order line %s"),
   NOT_FOUND("notFound", "Not Found"),

--- a/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/core/exceptions/ErrorCodes.java
@@ -113,7 +113,7 @@ public enum ErrorCodes {
   PIECE_FORMAT_IS_NOT_VALID_ERROR("pieceFormatIsNotValid", "Piece format %s is not compatible with purchase line %s"),
   PIECE_DISPLAY_ON_HOLDINGS_IS_NOT_CONSISTENT("pieceDisplayOnHoldingsIsNotConsistent", "Display On Holdings could not be set to false when Display To Public is true"),
   PIECE_RELATED_ORDER_DATA_IS_NOT_VALID("pieceRelatedOrderDataIsNotValid", "Adding piece for pending order with synchronized workflow is not allowed"),
-  PIECE_SEQUENCE_NUMBER_IS_INVALID("pieceSequenceNumberIsInvalid", "Piece sequence number must be a positive integer and within the correct range"),
+  PIECE_SEQUENCE_NUMBER_IS_INVALID("pieceSequenceNumberIsInvalid", "Piece sequence number must be a positive integer and not exceed the title's next available sequence number"),
   CREATE_PIECE_FOR_PENDING_ORDER_ERROR("createPiecePendingOrderError", "Creating piece for pending order is not possible. Please open order."),
   CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR("createItemForPieceIsNotAllowedError", "Create item for piece format %s is not allowed. Please check inventory option in the purchase order line %s"),
   NOT_FOUND("notFound", "Not Found"),

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
@@ -69,7 +69,7 @@ public class OpenCompositeOrderPieceService {
   /**
    * Creates pieces that are not yet in storage
    *
-   * @param poLine PO line to create Pieces Records for
+   * @param poLine                 PO line to create Pieces Records for
    * @param expectedPiecesWithItem expected Pieces to create with created associated Items records
    * @return void future
    */
@@ -86,13 +86,6 @@ public class OpenCompositeOrderPieceService {
         return updatePieces(holder, requestContext);
       })
       .map(pieces -> validateItemsCreationForPieces(pieces, poLine, expectedPiecesWithItem.size()));
-  }
-
-  private Future<List<Piece>> updatePieces(OpenOrderPieceHolder holder, RequestContext requestContext) {
-    logger.debug("updatePieces:: Trying to update pieces");
-    return collectResultsOnSuccess(holder.getPiecesWithChangedLocation().stream()
-      .map(piece -> updatePiece(piece, requestContext))
-      .toList());
   }
 
   private Future<List<Piece>> createPieces(OpenOrderPieceHolder holder, CompositePurchaseOrder order, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
@@ -128,37 +121,11 @@ public class OpenCompositeOrderPieceService {
   }
 
 
-  private Future<Piece> openOrderUpdateInventory(Piece piece, CompositePurchaseOrder order, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
+  private Future<Piece> openOrderUpdateInventory(Piece piece, Title title, CompositePurchaseOrder order,
+                                                 boolean isInstanceMatchingDisabled, RequestContext requestContext) {
     logger.debug("openOrderUpdateInventory:: Validating acq unit and updating order '{}' inventory - {}", order.getId(), piece.getId());
-    return titlesService.getTitleById(piece.getTitleId(), requestContext)
-      .compose(title ->
-        protectionService.isOperationRestricted(title.getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext)
-      )
-      .compose(v ->
-        openOrderUpdateInventory(order, order.getPoLines().getFirst(), piece, isInstanceMatchingDisabled, requestContext)
-      )
-      .map(v -> piece);
-  }
-
-  public Future<Piece> updatePiece(Piece piece, RequestContext requestContext) {
-    logger.debug("updatePiece:: Updating piece - {}", piece.getId());
-    return titlesService.getTitleById(piece.getTitleId(), requestContext)
-      .compose(title -> protectionService.isOperationRestricted(title.getAcqUnitIds(), ProtectedOperationType.UPDATE, requestContext))
-      .compose(vVoid -> pieceStorageService.getPieceById(piece.getId(), requestContext))
-      .compose(pieceStorage -> inventoryItemManager.updateItemWithPieceFields(pieceStorage, piece, requestContext)
-        .compose(aVoid -> {
-          var isReceivingStatusChanged = updatePieceStatus(piece, pieceStorage.getReceivingStatus(), piece.getReceivingStatus());
-          return pieceStorageService.updatePiece(piece, requestContext)
-            .compose(v -> {
-              logger.debug("updatePiece:: Status updated from: {} to {}", pieceStorage.getReceivingStatus(), piece.getReceivingStatus());
-              if (isReceivingStatusChanged) {
-                receiptStatusPublisher.sendEvent(MessageAddress.RECEIPT_STATUS, createPoLineUpdateEvent(piece.getPoLineId()), requestContext);
-              }
-              return Future.succeededFuture();
-            })
-            .onFailure(e -> logger.error("Error updating piece by id to storage {}", piece.getId(), e));
-        })
-      ).onFailure(e -> logger.error("Error getting piece by id from storage {}", piece.getId(), e))
+    return protectionService.isOperationRestricted(title.getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext)
+      .compose(v -> openOrderUpdateInventory(order, order.getPoLines().getFirst(), piece, title, isInstanceMatchingDisabled, requestContext))
       .map(v -> piece);
   }
 
@@ -168,17 +135,17 @@ public class OpenCompositeOrderPieceService {
    * @param poLine PO line to update Inventory for
    * @return CompletableFuture with void.
    */
-  public Future<Void> openOrderUpdateInventory(CompositePurchaseOrder compPO, PoLine poLine,
-                                               Piece piece, boolean isInstanceMatchingDisabled, RequestContext requestContext) {
+  public Future<Void> openOrderUpdateInventory(CompositePurchaseOrder compPO, PoLine poLine, Piece piece, Title title,
+                                               boolean isInstanceMatchingDisabled, RequestContext requestContext) {
     logger.debug("OpenCompositeOrderPieceService.openOrderUpdateInventory poLine.id={}", poLine.getId());
     if (!Boolean.TRUE.equals(poLine.getIsPackage())) {
       return inventoryItemManager.updateItemWithPieceFields(null, piece, requestContext);
     }
     var locationContext = createContextWithNewTenantId(requestContext, piece.getReceivingTenantId());
     var suppressDiscovery = Optional.ofNullable(poLine.getSuppressInstanceFromDiscovery()).orElse(false);
-    return titlesService.getTitleById(piece.getTitleId(), requestContext)
-      .compose(title -> titlesService.updateTitleWithInstance(title, isInstanceMatchingDisabled, suppressDiscovery, locationContext, requestContext).map(title::withInstanceId))
-      .compose(title -> getOrCreateHolding(poLine, piece, title, locationContext))
+    return titlesService.updateTitleWithInstance(title, isInstanceMatchingDisabled, suppressDiscovery, locationContext, requestContext)
+      .map(title::withInstanceId)
+      .compose(updatedTitle -> getOrCreateHolding(poLine, piece, updatedTitle, locationContext))
       .compose(holdingId -> updateItemsIfNeeded(compPO, poLine, holdingId, locationContext))
       .map(itemId -> Optional.ofNullable(itemId).map(piece::withItemId))
       .mapEmpty();
@@ -208,4 +175,34 @@ public class OpenCompositeOrderPieceService {
     throw new InventoryException(String.format("Error creating items for PO Line with '%s' id. Expected %d but %d created",
       poLine.getId(), expectedItemsQuantity, itemsSize));
   }
+
+  private Future<List<Piece>> updatePieces(OpenOrderPieceHolder holder, RequestContext requestContext) {
+    logger.debug("updatePieces:: Trying to update pieces");
+    return collectResultsOnSuccess(holder.getPiecesWithChangedLocation().stream()
+      .map(piece -> updatePiece(piece, requestContext))
+      .toList());
+  }
+
+  public Future<Piece> updatePiece(Piece piece, RequestContext requestContext) {
+    logger.debug("updatePiece:: Updating piece - {}", piece.getId());
+    return titlesService.getTitleById(piece.getTitleId(), requestContext)
+      .compose(title -> protectionService.isOperationRestricted(title.getAcqUnitIds(), ProtectedOperationType.UPDATE, requestContext))
+      .compose(vVoid -> pieceStorageService.getPieceById(piece.getId(), requestContext))
+      .compose(pieceStorage -> inventoryItemManager.updateItemWithPieceFields(pieceStorage, piece, requestContext)
+        .compose(aVoid -> {
+          var isReceivingStatusChanged = updatePieceStatus(piece, pieceStorage.getReceivingStatus(), piece.getReceivingStatus());
+          return pieceStorageService.updatePiece(piece, requestContext)
+            .compose(v -> {
+              logger.debug("updatePiece:: Status updated from: {} to {}", pieceStorage.getReceivingStatus(), piece.getReceivingStatus());
+              if (isReceivingStatusChanged) {
+                receiptStatusPublisher.sendEvent(MessageAddress.RECEIPT_STATUS, createPoLineUpdateEvent(piece.getPoLineId()), requestContext);
+              }
+              return Future.succeededFuture();
+            })
+            .onFailure(e -> logger.error("Error updating piece by id to storage {}", piece.getId(), e));
+        })
+      ).onFailure(e -> logger.error("Error getting piece by id from storage {}", piece.getId(), e))
+      .map(v -> piece);
+  }
+
 }

--- a/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
+++ b/src/main/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceService.java
@@ -97,7 +97,7 @@ public class OpenCompositeOrderPieceService {
     piecesToCreate.addAll(holder.getPiecesWithoutLocationId());
 
     piecesToCreate.stream()
-      .peek(piece -> piece.withTitleId(holder.getTitle().getId()))
+      .map(piece -> piece.withTitleId(holder.getTitle().getId()))
       .forEach(piece -> validatePieceSequenceNumber(piece, holder.getTitle(), piecesToCreate.size()));
 
     // Collect pieces after validation

--- a/src/main/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidator.java
+++ b/src/main/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidator.java
@@ -85,9 +85,8 @@ public class DefaultPieceFlowsValidator {
   }
 
   public static boolean isCreateHoldingForPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
-    Piece.Format pieceFormat = pieceToCreate.getFormat();
-    return pieceFormat == Piece.Format.ELECTRONIC && PoLineCommonUtil.isHoldingUpdateRequiredForEresource(originPoLine) ||
-      (pieceFormat == Piece.Format.PHYSICAL || pieceFormat == Piece.Format.OTHER) && PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(originPoLine);
+    return isPieceFormatElectronic(pieceToCreate) && PoLineCommonUtil.isHoldingUpdateRequiredForEresource(originPoLine)
+        || isPieceFormatNonElectronic(pieceToCreate) && PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(originPoLine);
   }
 
   public static boolean isCreateItemForPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
@@ -96,14 +95,11 @@ public class DefaultPieceFlowsValidator {
   }
 
   public static boolean isCreateItemForElectronicPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
-    Piece.Format pieceFormat = pieceToCreate.getFormat();
-    return pieceFormat == Piece.Format.ELECTRONIC && isItemsUpdateRequiredForEresource(originPoLine);
+    return isPieceFormatElectronic(pieceToCreate) && isItemsUpdateRequiredForEresource(originPoLine);
   }
 
-
   public static boolean isCreateItemForNonElectronicPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
-    Piece.Format pieceFormat = pieceToCreate.getFormat();
-    return (pieceFormat == Piece.Format.PHYSICAL || pieceFormat == Piece.Format.OTHER) && isItemsUpdateRequiredForPhysical(originPoLine);
+    return isPieceFormatNonElectronic(pieceToCreate) && isItemsUpdateRequiredForPhysical(originPoLine);
   }
 
   public static boolean isItemsUpdateRequiredForEresource(PoLine poLine) {
@@ -117,4 +113,13 @@ public class DefaultPieceFlowsValidator {
       .map(physical -> physical.getCreateInventory() == Physical.CreateInventory.INSTANCE_HOLDING_ITEM)
       .orElse(false);
   }
+
+  private static boolean isPieceFormatElectronic(Piece piece) {
+    return piece.getFormat() == Piece.Format.ELECTRONIC;
+  }
+
+  private static boolean isPieceFormatNonElectronic(Piece piece) {
+    return piece.getFormat() == Piece.Format.PHYSICAL || piece.getFormat() == Piece.Format.OTHER;
+  }
+
 }

--- a/src/main/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidator.java
+++ b/src/main/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidator.java
@@ -3,16 +3,17 @@ package org.folio.service.pieces.flows;
 import static org.folio.rest.core.exceptions.ErrorCodes.ALL_PIECES_MUST_HAVE_THE_SAME_POLINE_ID_AND_TITLE_ID;
 import static org.folio.rest.core.exceptions.ErrorCodes.CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_DISPLAY_ON_HOLDINGS_IS_NOT_CONSISTENT;
+import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_SEQUENCE_NUMBER_IS_INVALID;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.extern.log4j.Log4j2;
+import one.util.streamex.StreamEx;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.orders.utils.PoLineCommonUtil;
 import org.folio.rest.RestConstants;
 import org.folio.rest.core.exceptions.HttpException;
@@ -24,80 +25,81 @@ import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.Title;
 import org.folio.service.pieces.validators.PieceValidatorUtil;
 
 import io.vertx.core.json.JsonObject;
 
+@Log4j2
 public class DefaultPieceFlowsValidator {
-  private static final Logger logger = LogManager.getLogger(DefaultPieceFlowsValidator.class);
 
-  public void isPieceRequestValid(Piece pieceToCreate, CompositePurchaseOrder originalOrder, PoLine originPoLine, boolean isCreateItem) {
-    List<Error> isItemCreateValidError = validateItemCreateFlag(pieceToCreate, originPoLine, isCreateItem);
-    List<Error> combinedErrors = new ArrayList<>(isItemCreateValidError);
-    List<Error> pieceLocationErrors = Optional.ofNullable(PieceValidatorUtil.validatePieceLocation(pieceToCreate, originPoLine)).orElse(new ArrayList<>());
-    combinedErrors.addAll(pieceLocationErrors);
-    List<Error> pieceFormatErrors = Optional.ofNullable(PieceValidatorUtil.validatePieceFormat(pieceToCreate, originPoLine)).orElse(new ArrayList<>());
-    combinedErrors.addAll(pieceFormatErrors);
-    List<Error> displayOnHoldingsErrors = validateDisplayOnHoldingsConsistency(pieceToCreate);
-    combinedErrors.addAll(displayOnHoldingsErrors);
-    List<Error> relatedOrderErrors = PieceValidatorUtil.validatePieceRelatedOrder(originalOrder, originPoLine);
-    combinedErrors.addAll(relatedOrderErrors);
+  public void isPieceRequestValid(Piece pieceToCreate, CompositePurchaseOrder originalOrder, PoLine originPoLine, Title title, boolean isCreateItem) {
+    List<Error> combinedErrors = Stream.of(
+        PieceValidatorUtil.validatePieceLocation(pieceToCreate, originPoLine),
+        PieceValidatorUtil.validatePieceFormat(pieceToCreate, originPoLine),
+        PieceValidatorUtil.validatePieceRelatedOrder(originalOrder, originPoLine),
+        validateItemCreateFlag(pieceToCreate, originPoLine, isCreateItem),
+        validateDisplayOnHoldingsConsistency(pieceToCreate),
+        validatePieceSequenceNumber(pieceToCreate, title))
+      .flatMap(Collection::stream)
+      .toList();
     if (CollectionUtils.isNotEmpty(combinedErrors)) {
       Errors errors = new Errors().withErrors(combinedErrors).withTotalRecords(combinedErrors.size());
-      if (logger.isErrorEnabled()) logger.error("Validation error: {}", JsonObject.mapFrom(errors).encodePrettily());
+      if (log.isErrorEnabled()) log.error("Validation error: {}", JsonObject.mapFrom(errors).encodePrettily());
       throw new HttpException(RestConstants.BAD_REQUEST, errors);
     }
   }
 
-  public void isPieceBatchRequestValid(List<Piece> piecesToCreate, CompositePurchaseOrder originalOrder, PoLine originPoLine, boolean isCreateItem) {
-    var titlePoLineIds = piecesToCreate.stream()
-      .collect(Collectors.groupingBy(piece -> piece.getTitleId() + ":" + piece.getPoLineId()));
+  public void isPieceBatchRequestValid(List<Piece> piecesToCreate, CompositePurchaseOrder originalOrder, PoLine originPoLine, Title title, boolean isCreateItem) {
+    var titlePoLineIds = StreamEx.of(piecesToCreate).groupingBy(piece -> piece.getTitleId() + ":" + piece.getPoLineId());
     if (titlePoLineIds.size() > 1) {
       var param = new Parameter().withKey("titlePoLineIds").withValue(titlePoLineIds.keySet().toString());
       var error = ALL_PIECES_MUST_HAVE_THE_SAME_POLINE_ID_AND_TITLE_ID.toError().withParameters(List.of(param));
-      logger.error("isPieceBatchRequestValid:: Validation Error {}", error.getMessage());
+      log.error("isPieceBatchRequestValid:: Validation Error {}", error.getMessage());
       throw new HttpException(RestConstants.VALIDATION_ERROR, ALL_PIECES_MUST_HAVE_THE_SAME_POLINE_ID_AND_TITLE_ID);
     }
-    piecesToCreate.forEach(piece -> isPieceRequestValid(piece, originalOrder, originPoLine, isCreateItem));
+    piecesToCreate.forEach(piece -> isPieceRequestValid(piece, originalOrder, originPoLine, title, isCreateItem));
   }
 
   public static List<Error> validateItemCreateFlag(Piece pieceToCreate, PoLine originPoLine, boolean createItem) {
-    if (createItem && !isCreateItemForPiecePossible(pieceToCreate, originPoLine)) {
-      String msg = String.format(CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR.getDescription(), pieceToCreate.getFormat(), originPoLine.getId());
-      return List.of(new Error().withCode(CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR.getCode()).withMessage(msg));
-    }
-    return Collections.emptyList();
+    return createItem && !isCreateItemForPiecePossible(pieceToCreate, originPoLine)
+      ? List.of(new Error().withCode(CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR.getCode())
+        .withMessage(CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR.getDescription().formatted(pieceToCreate.getFormat(), originPoLine.getId())))
+      : List.of();
   }
 
   public static List<Error> validateDisplayOnHoldingsConsistency(Piece piece) {
-    if (Boolean.FALSE.equals(piece.getDisplayOnHolding()) && Boolean.TRUE.equals(piece.getDisplayToPublic())) {
-      return List.of(PIECE_DISPLAY_ON_HOLDINGS_IS_NOT_CONSISTENT.toError());
-    }
-    return Collections.emptyList();
+    return Boolean.FALSE.equals(piece.getDisplayOnHolding()) && Boolean.TRUE.equals(piece.getDisplayToPublic())
+      ? List.of(PIECE_DISPLAY_ON_HOLDINGS_IS_NOT_CONSISTENT.toError())
+      : List.of();
+  }
+
+  public static List<Error> validatePieceSequenceNumber(Piece piece, Title title) {
+    return piece.getSequenceNumber() != null && (piece.getSequenceNumber() > title.getNextSequenceNumber() || piece.getSequenceNumber() <= 0)
+      ? List.of(PIECE_SEQUENCE_NUMBER_IS_INVALID.toError())
+      : List.of();
   }
 
   public static boolean isCreateHoldingForPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
     Piece.Format pieceFormat = pieceToCreate.getFormat();
-    return (pieceFormat == Piece.Format.ELECTRONIC && PoLineCommonUtil.isHoldingUpdateRequiredForEresource(originPoLine)) ||
-              ((pieceFormat == Piece.Format.PHYSICAL || pieceFormat == Piece.Format.OTHER)
-                        && PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(originPoLine));
+    return pieceFormat == Piece.Format.ELECTRONIC && PoLineCommonUtil.isHoldingUpdateRequiredForEresource(originPoLine) ||
+      (pieceFormat == Piece.Format.PHYSICAL || pieceFormat == Piece.Format.OTHER) && PoLineCommonUtil.isHoldingUpdateRequiredForPhysical(originPoLine);
   }
 
   public static boolean isCreateItemForPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
-    return isCreateItemForElectronicPiecePossible(pieceToCreate, originPoLine) ||
-                  isCreateItemForNonElectronicPiecePossible(pieceToCreate, originPoLine);
+    return isCreateItemForElectronicPiecePossible(pieceToCreate, originPoLine)
+        || isCreateItemForNonElectronicPiecePossible(pieceToCreate, originPoLine);
   }
 
   public static boolean isCreateItemForElectronicPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
     Piece.Format pieceFormat = pieceToCreate.getFormat();
-    return (pieceFormat == Piece.Format.ELECTRONIC && isItemsUpdateRequiredForEresource(originPoLine));
+    return pieceFormat == Piece.Format.ELECTRONIC && isItemsUpdateRequiredForEresource(originPoLine);
   }
 
 
   public static boolean isCreateItemForNonElectronicPiecePossible(Piece pieceToCreate, PoLine originPoLine) {
     Piece.Format pieceFormat = pieceToCreate.getFormat();
-    return (pieceFormat == Piece.Format.PHYSICAL || pieceFormat == Piece.Format.OTHER)
-                            && isItemsUpdateRequiredForPhysical(originPoLine);
+    return (pieceFormat == Piece.Format.PHYSICAL || pieceFormat == Piece.Format.OTHER) && isItemsUpdateRequiredForPhysical(originPoLine);
   }
 
   public static boolean isItemsUpdateRequiredForEresource(PoLine poLine) {

--- a/src/main/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidator.java
+++ b/src/main/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidator.java
@@ -79,7 +79,7 @@ public class DefaultPieceFlowsValidator {
   }
 
   public static List<Error> validatePieceSequenceNumber(Piece piece, Title title, int piecesInBatch) {
-    return piece.getSequenceNumber() != null && (piece.getSequenceNumber() >= title.getNextSequenceNumber() + piecesInBatch || piece.getSequenceNumber() <= 0)
+    return piece.getSequenceNumber() != null && (piece.getSequenceNumber() <= 0 || piece.getSequenceNumber() >= title.getNextSequenceNumber() + piecesInBatch)
       ? List.of(PIECE_SEQUENCE_NUMBER_IS_INVALID.toError())
       : List.of();
   }

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
@@ -46,7 +46,7 @@ public class PieceCreateFlowManager {
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(pieceToCreate).withCreateItem(createItem);
     return basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext)
       .compose(v -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
-      .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceRequestValid(pieceToCreate, holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), createItem)))
+      .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceRequestValid(pieceToCreate, holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), holder.getTitle(), createItem)))
       .compose(v -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext))
       .compose(v -> processInventory(holder, requestContext))
       .compose(v -> updatePoLine(holder, requestContext))
@@ -62,7 +62,7 @@ public class PieceCreateFlowManager {
     var holder = new PieceBatchCreationHolder().withPieceToCreate(pieceCollection).withCreateItem(createItem);
     return basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext)
       .compose(v -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
-      .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceBatchRequestValid(holder.getPiecesToCreate(), holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), createItem)))
+      .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceBatchRequestValid(holder.getPiecesToCreate(), holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), holder.getTitle(), createItem)))
       .compose(v -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext))
       .compose(v -> processInventory(holder, requestContext))
       .compose(v -> updatePoLine(holder, requestContext))

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
@@ -6,8 +6,8 @@ import static org.folio.orders.utils.HelperUtils.collectResultsOnSuccess;
 import java.util.List;
 
 import io.vertx.core.Future;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.folio.models.pieces.PieceBatchCreationHolder;
 import org.folio.models.pieces.PieceCreationHolder;
 import org.folio.orders.utils.ProtectedOperationType;
@@ -18,30 +18,22 @@ import org.folio.service.ProtectionService;
 import org.folio.service.pieces.PieceStorageService;
 import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
 import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
+import org.folio.service.titles.TitlesService;
 
+@Log4j2
+@RequiredArgsConstructor
 public class PieceCreateFlowManager {
-  private static final Logger logger = LogManager.getLogger(PieceCreateFlowManager.class);
 
   private final PieceStorageService pieceStorageService;
+  private final TitlesService titlesService;
   private final ProtectionService protectionService;
   private final PieceCreateFlowInventoryManager pieceCreateFlowInventoryManager;
   private final DefaultPieceFlowsValidator defaultPieceFlowsValidator;
   private final PieceCreateFlowPoLineService pieceCreateFlowPoLineService;
   private final BasePieceFlowHolderBuilder basePieceFlowHolderBuilder;
 
-  public PieceCreateFlowManager(PieceStorageService pieceStorageService, ProtectionService protectionService,
-                                PieceCreateFlowInventoryManager pieceCreateFlowInventoryManager, DefaultPieceFlowsValidator defaultPieceFlowsValidator,
-                                PieceCreateFlowPoLineService pieceCreateFlowPoLineService, BasePieceFlowHolderBuilder basePieceFlowHolderBuilder) {
-    this.pieceStorageService = pieceStorageService;
-    this.protectionService = protectionService;
-    this.pieceCreateFlowInventoryManager = pieceCreateFlowInventoryManager;
-    this.pieceCreateFlowPoLineService = pieceCreateFlowPoLineService;
-    this.defaultPieceFlowsValidator = defaultPieceFlowsValidator;
-    this.basePieceFlowHolderBuilder = basePieceFlowHolderBuilder;
-  }
-
   public Future<Piece> createPiece(Piece pieceToCreate, boolean createItem, RequestContext requestContext) {
-    logger.info("createPiece:: manual createPiece start, poLineId: {}, receivingTenantId: {}",
+    log.info("createPiece:: manual createPiece start, poLineId: {}, receivingTenantId: {}",
       pieceToCreate.getPoLineId(), pieceToCreate.getReceivingTenantId());
     PieceCreationHolder holder = new PieceCreationHolder().withPieceToCreate(pieceToCreate).withCreateItem(createItem);
     return basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext)
@@ -50,13 +42,14 @@ public class PieceCreateFlowManager {
       .compose(v -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext))
       .compose(v -> processInventory(holder, requestContext))
       .compose(v -> updatePoLine(holder, requestContext))
-      .compose(v -> pieceStorageService.insertPiece(pieceToCreate, requestContext));
+      .compose(v -> titlesService.generateNextSequenceNumbers(List.of(holder.getPieceToCreate()), holder.getTitle(), requestContext))
+      .compose(pieces -> pieceStorageService.insertPiece(pieces.getFirst(), requestContext));
   }
 
   public Future<PieceCollection> createPieces(PieceCollection pieceCollection, boolean createItem, RequestContext requestContext) {
-    logger.info("createPieces:: Trying to create '{}' pieces", pieceCollection.getPieces().size());
+    log.info("createPieces:: Trying to create '{}' pieces", pieceCollection.getPieces().size());
     if (pieceCollection.getPieces().isEmpty()) {
-      logger.info("createPieces:: No pieces to create");
+      log.info("createPieces:: No pieces to create");
       return Future.succeededFuture();
     }
     var holder = new PieceBatchCreationHolder().withPieceToCreate(pieceCollection).withCreateItem(createItem);
@@ -66,7 +59,8 @@ public class PieceCreateFlowManager {
       .compose(v -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext))
       .compose(v -> processInventory(holder, requestContext))
       .compose(v -> updatePoLine(holder, requestContext))
-      .compose(v -> pieceStorageService.insertPiecesBatch(holder.getPiecesToCreate(), requestContext));
+      .compose(v -> titlesService.generateNextSequenceNumbers(holder.getPiecesToCreate(), holder.getTitle(), requestContext))
+      .compose(pieces -> pieceStorageService.insertPiecesBatch(pieces, requestContext));
   }
 
   private Future<Void> processInventory(PieceCreationHolder holder, RequestContext requestContext) {
@@ -113,4 +107,5 @@ public class PieceCreateFlowManager {
     }
     return Future.succeededFuture();
   }
+
 }

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -82,7 +82,7 @@ public class PieceUpdateFlowManager {
       .map(holder::withPieceFromStorage)
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext))
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
-      .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceRequestValid(pieceToUpdate, holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), createItem)))
+      .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceRequestValid(pieceToUpdate, holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), holder.getTitle(), createItem)))
       .compose(title -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), UPDATE, requestContext))
       .compose(v -> pieceUpdateFlowInventoryManager.processInventory(holder, requestContext))
       .compose(v -> updatePoLine(holder, requestContext))

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -191,7 +191,7 @@ public class TitlesService {
     log.info("generateNextSequenceNumbers:: Generating {} sequence numbers starting from {} for title: '{}'", pieces.size(), title.getNextSequenceNumber(), title.getId());
     var requestEntry = new RequestEntry(SEQUENCE_NUMBERS_ENDPOINT).withId(title.getId())
       .withQueryParameter(SEQUENCE_NUMBER_PARAM, String.valueOf(pieces.size()));
-    return restClient.postBatch(requestEntry, null, SequenceNumbers.class, requestContext)
+    return restClient.get(requestEntry, SequenceNumbers.class, requestContext)
       .compose(titleSequenceNumbers -> {
         Set<Integer> assignedNumbers = StreamEx.of(pieces)
           .map(Piece::getSequenceNumber)

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -186,7 +186,7 @@ public class TitlesService {
 
   public Future<List<Piece>> generateNextSequenceNumbers(List<Piece> pieces, Title title, RequestContext requestContext) {
     if (CollectionUtils.isEmpty(pieces)) {
-      return Future.succeededFuture(pieces);
+      return Future.succeededFuture(Optional.ofNullable(pieces).orElse(List.of()));
     }
     var requestEntry = new RequestEntry(SEQUENCE_NUMBERS_ENDPOINT).withId(title.getId())
       .withQueryParameter(SEQUENCE_NUMBER_PARAM, String.valueOf(pieces.size()));

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -190,7 +190,7 @@ public class TitlesService {
     }
     var requestEntry = new RequestEntry(SEQUENCE_NUMBERS_ENDPOINT).withId(title.getId())
       .withQueryParameter(SEQUENCE_NUMBER_PARAM, String.valueOf(pieces.size()));
-    return restClient.get(requestEntry, SequenceNumbers.class, requestContext)
+    return restClient.post(requestEntry, null, SequenceNumbers.class, requestContext)
       .compose(titleSequenceNumbers -> {
         Set<Integer> assignedNumbers = StreamEx.of(pieces)
           .map(Piece::getSequenceNumber)

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -190,7 +190,7 @@ public class TitlesService {
     }
     var requestEntry = new RequestEntry(SEQUENCE_NUMBERS_ENDPOINT).withId(title.getId())
       .withQueryParameter(SEQUENCE_NUMBER_PARAM, String.valueOf(pieces.size()));
-    return restClient.post(requestEntry, null, SequenceNumbers.class, requestContext)
+    return restClient.postBatch(requestEntry, null, SequenceNumbers.class, requestContext)
       .compose(titleSequenceNumbers -> {
         Set<Integer> assignedNumbers = StreamEx.of(pieces)
           .map(Piece::getSequenceNumber)

--- a/src/main/java/org/folio/service/titles/TitlesService.java
+++ b/src/main/java/org/folio/service/titles/TitlesService.java
@@ -188,6 +188,7 @@ public class TitlesService {
     if (CollectionUtils.isEmpty(pieces)) {
       return Future.succeededFuture(Optional.ofNullable(pieces).orElse(List.of()));
     }
+    log.info("generateNextSequenceNumbers:: Generating {} sequence numbers starting from {} for title: '{}'", pieces.size(), title.getNextSequenceNumber(), title.getId());
     var requestEntry = new RequestEntry(SEQUENCE_NUMBERS_ENDPOINT).withId(title.getId())
       .withQueryParameter(SEQUENCE_NUMBER_PARAM, String.valueOf(pieces.size()));
     return restClient.postBatch(requestEntry, null, SequenceNumbers.class, requestContext)
@@ -200,6 +201,7 @@ public class TitlesService {
           .map(Integer::valueOf)
           .filter(number -> !assignedNumbers.contains(number))
           .toCollection(LinkedList::new);
+        log.info("generateNextSequenceNumbers:: Already assigned numbers: {}, numbers to assign: {}", assignedNumbers, pendingNumbers);
         pieces.stream()
           .filter(piece -> piece.getSequenceNumber() == null)
           .forEach(piece -> piece.setSequenceNumber(pendingNumbers.poll()));

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -154,6 +154,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.ws.rs.core.Response;
 
@@ -611,6 +612,7 @@ public class MockServer {
     router.post(resourcesPath(ORDER_TEMPLATES)).handler(ctx -> handlePostGenericSubObj(ctx, ORDER_TEMPLATES));
     router.post(resourcesPath(FINANCE_BATCH_TRANSACTIONS)).handler(this::handleBatchTransactions);
     router.post(resourcesPath(TITLES)).handler(ctx -> handlePostGenericSubObj(ctx, TITLES));
+    router.post(resourcePath(TITLES) + "/sequence-numbers").handler(this::handleTitleSequenceNumbers);
     router.post(resourcesPath(ROUTING_LISTS)).handler(ctx -> handlePostGenericSubObj(ctx, ROUTING_LISTS));
     router.post(resourcesPath(ACQUISITIONS_UNITS)).handler(ctx -> handlePostGenericSubObj(ctx, ACQUISITIONS_UNITS));
     router.post(resourcesPath(ACQUISITION_METHODS)).handler(ctx -> handlePostGenericSubObj(ctx, ACQUISITION_METHODS));
@@ -2571,6 +2573,15 @@ public class MockServer {
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
         .end(JsonObject.mapFrom(seqNumber).encodePrettily());
     }
+  }
+
+  private void handleTitleSequenceNumbers(RoutingContext ctx) {
+    var sequence = IntStream.range(0, 10).mapToObj(String::valueOf).toList();
+    var seqNumbers = new SequenceNumbers().withSequenceNumbers(sequence);
+    ctx.response()
+      .setStatusCode(200)
+      .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+      .end(JsonObject.mapFrom(seqNumbers).encodePrettily());
   }
 
   private void handleGetContributorNameTypes(RoutingContext ctx) {

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -612,7 +612,6 @@ public class MockServer {
     router.post(resourcesPath(ORDER_TEMPLATES)).handler(ctx -> handlePostGenericSubObj(ctx, ORDER_TEMPLATES));
     router.post(resourcesPath(FINANCE_BATCH_TRANSACTIONS)).handler(this::handleBatchTransactions);
     router.post(resourcesPath(TITLES)).handler(ctx -> handlePostGenericSubObj(ctx, TITLES));
-    router.post(resourcePath(TITLES) + "/sequence-numbers").handler(this::handleTitleSequenceNumbers);
     router.post(resourcesPath(ROUTING_LISTS)).handler(ctx -> handlePostGenericSubObj(ctx, ROUTING_LISTS));
     router.post(resourcesPath(ACQUISITIONS_UNITS)).handler(ctx -> handlePostGenericSubObj(ctx, ACQUISITIONS_UNITS));
     router.post(resourcesPath(ACQUISITION_METHODS)).handler(ctx -> handlePostGenericSubObj(ctx, ACQUISITION_METHODS));
@@ -665,6 +664,7 @@ public class MockServer {
     router.get(resourcesPath(LEDGERS)).handler(this::handleGetLedgers);
     router.get(resourcesPath(TITLES)).handler(this::handleGetTitles);
     router.get(resourcePath(TITLES)).handler(this::handleGetOrderTitleById);
+    router.get(resourcePath(TITLES) + "/sequence-numbers").handler(this::handleTitleSequenceNumbers);
     router.get(resourcesPath(ROUTING_LISTS)).handler(this::handleGetRoutingLists);
     router.get(resourcePath(ROUTING_LISTS)).handler(this::handleGetRoutingListById);
     router.get(resourcesPath(REASONS_FOR_CLOSURE)).handler(ctx -> handleGetGenericSubObjs(ctx, REASONS_FOR_CLOSURE));

--- a/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
@@ -194,7 +194,7 @@ public class OpenCompositeOrderPieceServiceTest {
 
     doReturn(succeededFuture(null)).when(inventoryItemManager).updateItemWithPieceFields(null, piece, requestContext);
 
-    openCompositeOrderPieceService.openOrderUpdateInventory(order, line, piece, false, requestContext).result();
+    openCompositeOrderPieceService.openOrderUpdateInventory(order, line, piece, title, false, requestContext).result();
 
     assertEquals(title.getId(), piece.getTitleId());
   }
@@ -225,7 +225,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(itemId)).when(inventoryInstanceManager).createInstanceRecord(eq(title), anyBoolean(), eq(requestContext));
 
     //When
-    openCompositeOrderPieceService.openOrderUpdateInventory(order, line, piece, false, requestContext).result();
+    openCompositeOrderPieceService.openOrderUpdateInventory(order, line, piece, title, false, requestContext).result();
 
     //Then
     assertEquals(piece.getItemId(), itemId);
@@ -252,7 +252,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(instanceId)).when(titlesService).updateTitleWithInstance(eq(title), anyBoolean(), anyBoolean(), eq(requestContext), eq(requestContext));
 
     //When
-    openCompositeOrderPieceService.openOrderUpdateInventory(order, line, piece, false, requestContext).result();
+    openCompositeOrderPieceService.openOrderUpdateInventory(order, line, piece, title, false, requestContext).result();
 
     //Then
     assertEquals(holdingId, piece.getHoldingId());
@@ -285,7 +285,7 @@ public class OpenCompositeOrderPieceServiceTest {
     Title title = new Title().withId(titleId).withTitle("test title");
 
     doReturn(succeededFuture(null)).when(openCompositeOrderPieceService).openOrderUpdateInventory(any(CompositePurchaseOrder.class),
-      any(PoLine.class), any(Piece.class), any(Boolean.class), eq(requestContext));
+      any(PoLine.class), any(Piece.class), any(Title.class), any(Boolean.class), eq(requestContext));
     doReturn(succeededFuture(Collections.emptyList())).when(pieceStorageService).getPiecesByPoLineId(line, requestContext);
     doReturn(succeededFuture(new PieceCollection())).when(pieceStorageService).insertPiecesBatch(any(), eq(requestContext));
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
@@ -352,7 +352,7 @@ public class OpenCompositeOrderPieceServiceTest {
 
 
     doReturn(succeededFuture(null)).when(openCompositeOrderPieceService).openOrderUpdateInventory(any(CompositePurchaseOrder.class),
-      any(PoLine.class), any(Piece.class), any(Boolean.class), eq(requestContext));
+      any(PoLine.class), any(Piece.class), any(Title.class), any(Boolean.class), eq(requestContext));
     doReturn(succeededFuture(Collections.emptyList())).when(pieceStorageService).getPiecesByPoLineId(line, requestContext);
     doReturn(succeededFuture(new PieceCollection())).when(pieceStorageService).insertPiecesBatch(any(), eq(requestContext));
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
@@ -422,7 +422,7 @@ public class OpenCompositeOrderPieceServiceTest {
     Title title = new Title().withId(titleId).withTitle("test title");
 
     doReturn(succeededFuture(null)).when(openCompositeOrderPieceService).openOrderUpdateInventory(any(CompositePurchaseOrder.class),
-      any(PoLine.class), any(Piece.class), any(Boolean.class), eq(requestContext));
+      any(PoLine.class), any(Piece.class), any(Title.class), any(Boolean.class), eq(requestContext));
     doReturn(succeededFuture(Collections.emptyList())).when(pieceStorageService).getPiecesByPoLineId(line, requestContext);
     doReturn(succeededFuture(new PieceCollection())).when(pieceStorageService).insertPiecesBatch(any(), eq(requestContext));
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
@@ -491,7 +491,7 @@ public class OpenCompositeOrderPieceServiceTest {
     Title title = new Title().withId(titleId).withTitle("test title");
 
     doReturn(succeededFuture(null)).when(openCompositeOrderPieceService).openOrderUpdateInventory(any(CompositePurchaseOrder.class),
-      any(PoLine.class), any(Piece.class), any(Boolean.class), eq(requestContext));
+      any(PoLine.class), any(Piece.class), any(Title.class), any(Boolean.class), eq(requestContext));
     doReturn(succeededFuture(Collections.emptyList())).when(pieceStorageService).getPiecesByPoLineId(line, requestContext);
     doReturn(succeededFuture(new PieceCollection())).when(pieceStorageService).insertPiecesBatch(any(), eq(requestContext));
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
@@ -576,7 +576,7 @@ public class OpenCompositeOrderPieceServiceTest {
     Title title = new Title().withId(titleId).withTitle("test title");
 
     doReturn(succeededFuture(null)).when(openCompositeOrderPieceService).openOrderUpdateInventory(any(CompositePurchaseOrder.class),
-      any(PoLine.class), any(Piece.class), any(Boolean.class), eq(requestContext));
+      any(PoLine.class), any(Piece.class), any(Title.class), any(Boolean.class), eq(requestContext));
     doReturn(succeededFuture(Collections.emptyList())).when(pieceStorageService).getPiecesByPoLineId(line, requestContext);
     doReturn(succeededFuture(new PieceCollection())).when(pieceStorageService).insertPiecesBatch(any(), eq(requestContext));
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
@@ -648,7 +648,7 @@ public class OpenCompositeOrderPieceServiceTest {
       .withReceiptDate(expectedReceiptDate);
 
     doReturn(succeededFuture(null)).when(openCompositeOrderPieceService).openOrderUpdateInventory(any(CompositePurchaseOrder.class),
-      any(PoLine.class), any(Piece.class), any(Boolean.class), eq(requestContext));
+      any(PoLine.class), any(Piece.class), any(Title.class), any(Boolean.class), eq(requestContext));
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
     doReturn(succeededFuture(null)).when(inventoryItemManager).updateItemWithPieceFields(eq(pieceBefore), any(Piece.class), eq(requestContext));
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(titleId, requestContext);
@@ -759,8 +759,8 @@ public class OpenCompositeOrderPieceServiceTest {
       return mock(TitlesService.class);
     }
 
-    @Bean OpenCompositeOrderHolderBuilder openCompositeOrderHolderBuilder(PieceStorageService pieceStorageService) {
-      return spy(new OpenCompositeOrderHolderBuilder(pieceStorageService));
+    @Bean OpenCompositeOrderHolderBuilder openCompositeOrderHolderBuilder(PieceStorageService pieceStorageService, TitlesService titlesService) {
+      return spy(new OpenCompositeOrderHolderBuilder(pieceStorageService, titlesService));
     }
 
     @Bean

--- a/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
+++ b/src/test/java/org/folio/service/orders/flows/update/open/OpenCompositeOrderPieceServiceTest.java
@@ -291,6 +291,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
     doReturn(succeededFuture(compOrder)).when(purchaseOrderStorageService).getCompositeOrderById(eq(orderId), eq(requestContext));
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(titleId, requestContext);
+    doAnswer(invocation -> succeededFuture(invocation.getArgument(0))).when(titlesService).generateNextSequenceNumbers(any(), eq(title), eq(requestContext));
 
     final ArgumentCaptor<List<Piece>> pieceArgumentCaptor = ArgumentCaptor.forClass(List.class);
     doAnswer((Answer<Future<PieceCollection>>) invocation -> {
@@ -358,6 +359,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
     doReturn(succeededFuture(compOrder)).when(purchaseOrderStorageService).getCompositeOrderById(eq(orderId), eq(requestContext));
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(titleId, requestContext);
+    doAnswer(invocation -> succeededFuture(invocation.getArgument(0))).when(titlesService).generateNextSequenceNumbers(any(), eq(title), eq(requestContext));
 
     final ArgumentCaptor<List<Piece>> pieceArgumentCaptor = ArgumentCaptor.forClass(List.class);
     doAnswer((Answer<Future<PieceCollection>>) invocation -> {
@@ -428,6 +430,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
     doReturn(succeededFuture(compOrder)).when(purchaseOrderStorageService).getCompositeOrderById(eq(orderId), eq(requestContext));
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(titleId, requestContext);
+    doAnswer(invocation -> succeededFuture(invocation.getArgument(0))).when(titlesService).generateNextSequenceNumbers(any(), eq(title), eq(requestContext));
 
     final ArgumentCaptor<List<Piece>> pieceArgumentCaptor = ArgumentCaptor.forClass(List.class);
     doAnswer((Answer<Future<PieceCollection>>) invocation -> {
@@ -497,6 +500,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
     doReturn(succeededFuture(compOrder)).when(purchaseOrderStorageService).getCompositeOrderById(eq(orderId), eq(requestContext));
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(titleId, requestContext);
+    doAnswer(invocation -> succeededFuture(invocation.getArgument(0))).when(titlesService).generateNextSequenceNumbers(any(), eq(title), eq(requestContext));
 
     final ArgumentCaptor<List<Piece>> pieceArgumentCaptor = ArgumentCaptor.forClass(List.class);
     doAnswer((Answer<Future<PieceCollection>>) invocation -> {
@@ -582,6 +586,7 @@ public class OpenCompositeOrderPieceServiceTest {
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
     doReturn(succeededFuture(compOrder)).when(purchaseOrderStorageService).getCompositeOrderById(eq(orderId), eq(requestContext));
     doReturn(succeededFuture(title)).when(titlesService).getTitleById(titleId, requestContext);
+    doAnswer(invocation -> succeededFuture(invocation.getArgument(0))).when(titlesService).generateNextSequenceNumbers(any(), eq(title), eq(requestContext));
 
     final ArgumentCaptor<List<Piece>> pieceArgumentCaptor = ArgumentCaptor.forClass(List.class);
     doAnswer((Answer<Future<PieceCollection>>) invocation -> {

--- a/src/test/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidatorTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/DefaultPieceFlowsValidatorTest.java
@@ -1,5 +1,6 @@
 package org.folio.service.pieces.flows;
 
+import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_SEQUENCE_NUMBER_IS_INVALID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,6 +17,7 @@ import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.Eresource;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.Title;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,11 +29,12 @@ public class DefaultPieceFlowsValidatorTest {
   private static final String LOCATION_ID = UUID.randomUUID().toString();
   private static final String PO_LINE_ID = UUID.randomUUID().toString();
 
-  private DefaultPieceFlowsValidator defaultPieceFlowsValidator = new DefaultPieceFlowsValidator();
+  private final DefaultPieceFlowsValidator defaultPieceFlowsValidator = new DefaultPieceFlowsValidator();
 
   @Test
-  void createPieceIsForbiddenIfPieceAndLIneFormatIsNotCompatible() {
+  void createPieceIsForbiddenIfPieceAndLineFormatIsNotCompatible() {
     Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
+    Title title = new Title();
     Location loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1);
     CompositePurchaseOrder originOrder = new CompositePurchaseOrder().withId(ORDER_IRD).withWorkflowStatus(WorkflowStatus.OPEN);
@@ -40,7 +43,7 @@ public class DefaultPieceFlowsValidatorTest {
                                     .withLocations(List.of(loc)).withCost(cost);
 
     HttpException exception = Assertions.assertThrows(HttpException.class, () -> {
-      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, true);
+      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, title, true);
     });
 
     boolean isErrorPresent = exception.getErrors().getErrors().stream()
@@ -51,6 +54,7 @@ public class DefaultPieceFlowsValidatorTest {
   @Test
   void createPieceIsForbiddenIfCreateInventoryInTheLineDonNotAllowThat() {
     Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
+    Title title = new Title();
     Location loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1);
     Eresource eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING);
@@ -61,7 +65,7 @@ public class DefaultPieceFlowsValidatorTest {
       .withLocations(List.of(loc)).withCost(cost);
 
     HttpException exception = Assertions.assertThrows(HttpException.class, () -> {
-      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, true);
+      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, title, true);
     });
 
     boolean isErrorPresent = exception.getErrors().getErrors().stream()
@@ -72,6 +76,7 @@ public class DefaultPieceFlowsValidatorTest {
   @Test
   void createPieceAllowableIfCreateInventoryInTheLineAllowThatButCreateItemFlagIsFalse() {
     Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
+    Title title = new Title();
     Location loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1);
     Eresource eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
@@ -81,12 +86,13 @@ public class DefaultPieceFlowsValidatorTest {
       .withEresource(eresource)
       .withLocations(List.of(loc)).withCost(cost);
 
-    defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, true);
+    defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, title, true);
   }
 
   @Test
   void createPieceIsValid() {
-    Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
+    Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC).withSequenceNumber(1);
+    Title title = new Title();
     Location loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1);
     Eresource eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
@@ -96,7 +102,7 @@ public class DefaultPieceFlowsValidatorTest {
                 .withEresource(eresource)
                 .withLocations(List.of(loc)).withCost(cost);
 
-    defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, true);
+    defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, title, true);
   }
 
   @ParameterizedTest
@@ -107,6 +113,7 @@ public class DefaultPieceFlowsValidatorTest {
     Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC)
       .withDisplayOnHolding(displayOnHoldings)
       .withDisplayToPublic(displayToPublic);
+    Title title = new Title();
     Location loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1);
     Eresource eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
@@ -116,7 +123,7 @@ public class DefaultPieceFlowsValidatorTest {
       .withEresource(eresource)
       .withLocations(List.of(loc)).withCost(cost);
 
-    defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, true);
+    defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, title, true);
   }
 
   @Test
@@ -124,6 +131,7 @@ public class DefaultPieceFlowsValidatorTest {
     Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC)
       .withDisplayOnHolding(false)
       .withDisplayToPublic(true);
+    Title title = new Title();
     Location loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1);
     Eresource eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
@@ -134,7 +142,7 @@ public class DefaultPieceFlowsValidatorTest {
       .withLocations(List.of(loc)).withCost(cost);
 
     HttpException exception = Assertions.assertThrows(HttpException.class, () -> {
-      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, true);
+      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, title, true);
     });
     boolean isErrorPresent = exception.getErrors().getErrors().stream()
       .anyMatch(error -> error.getCode().equals(ErrorCodes.PIECE_DISPLAY_ON_HOLDINGS_IS_NOT_CONSISTENT.getCode()));
@@ -144,6 +152,7 @@ public class DefaultPieceFlowsValidatorTest {
   @Test
   void createPieceWithPendingOrderThatHasSynchronizedStatus() {
     Piece piece = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
+    Title title = new Title();
     Location loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     Cost cost = new Cost().withQuantityElectronic(1);
     Eresource eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
@@ -156,7 +165,7 @@ public class DefaultPieceFlowsValidatorTest {
       .withLocations(List.of(loc)).withCost(cost);
 
     HttpException exception = Assertions.assertThrows(HttpException.class, () -> {
-      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, true);
+      defaultPieceFlowsValidator.isPieceRequestValid(piece, originOrder, originPoLine, title, true);
     });
     boolean isErrorPresent = exception.getErrors().getErrors().stream()
       .anyMatch(error -> error.getCode().equals(ErrorCodes.PIECE_RELATED_ORDER_DATA_IS_NOT_VALID.getCode()));
@@ -167,6 +176,7 @@ public class DefaultPieceFlowsValidatorTest {
   void testIsPieceBatchRequestValidWithSameTitleIdAndPoLineId() {
     var piece1 = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
     var piece2 = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
+    var title = new Title();
     var loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
     var cost = new Cost().withQuantityElectronic(1);
     var eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
@@ -176,19 +186,20 @@ public class DefaultPieceFlowsValidatorTest {
       .withEresource(eresource)
       .withLocations(List.of(loc)).withCost(cost);
 
-    defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, true);
+    defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, title, true);
   }
 
   @Test
   void testIsPieceBatchRequestCheckEachPieceValidation() {
     var piece1 = new Piece().withPoLineId(PO_LINE_ID).withTitleId(ORDER_IRD).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
     var piece2 = new Piece().withPoLineId(PO_LINE_ID).withTitleId(ORDER_IRD).withLocationId(LOCATION_ID).withFormat(Piece.Format.PHYSICAL);
+    var title = new Title();
     var originOrder = new CompositePurchaseOrder().withId(ORDER_IRD).withWorkflowStatus(WorkflowStatus.OPEN);
     var originPoLine = new PoLine().withIsPackage(true).withPurchaseOrderId(ORDER_IRD)
       .withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE).withId(PO_LINE_ID);
 
     var exception = Assertions.assertThrows(HttpException.class, () ->
-      defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, true));
+      defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, title, true));
     boolean isErrorPresent = exception.getErrors().getErrors().stream()
       .anyMatch(error -> error.getCode().equals(ErrorCodes.CREATE_ITEM_FOR_PIECE_IS_NOT_ALLOWED_ERROR.getCode()));
     assertTrue(isErrorPresent);
@@ -198,12 +209,13 @@ public class DefaultPieceFlowsValidatorTest {
   void testIsPieceBatchRequestValidWithDifferentTitleIds() {
     var piece1 = new Piece().withPoLineId(PO_LINE_ID).withTitleId(UUID.randomUUID().toString()).withLocationId(LOCATION_ID).withFormat(Piece.Format.PHYSICAL);
     var piece2 = new Piece().withPoLineId(PO_LINE_ID).withTitleId(UUID.randomUUID().toString()).withLocationId(LOCATION_ID).withFormat(Piece.Format.PHYSICAL);
+    var title = new Title();
     var originOrder = new CompositePurchaseOrder().withId(ORDER_IRD).withWorkflowStatus(WorkflowStatus.OPEN);
     var originPoLine = new PoLine().withIsPackage(true).withPurchaseOrderId(ORDER_IRD)
       .withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE).withId(PO_LINE_ID);
 
     var exception = Assertions.assertThrows(HttpException.class, () ->
-      defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, true));
+      defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, title, true));
 
     boolean isErrorPresent = exception.getErrors().getErrors().stream()
       .anyMatch(error -> error.getMessage().equals("All pieces in the batch should have the same titleId and poLineId"));
@@ -216,16 +228,39 @@ public class DefaultPieceFlowsValidatorTest {
       .withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
     var piece2 = new Piece().withPoLineId(UUID.randomUUID().toString()).withTitleId(ORDER_IRD)
       .withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC);
+    var title = new Title();
     var originOrder = new CompositePurchaseOrder().withId(ORDER_IRD).withWorkflowStatus(WorkflowStatus.OPEN);
     var originPoLine = new PoLine().withIsPackage(true).withPurchaseOrderId(ORDER_IRD)
       .withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE).withId(PO_LINE_ID);
 
     var exception = Assertions.assertThrows(HttpException.class, () ->
-      defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, true));
+      defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, title, true));
 
     boolean isErrorPresent = exception.getErrors().getErrors().stream()
       .anyMatch(error -> error.getMessage().equals("All pieces in the batch should have the same titleId and poLineId"));
     assertTrue(isErrorPresent);
+  }
+
+  @Test
+  void testIsPieceBatchRequestValidWithIncorrectSequenceNumbers() {
+    var piece1 = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC).withSequenceNumber(0);
+    var piece2 = new Piece().withPoLineId(PO_LINE_ID).withLocationId(LOCATION_ID).withFormat(Piece.Format.ELECTRONIC).withSequenceNumber(10);
+    var title = new Title();
+    var loc = new Location().withLocationId(LOCATION_ID).withQuantityElectronic(1).withQuantity(1);
+    var cost = new Cost().withQuantityElectronic(1);
+    var eresource = new Eresource().withCreateInventory(Eresource.CreateInventory.INSTANCE_HOLDING_ITEM);
+    var originOrder = new CompositePurchaseOrder().withId(ORDER_IRD).withWorkflowStatus(WorkflowStatus.OPEN);
+    var originPoLine = new PoLine().withIsPackage(true).withPurchaseOrderId(ORDER_IRD)
+      .withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE).withId(PO_LINE_ID)
+      .withEresource(eresource)
+      .withLocations(List.of(loc)).withCost(cost);
+
+    var exception = Assertions.assertThrows(HttpException.class, () ->
+      defaultPieceFlowsValidator.isPieceBatchRequestValid(List.of(piece1, piece2), originOrder, originPoLine, title, true));
+
+    boolean areErrorsPresent = exception.getErrors().getErrors().stream()
+      .allMatch(error -> error.getCode().equals(PIECE_SEQUENCE_NUMBER_IS_INVALID.getCode()));
+    assertTrue(areErrorsPresent);
   }
 
 }

--- a/src/test/java/org/folio/service/titles/TitlesServiceTest.java
+++ b/src/test/java/org/folio/service/titles/TitlesServiceTest.java
@@ -437,8 +437,6 @@ public class TitlesServiceTest {
     });
   }
 
-  // Tests for generateNextSequenceNumbers method
-
   @Test
   void testGenerateNextSequenceNumbers_emptyPiecesList() {
     List<Piece> pieces = Collections.emptyList();
@@ -449,7 +447,7 @@ public class TitlesServiceTest {
       assertTrue(ar.succeeded());
       assertNotNull(ar.result());
       assertTrue(ar.result().isEmpty());
-      verify(restClient, never()).postBatch(any(RequestEntry.class), any(), eq(SequenceNumbers.class), any(RequestContext.class));
+      verify(restClient, never()).get(any(RequestEntry.class), eq(SequenceNumbers.class), any(RequestContext.class));
     });
   }
 
@@ -463,7 +461,7 @@ public class TitlesServiceTest {
       assertTrue(ar.succeeded());
       assertNotNull(ar.result());
       assertTrue(ar.result().isEmpty());
-      verify(restClient, never()).postBatch(any(RequestEntry.class), any(), eq(SequenceNumbers.class), any(RequestContext.class));
+      verify(restClient, never()).get(any(RequestEntry.class), eq(SequenceNumbers.class), any(RequestContext.class));
     });
   }
 
@@ -477,7 +475,7 @@ public class TitlesServiceTest {
 
     var sequenceNumbers = new SequenceNumbers().withSequenceNumbers(List.of("1", "2", "3"));
 
-    when(restClient.postBatch(any(RequestEntry.class), any(), eq(SequenceNumbers.class), eq(requestContext)))
+    when(restClient.get(any(RequestEntry.class), eq(SequenceNumbers.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(sequenceNumbers));
 
     var result = titlesService.generateNextSequenceNumbers(pieces, title, requestContext);
@@ -491,7 +489,7 @@ public class TitlesServiceTest {
       assertEquals(Integer.valueOf(3), resultPieces.get(2).getSequenceNumber());
 
       ArgumentCaptor<RequestEntry> requestCaptor = ArgumentCaptor.forClass(RequestEntry.class);
-      verify(restClient).postBatch(requestCaptor.capture(), any(), eq(SequenceNumbers.class), eq(requestContext));
+      verify(restClient).get(requestCaptor.capture(), eq(SequenceNumbers.class), eq(requestContext));
 
       var capturedRequest = requestCaptor.getValue();
       assertTrue(capturedRequest.buildEndpoint().contains(title.getId()));
@@ -509,7 +507,7 @@ public class TitlesServiceTest {
 
     var sequenceNumbers = new SequenceNumbers().withSequenceNumbers(List.of("1", "2", "3"));
 
-    when(restClient.postBatch(any(RequestEntry.class), any(), eq(SequenceNumbers.class), eq(requestContext)))
+    when(restClient.get(any(RequestEntry.class), eq(SequenceNumbers.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(sequenceNumbers));
 
     var result = titlesService.generateNextSequenceNumbers(pieces, title, requestContext);
@@ -536,7 +534,7 @@ public class TitlesServiceTest {
 
     var sequenceNumbers = new SequenceNumbers().withSequenceNumbers(List.of("1", "2", "3", "4"));
 
-    when(restClient.postBatch(any(RequestEntry.class), any(), eq(SequenceNumbers.class), eq(requestContext)))
+    when(restClient.get(any(RequestEntry.class), eq(SequenceNumbers.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(sequenceNumbers));
 
     var result = titlesService.generateNextSequenceNumbers(pieces, title, requestContext);
@@ -563,7 +561,7 @@ public class TitlesServiceTest {
       new Piece().withId(PIECE_ID_1).withSequenceNumber(null)
     );
 
-    when(restClient.postBatch(any(RequestEntry.class), any(), eq(SequenceNumbers.class), eq(requestContext)))
+    when(restClient.get(any(RequestEntry.class), eq(SequenceNumbers.class), eq(requestContext)))
       .thenReturn(Future.failedFuture(new RuntimeException("REST call failed")));
 
     var result = titlesService.generateNextSequenceNumbers(pieces, title, requestContext);

--- a/src/test/java/org/folio/service/titles/TitlesServiceTest.java
+++ b/src/test/java/org/folio/service/titles/TitlesServiceTest.java
@@ -52,7 +52,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@CopilotGenerated(model = "Claude Sonnet 4")
+@CopilotGenerated(partiallyGenerated = true, model = "Claude Sonnet 4")
 @ExtendWith(MockitoExtension.class)
 public class TitlesServiceTest {
   private static final String TITLE_ID = "test-title-id";


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1356] BE - Create Sequence field in receiving](https://folio-org.atlassian.net/browse/MODORDERS-1356)

### **Approach**
- Add method for populating sequence number for pieces
- Add validation for piece sequence numbers
- Integrate sequence number population in all places where pieces are created
- Update tests

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
