### PR TITLE
MODORDERS-1432 - The open order is not created after import .mrc file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODORDERS-1040](https://folio-org.atlassian.net/browse/MODORDERS-1040) - Subscribe to JobExecution status change and add cache
 * [MODORDERS-1042](https://folio-org.atlassian.net/browse/MODORDERS-1042) - Do not process event if JobExecution status is Cancelled
 * [MODORDERS-1400](https://folio-org.atlassian.net/browse/MODORDERS-1400) - assertj: Fix scope to test, bump version to 3.27.7
+* [MODORDERS-1432](https://folio-org.atlassian.net/browse/MODORDERS-1432) - The open order is not created after import .mrc file
 
 ## 13.0.0 - Released (Sunflower R1 2025)
 The primary focus of this release was to enhance multi-tenant functionality, improve piece management, and implement various inventory and order processing features.

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <!--Folio dependencies properties-->
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <mod-configuration-client.version>5.12.1</mod-configuration-client.version>
-    <folio-di-support.version>4.0.0-SNAPSHOT</folio-di-support.version>
+    <folio-di-support.version>4.0.0</folio-di-support.version>
     <mod-di-converter-storage-client.version>2.4.3</mod-di-converter-storage-client.version>
     <data-import-processing-core.version>5.0.0-SNAPSHOT</data-import-processing-core.version>
     <folio-kafka-wrapper.version>4.0.0-SNAPSHOT</folio-kafka-wrapper.version>

--- a/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
@@ -44,6 +44,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String JOB_PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
+  private static final String USER_ID_KEY = "userId";
 
   private final Vertx vertx;
   private final JobProfileSnapshotCache profileSnapshotCache;
@@ -113,6 +114,8 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
       } else if (RestVerticle.OKAPI_USERID_HEADER.equalsIgnoreCase(header.key())) {
         String userId = header.value().toString();
         eventPayload.getContext().put(RestVerticle.OKAPI_USERID_HEADER, userId);
+        // put userId into the context to ensure that it is populated in the result event headers by di-core-library
+        eventPayload.getContext().put(USER_ID_KEY, userId);
       } else if (RestVerticle.OKAPI_REQUESTID_HEADER.equalsIgnoreCase(header.key())) {
         String requestId = header.value().toString();
         eventPayload.getContext().put(RestVerticle.OKAPI_REQUESTID_HEADER, requestId);

--- a/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
@@ -40,11 +40,11 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
 
   private static final Logger LOGGER = LogManager.getLogger();
 
+  static final String USER_ID_KEY = "userId";
   private static final String PROFILE_SNAPSHOT_NOT_FOUND_MSG = "JobProfileSnapshot was not found by id '%s'";
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String JOB_PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
-  private static final String USER_ID_KEY = "userId";
 
   private final Vertx vertx;
   private final JobProfileSnapshotCache profileSnapshotCache;

--- a/src/test/java/org/folio/verticle/consumers/DataImportKafkaHandlerTest.java
+++ b/src/test/java/org/folio/verticle/consumers/DataImportKafkaHandlerTest.java
@@ -159,6 +159,7 @@ public class DataImportKafkaHandlerTest {
           DataImportEventPayload payload = invocation.getArgument(0);
           // Verify headers were populated into context
           assertEquals(userId, payload.getContext().get(RestVerticle.OKAPI_USERID_HEADER));
+          assertEquals(userId, payload.getContext().get(DataImportKafkaHandler.USER_ID_KEY));
           assertEquals(requestId, payload.getContext().get(RestVerticle.OKAPI_REQUESTID_HEADER));
           assertEquals(permissions, payload.getContext().get(CreateOrderEventHandler.OKAPI_PERMISSIONS_HEADER));
           return CompletableFuture.completedFuture(payload);


### PR DESCRIPTION
## Purpose
to fix open order import with actions for inventory entities

## Approach
* put userId to the event payload context so that it can be populated into the result event headers by di-processing-core library and received by the mod-inventory module


## Learning
[MODORDERS-1432](https://issues.folio.org/browse/MODORDERS-1432)