### PR TITLE
Release Trillium Bugfix v13.1.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## 13.1.1 - Released (Trillium R2 2025)
+This release focused on fixing holdings and items creation/deletion logic when budget or ledger restrictions prevent operation
+
+[Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.0.0...v13.1.1)
+
+### Bug Fixes
+* [MODORDERS-1435](https://folio-org.atlassian.net/browse/MODORDERS-1435) - Changing a piece format: encumbrance not updated
+* [MODORDERS-1434](https://folio-org.atlassian.net/browse/MODORDERS-1434) - Batch create pieces: encumbrance is not updated
+* [MODORDERS-1415](https://folio-org.atlassian.net/browse/MODORDERS-1415) - Fix holdings and items creation/deletion logic when budget or ledger restrictions prevent operation
+
 ## 13.1.0 - Released (Trillium R2 2025)
 This release focused on upgrading to Vert.x 5.0, improving holdings/instance connection handling, enhancing fiscal year and encumbrance logic, piece/receiving improvements, and a large round of bug fixes across the acquisitions flow.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -581,6 +581,8 @@
             "inventory-storage.instance-types.collection.get",
             "inventory-storage.instance-statuses.collection.get",
             "inventory-storage.contributor-name-types.collection.get",
+            "finance.funds.budget.item.get",
+            "finance.fiscal-years.item.get",
             "finance.transactions.batch.execute",
             "finance-storage.ledgers.collection.get",
             "orders-storage.pieces.item.get",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>13.1.1</version>
+  <version>13.1.2-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v13.1.1</tag>
+    <tag>v13.1.0</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>13.1.1-SNAPSHOT</version>
+  <version>13.1.1</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v13.1.0</tag>
+    <tag>v13.1.1</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/org/folio/models/pieces/BasePieceFlowHolder.java
+++ b/src/main/java/org/folio/models/pieces/BasePieceFlowHolder.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
-import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.Title;
 
@@ -15,6 +14,7 @@ public abstract class BasePieceFlowHolder {
 
   private PoLine compositePoLineToSave;
   private Title title;
+  private boolean lineUpdated = false;
 
   public BasePieceFlowHolder() {
 
@@ -32,6 +32,12 @@ public abstract class BasePieceFlowHolder {
     return this;
   }
 
+  public BasePieceFlowHolder withOrderInformation(CompositePurchaseOrder originPurchaseOrder, CompositePurchaseOrder purchaseOrderToSave) {
+    this.originPurchaseOrder = originPurchaseOrder;
+    this.purchaseOrderToSave =  purchaseOrderToSave;
+    return this;
+  }
+
   public BasePieceFlowHolder withPoLineOnly(PoLine compositePoLineToSave) {
     this.compositePoLineToSave = compositePoLineToSave;
     return this;
@@ -40,6 +46,10 @@ public abstract class BasePieceFlowHolder {
   public BasePieceFlowHolder withTitleInformation(Title title) {
     this.title = title;
     return this;
+  }
+
+  public void setLineUpdated(boolean lineUpdated) {
+    this.lineUpdated = lineUpdated;
   }
 
   public CompositePurchaseOrder getOriginPurchaseOrder() {
@@ -69,4 +79,7 @@ public abstract class BasePieceFlowHolder {
     return title;
   }
 
+  public boolean getLineUpdated() {
+    return lineUpdated;
+  }
 }

--- a/src/main/java/org/folio/models/pieces/PieceBatchCreationHolder.java
+++ b/src/main/java/org/folio/models/pieces/PieceBatchCreationHolder.java
@@ -18,11 +18,6 @@ public class PieceBatchCreationHolder extends BasePieceFlowHolder {
     return createItem;
   }
 
-  public PieceBatchCreationHolder withPieceToCreate(List<Piece> piecesToCreate) {
-    this.piecesToCreate = piecesToCreate;
-    return this;
-  }
-
   public PieceBatchCreationHolder withPieceToCreate(PieceCollection pieceCollection) {
     this.piecesToCreate = pieceCollection.getPieces();
     return this;

--- a/src/main/java/org/folio/service/pieces/PieceUtil.java
+++ b/src/main/java/org/folio/service/pieces/PieceUtil.java
@@ -2,6 +2,7 @@ package org.folio.service.pieces;
 
 import static org.folio.rest.jaxrs.model.PoLine.OrderFormat.OTHER;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
@@ -41,6 +42,14 @@ public class PieceUtil {
       .filter(loc -> Objects.nonNull(loc.getQuantityPhysical()))
       .filter(loc -> isLocationMatch(piece, loc))
       .collect(Collectors.toList());
+  }
+
+  public static List<Location> findLocationsUsingPieceList(List<Piece> pieces, PoLine poLine) {
+    return pieces.stream()
+      .map(piece -> findOrderPieceLineLocation(piece, poLine))
+      .flatMap(Collection::stream)
+      .distinct()
+      .toList();
   }
 
   public static Map<Piece.Format, Integer> calculatePiecesQuantityWithoutLocation(PoLine poLine) {

--- a/src/main/java/org/folio/service/pieces/flows/BasePieceFlowUpdatePoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/BasePieceFlowUpdatePoLineService.java
@@ -16,6 +16,7 @@ import org.folio.service.pieces.validators.PieceValidatorUtil;
 import io.vertx.core.Future;
 
 import java.util.List;
+import java.util.Objects;
 
 public abstract class BasePieceFlowUpdatePoLineService<T extends BasePieceFlowHolder> implements PoLineUpdateQuantityService<T> {
   protected final PurchaseOrderStorageService purchaseOrderStorageService;
@@ -29,16 +30,26 @@ public abstract class BasePieceFlowUpdatePoLineService<T extends BasePieceFlowHo
     this.receivingEncumbranceStrategy = receivingEncumbranceStrategy;
   }
 
-  public Future<Void> updatePoLine(T holder, RequestContext requestContext) {
-    boolean isLineUpdated = poLineUpdateQuantity(holder);
-    if (isLineUpdated) {
-      return receivingEncumbranceStrategy
-        .processEncumbrances(holder.getPurchaseOrderToSave(), holder.getPurchaseOrderToSave(), requestContext)
-        .map(aVoid -> {
-          updateEstimatedPrice(holder.getPoLineToSave());
-          return null;
-        })
-        .compose(v -> purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), getPieceLocations(holder), requestContext));
+  public Future<Void> updatePoLineCostAndProcessEncumbrances(T holder, RequestContext requestContext) {
+    if (skipUpdatingPoLine(holder.getOriginPoLine())) {
+      return Future.succeededFuture();
+    }
+    boolean costUpdated = poLineUpdateCost(holder);
+    holder.setLineUpdated(holder.getLineUpdated() || costUpdated);
+    if (costUpdated) {
+      return receivingEncumbranceStrategy.processEncumbrances(holder.getPurchaseOrderToSave(), holder.getPurchaseOrderToSave(), requestContext);
+    }
+    return Future.succeededFuture();
+  }
+
+  public Future<Void> updateLocationsAndSavePoLine(T holder, RequestContext requestContext) {
+    if (!skipUpdatingPoLine(holder.getOriginPoLine())) {
+      boolean lineUpdated2 = poLineUpdateLocations(holder);
+      holder.setLineUpdated(holder.getLineUpdated() || lineUpdated2 ||
+        !Objects.equals(holder.getOriginPoLine().getInstanceId(), holder.getPoLineToSave().getInstanceId()));
+    }
+    if (holder.getLineUpdated()) {
+      return purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), getPieceLocations(holder), requestContext);
     }
     return Future.succeededFuture();
   }
@@ -54,5 +65,9 @@ public abstract class BasePieceFlowUpdatePoLineService<T extends BasePieceFlowHo
   protected boolean isLocationUpdateRequired(Piece piece, PoLine lineToSave) {
     return (piece.getHoldingId() != null || piece.getLocationId() != null) ||
                       PieceValidatorUtil.isLocationRequired(piece.getFormat(), lineToSave);
+  }
+
+  private boolean skipUpdatingPoLine(PoLine poLine) {
+    return Boolean.TRUE.equals(poLine.getIsPackage()) || Boolean.TRUE.equals(poLine.getCheckinItems());
   }
 }

--- a/src/main/java/org/folio/service/pieces/flows/PoLineUpdateQuantityService.java
+++ b/src/main/java/org/folio/service/pieces/flows/PoLineUpdateQuantityService.java
@@ -1,5 +1,6 @@
 package org.folio.service.pieces.flows;
 
 public interface PoLineUpdateQuantityService<T> {
-  boolean poLineUpdateQuantity(T holder);
+  boolean poLineUpdateCost(T holder);
+  boolean poLineUpdateLocations(T holder);
 }

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowManager.java
@@ -40,8 +40,9 @@ public class PieceCreateFlowManager {
       .compose(v -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceRequestValid(pieceToCreate, holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), holder.getTitle(), createItem)))
       .compose(v -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext))
+      .compose(v -> pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(holder, requestContext))
       .compose(v -> processInventory(holder, requestContext))
-      .compose(v -> updatePoLine(holder, requestContext))
+      .compose(v -> pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(holder, requestContext))
       .compose(v -> titlesService.generateNextSequenceNumbers(List.of(holder.getPieceToCreate()), holder.getTitle(), requestContext))
       .compose(pieces -> pieceStorageService.insertPiece(pieces.getFirst(), requestContext));
   }
@@ -57,8 +58,9 @@ public class PieceCreateFlowManager {
       .compose(v -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceBatchRequestValid(holder.getPiecesToCreate(), holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), holder.getTitle(), createItem)))
       .compose(v -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), ProtectedOperationType.CREATE, requestContext))
-      .compose(v -> processInventory(holder, requestContext))
-      .compose(v -> updatePoLine(holder, requestContext))
+      .compose(v -> pieceCreateFlowPoLineService.updatePoLineBatch(holder, requestContext))
+      .compose(v -> processInventoryBatch(holder, requestContext))
+      .compose(v -> pieceCreateFlowPoLineService.updateLocationsAndSavePoLineBatch(holder, requestContext))
       .compose(v -> titlesService.generateNextSequenceNumbers(holder.getPiecesToCreate(), holder.getTitle(), requestContext))
       .compose(pieces -> pieceStorageService.insertPiecesBatch(pieces, requestContext));
   }
@@ -68,44 +70,12 @@ public class PieceCreateFlowManager {
       holder.getPoLineToSave(), holder.getPieceToCreate(), holder.isCreateItem(), requestContext);
   }
 
-  private Future<Void> processInventory(PieceBatchCreationHolder holder, RequestContext requestContext) {
+  private Future<Void> processInventoryBatch(PieceBatchCreationHolder holder, RequestContext requestContext) {
     var futures = holder.getPiecesToCreate().stream()
       .map(piece -> pieceCreateFlowInventoryManager.processInventory(holder.getPurchaseOrderToSave(),
         holder.getPoLineToSave(), piece, holder.isCreateItem(), requestContext))
       .toList();
     return collectResultsOnSuccess(futures).mapEmpty();
-  }
-
-  protected Future<Void> updatePoLine(PieceBatchCreationHolder holder, RequestContext requestContext) {
-    var pieceCreationHolderList = createPieceCreationHolderList(holder);
-    var futures = pieceCreationHolderList.stream()
-      .map(pieceCreationHolder -> updatePoLine(pieceCreationHolder, requestContext))
-      .toList();
-    return collectResultsOnSuccess(futures).mapEmpty();
-  }
-
-  private List<PieceCreationHolder> createPieceCreationHolderList(PieceBatchCreationHolder holder) {
-    return holder.getPiecesToCreate().stream()
-      .map(piece -> createPieceCreationHolder(piece, holder))
-      .toList();
-  }
-
-  private PieceCreationHolder createPieceCreationHolder(Piece piece, PieceBatchCreationHolder holder) {
-    var pieceCreationHolder = new PieceCreationHolder()
-      .withPieceToCreate(piece)
-      .withCreateItem(holder.isCreateItem());
-    pieceCreationHolder
-      .withTitleInformation(holder.getTitle())
-      .withPoLineOnly(holder.getPoLineToSave())
-      .withOrderInformation(holder.getPurchaseOrderToSave());
-    return pieceCreationHolder;
-  }
-
-  protected Future<Void> updatePoLine(PieceCreationHolder holder, RequestContext requestContext) {
-    if (!Boolean.TRUE.equals(holder.getOriginPoLine().getIsPackage()) && !Boolean.TRUE.equals(holder.getOriginPoLine().getCheckinItems())) {
-      return pieceCreateFlowPoLineService.updatePoLine(holder, requestContext);
-    }
-    return Future.succeededFuture();
   }
 
 }

--- a/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineService.java
@@ -4,8 +4,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.vertx.core.Future;
 import org.apache.commons.collections4.CollectionUtils;
+import org.folio.models.pieces.PieceBatchCreationHolder;
 import org.folio.models.pieces.PieceCreationHolder;
+import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.Piece;
@@ -15,6 +18,8 @@ import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 import org.folio.service.pieces.PieceUtil;
 import org.folio.service.pieces.flows.BasePieceFlowUpdatePoLineService;
+
+import static org.folio.orders.utils.HelperUtils.chainCall;
 
 public class PieceCreateFlowPoLineService extends BasePieceFlowUpdatePoLineService<PieceCreationHolder> {
 
@@ -29,14 +34,28 @@ public class PieceCreateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
   }
 
   @Override
-  public boolean poLineUpdateQuantity(PieceCreationHolder holder) {
+  public boolean poLineUpdateCost(PieceCreationHolder holder) {
+    PoLine lineToSave = holder.getPoLineToSave();
+    Piece piece = holder.getPieceToCreate();
+    Cost cost = lineToSave.getCost();
+    if (piece.getFormat() == Piece.Format.ELECTRONIC) {
+      Integer prevQty = Optional.ofNullable(cost.getQuantityElectronic()).orElse(0);
+      cost.setQuantityElectronic(prevQty + 1);
+    } else {
+      Integer prevQty = Optional.ofNullable(cost.getQuantityPhysical()).orElse(0);
+      cost.setQuantityPhysical(prevQty + 1);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean poLineUpdateLocations(PieceCreationHolder holder) {
     PoLine lineToSave = holder.getPoLineToSave();
     Piece piece = holder.getPieceToCreate();
     final int qty = 1;
     List<Location> locationsToUpdate = PieceUtil.findOrderPieceLineLocation(piece, lineToSave);
     if (CollectionUtils.isNotEmpty(locationsToUpdate)) {
       Location loc = locationsToUpdate.get(0);
-      Cost cost = lineToSave.getCost();
       if (Objects.nonNull(piece.getReceivingTenantId())) {
         loc.setTenantId(piece.getReceivingTenantId());
       }
@@ -44,14 +63,10 @@ public class PieceCreateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
         Integer prevLocQty = Optional.ofNullable(loc.getQuantityElectronic()).orElse(0);
         loc.setQuantityElectronic(prevLocQty + qty);
         loc.setQuantity(loc.getQuantity() + qty);
-        Integer prevCostQty = Optional.ofNullable(cost.getQuantityElectronic()).orElse(0);
-        cost.setQuantityElectronic(prevCostQty + qty);
       } else {
         Integer prevLocQty = Optional.ofNullable(loc.getQuantityPhysical()).orElse(0);
         loc.setQuantityPhysical(prevLocQty + qty);
         loc.setQuantity(loc.getQuantity() + qty);
-        Integer prevCostQty = Optional.ofNullable(cost.getQuantityPhysical()).orElse(0);
-        cost.setQuantityPhysical(prevCostQty + qty);
       }
     } else if (isLocationUpdateRequired(piece, lineToSave)) {
       Location locationToAdd = new Location().withQuantity(qty);
@@ -60,31 +75,51 @@ public class PieceCreateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
       } else {
         locationToAdd = locationToAdd.withLocationId(piece.getLocationId());
       }
-      Cost cost = lineToSave.getCost();
       if (Objects.nonNull(piece.getReceivingTenantId())) {
         locationToAdd.setTenantId(piece.getReceivingTenantId());
       }
       if (piece.getFormat() == Piece.Format.ELECTRONIC) {
         locationToAdd.withQuantityElectronic(qty);
-        Integer prevQty = Optional.ofNullable(cost.getQuantityElectronic()).orElse(0);
-        cost.setQuantityElectronic(prevQty + qty);
       } else {
         locationToAdd.withQuantityPhysical(qty);
-        Integer prevQty = Optional.ofNullable(cost.getQuantityPhysical()).orElse(0);
-        cost.setQuantityPhysical(prevQty + qty);
       }
       List<Location> locations = lineToSave.getLocations();
       locations.add(locationToAdd);
-    } else {
-      Cost cost = lineToSave.getCost();
-      if (piece.getFormat() == Piece.Format.ELECTRONIC) {
-        Integer prevQty = Optional.ofNullable(cost.getQuantityElectronic()).orElse(0);
-        cost.setQuantityElectronic(prevQty + qty);
-      } else {
-        Integer prevQty = Optional.ofNullable(cost.getQuantityPhysical()).orElse(0);
-        cost.setQuantityPhysical(prevQty + qty);
-      }
     }
     return true;
   }
+
+  public Future<Void> updatePoLineBatch(PieceBatchCreationHolder holder, RequestContext requestContext) {
+    return chainCall(holder.getPiecesToCreate(), piece ->
+      updatePoLineCostAndProcessEncumbrances(createPieceCreationHolder(piece, holder), requestContext));
+  }
+
+  public Future<Void> updateLocationsAndSavePoLineBatch(PieceBatchCreationHolder holder, RequestContext requestContext) {
+    var pieceCreationHolderList = createPieceCreationHolderList(holder);
+    for (var pieceCreationHolder : pieceCreationHolderList) {
+      poLineUpdateLocations(pieceCreationHolder);
+    }
+    return purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), getPieceLocations(holder), requestContext);
+  }
+
+  private PieceCreationHolder createPieceCreationHolder(Piece piece, PieceBatchCreationHolder holder) {
+    var pieceCreationHolder = new PieceCreationHolder()
+      .withPieceToCreate(piece)
+      .withCreateItem(holder.isCreateItem());
+    pieceCreationHolder
+      .withTitleInformation(holder.getTitle())
+      .withOrderInformation(holder.getOriginPurchaseOrder(), holder.getPurchaseOrderToSave());
+    return pieceCreationHolder;
+  }
+
+  private List<PieceCreationHolder> createPieceCreationHolderList(PieceBatchCreationHolder holder) {
+    return holder.getPiecesToCreate().stream()
+      .map(piece -> createPieceCreationHolder(piece, holder))
+      .toList();
+  }
+
+  private List<Location> getPieceLocations(PieceBatchCreationHolder holder) {
+    return PieceUtil.findLocationsUsingPieceList(holder.getPiecesToCreate(), holder.getPoLineToSave());
+  }
+
 }

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManager.java
@@ -51,13 +51,14 @@ public class PieceDeleteFlowManager {
     return pieceStorageService.getPieceById(pieceId, requestContext)
       .map(holder::withPieceToDelete)
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext))
-      .compose(aVoid -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
-      .compose(aVoid -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), DELETE, requestContext))
-      .compose(aVoid -> isAllowedToDeletePiece(holder))
-      .compose(aVoid -> isDeletePieceRequestValid(holder, requestContext))
-      .compose(aVoid -> pieceDeleteFlowInventoryManager.processInventory(holder, requestContext))
-      .compose(pair -> updatePoLine(holder, requestContext))
-      .compose(aVoid -> pieceStorageService.deletePiece(holder.getPieceToDelete().getId(), true, requestContext));
+      .compose(v -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
+      .compose(v -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), DELETE, requestContext))
+      .compose(v -> isAllowedToDeletePiece(holder))
+      .compose(v -> isDeletePieceRequestValid(holder, requestContext))
+      .compose(v -> pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(holder, requestContext))
+      .compose(v -> pieceDeleteFlowInventoryManager.processInventory(holder, requestContext))
+      .compose(v -> pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(holder, requestContext))
+      .compose(pair -> pieceStorageService.deletePiece(holder.getPieceToDelete().getId(), true, requestContext));
   }
 
   private Future<Void> isAllowedToDeletePiece(PieceDeletionHolder holder) {
@@ -91,13 +92,6 @@ public class PieceDeleteFlowManager {
         return Future.succeededFuture();
       })
       .mapEmpty();
-  }
-
-  protected Future<Void> updatePoLine(PieceDeletionHolder holder, RequestContext requestContext) {
-    var poLine = holder.getOriginPoLine();
-    return Boolean.TRUE.equals(poLine.getIsPackage()) || Boolean.TRUE.equals(poLine.getCheckinItems())
-      ? Future.succeededFuture()
-      : pieceDeleteFlowPoLineService.updatePoLine(holder, requestContext);
   }
 
 }

--- a/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowPoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowPoLineService.java
@@ -28,7 +28,32 @@ public class PieceDeleteFlowPoLineService extends BasePieceFlowUpdatePoLineServi
   }
 
   @Override
-  public boolean poLineUpdateQuantity(PieceDeletionHolder holder) {
+  public boolean poLineUpdateCost(PieceDeletionHolder holder) {
+    PoLine lineToSave = holder.getPoLineToSave();
+    Piece piece = holder.getPieceToDelete();
+    Cost cost = lineToSave.getCost();
+    if (piece.getFormat() == Piece.Format.ELECTRONIC) {
+      if (cost.getQuantityElectronic() != null) {
+        int prevQty = cost.getQuantityElectronic();
+        if (prevQty > 0) {
+          cost.setQuantityElectronic(prevQty - 1);
+          return true;
+        }
+      }
+    } else {
+      if (cost.getQuantityPhysical() != null) {
+        int prevQty = cost.getQuantityPhysical();
+        if (prevQty > 0) {
+          cost.setQuantityPhysical(prevQty - 1);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean poLineUpdateLocations(PieceDeletionHolder holder) {
     PoLine lineToSave = holder.getPoLineToSave();
     Piece piece = holder.getPieceToDelete();
     final int qty = 1;
@@ -36,18 +61,15 @@ public class PieceDeleteFlowPoLineService extends BasePieceFlowUpdatePoLineServi
     List<Location> locationToDelete = new ArrayList<>();
     if (CollectionUtils.isNotEmpty(locationsToUpdate)) {
       Location loc = locationsToUpdate.get(0);
-      Cost cost = lineToSave.getCost();
       if (piece.getFormat() == Piece.Format.ELECTRONIC) {
         loc.setQuantityElectronic(loc.getQuantityElectronic() - qty);
         loc.setQuantity(loc.getQuantity() - qty);
-        cost.setQuantityElectronic(cost.getQuantityElectronic() - qty);
         if (loc.getQuantityElectronic() == 0) {
           loc.setQuantityElectronic(null);
         }
       } else {
         loc.setQuantityPhysical(loc.getQuantityPhysical() - qty);
         loc.setQuantity(loc.getQuantity() - qty);
-        cost.setQuantityPhysical(cost.getQuantityPhysical() - qty);
         if (loc.getQuantityPhysical() == 0) {
           loc.setQuantityPhysical(null);
         }
@@ -57,26 +79,8 @@ public class PieceDeleteFlowPoLineService extends BasePieceFlowUpdatePoLineServi
       }
       lineToSave.getLocations().removeAll(locationToDelete);
       return true;
-    } else if (!isLocationUpdateRequired(piece, lineToSave)) {
-      Cost cost = lineToSave.getCost();
-      if (piece.getFormat() == Piece.Format.ELECTRONIC) {
-        if (cost.getQuantityElectronic() != null) {
-          int prevQty = cost.getQuantityElectronic();
-          if (prevQty > 0) {
-            cost.setQuantityElectronic(prevQty - qty);
-            return true;
-          }
-        }
-      } else {
-        if (cost.getQuantityPhysical() != null) {
-          int prevQty = cost.getQuantityPhysical();
-          if (prevQty > 0) {
-            cost.setQuantityPhysical(prevQty - qty);
-            return true;
-          }
-        }
-      }
     }
     return false;
   }
+
 }

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManager.java
@@ -83,8 +83,10 @@ public class PieceUpdateFlowManager {
       .compose(aHolder -> basePieceFlowHolderBuilder.updateHolderWithTitleInformation(holder, requestContext))
       .compose(v -> asFuture(() -> defaultPieceFlowsValidator.isPieceRequestValid(pieceToUpdate, holder.getOriginPurchaseOrder(), holder.getOriginPoLine(), holder.getTitle(), 0, createItem)))
       .compose(title -> protectionService.isOperationRestricted(holder.getTitle().getAcqUnitIds(), UPDATE, requestContext))
+      .compose(v -> updatePoLineReceiptStatus(holder, List.of(holder.getPieceToUpdate()), requestContext))
+      .compose(v -> updatePoLineService.updatePoLineCostAndProcessEncumbrances(holder, requestContext))
       .compose(v -> pieceUpdateFlowInventoryManager.processInventory(holder, requestContext))
-      .compose(v -> updatePoLine(holder, requestContext))
+      .compose(v -> updatePoLineService.updateLocationsAndSavePoLine(holder, requestContext))
       .map(v -> updatePieceStatus(holder.getPieceToUpdate(), holder.getPieceFromStorage().getReceivingStatus(), holder.getPieceToUpdate().getReceivingStatus()))
       .compose(verifyReceiptStatus -> pieceStorageService.updatePiece(holder.getPieceToUpdate(), requestContext).map(verifyReceiptStatus))
       .compose(verifyReceiptStatus -> asFuture(() -> {
@@ -106,7 +108,8 @@ public class PieceUpdateFlowManager {
       .map(piecesByPoLineId -> piecesByPoLineId.entrySet().stream()
         .map(entry -> new PieceBatchStatusUpdateHolder(newStatus, claimingInterval, internalNote, externalNote, entry.getValue(), entry.getKey()))
         .map(holder -> basePieceFlowHolderBuilder.updateHolderWithOrderInformation(holder, requestContext)
-          .compose(v -> updatePoLine(holder, requestContext))
+          .compose(v -> updatePoLineReceiptStatus(holder, holder.getPieces(), requestContext))
+          .compose(v -> savePoLineIfNeeded(holder, requestContext))
           .compose(v -> updatePiecesStatusesByPoLine(holder, requestContext)))
         .toList())
       .compose(HelperUtils::collectResultsOnSuccess)
@@ -115,39 +118,37 @@ public class PieceUpdateFlowManager {
       .mapEmpty();
   }
 
-  protected Future<Void> updatePoLine(PieceUpdateHolder holder, RequestContext requestContext) {
-    return updatePoLine(holder, List.of(holder.getPieceToUpdate()), requestContext)
-      .compose(v -> !Boolean.TRUE.equals(holder.getOriginPoLine().getIsPackage()) && !Boolean.TRUE.equals(holder.getOriginPoLine().getCheckinItems())
-        ? updatePoLineService.updatePoLine(holder, requestContext)
-        : Future.succeededFuture());
-  }
-
-  protected Future<Void> updatePoLine(PieceBatchStatusUpdateHolder holder, RequestContext requestContext) {
-    return updatePoLine(holder, holder.getPieces(), requestContext);
-  }
-
-  private <T extends BasePieceFlowHolder> Future<Void> updatePoLine(T holder, List<Piece> piecesToUpdate, RequestContext requestContext) {
+  private <T extends BasePieceFlowHolder> Future<Void> updatePoLineReceiptStatus(T holder, List<Piece> piecesToUpdate,
+      RequestContext requestContext) {
     var originPurchaseOrder = holder.getOriginPurchaseOrder();
     if (originPurchaseOrder.getOrderType() != OrderType.ONE_TIME || originPurchaseOrder.getWorkflowStatus() != WorkflowStatus.OPEN) {
       return Future.succeededFuture();
     }
-
     var originPoLine = holder.getOriginPoLine();
     var poLineToSave = holder.getPoLineToSave();
-    var pieceIds = piecesToUpdate.stream().map(Piece::getId).toList();
     return pieceStorageService.getPiecesByLineId(originPoLine.getId(), requestContext)
-      .compose(pieces -> {
+      .map(pieces -> {
         if (PoLineCommonUtil.isCancelledOrOngoingStatus(poLineToSave)) {
           log.info("updatePoLine:: Skip updating PoLine: '{}' with status: '{}'", poLineToSave.getId(), poLineToSave.getReceiptStatus());
         } else {
           var newStatus = calculatePoLineReceiptStatus(poLineToSave.getId(), pieces, piecesToUpdate);
           poLineToSave.setReceiptStatus(PoLine.ReceiptStatus.fromValue(newStatus.value()));
+          holder.setLineUpdated(true);
         }
-        var locations = getPieceLocations(piecesToUpdate, poLineToSave);
-        return purchaseOrderLineService.saveOrderLine(poLineToSave, locations, requestContext);
-      })
-      .onSuccess(v -> log.info("updatePoLine:: PoLine with id: '{}' is updated for pieceIds: {}", originPoLine.getId(), pieceIds))
-      .onFailure(t -> log.error("Failed to update PO line with id: '{}' for pieceIds: {}", originPoLine.getId(), pieceIds, t));
+        return null;
+      });
+  }
+
+  private Future<Void> savePoLineIfNeeded(PieceBatchStatusUpdateHolder holder, RequestContext requestContext) {
+    if (!holder.getLineUpdated()) {
+      return Future.succeededFuture();
+    }
+    PoLine poLineToSave = holder.getPoLineToSave();
+    var pieceIds = holder.getPieces().stream().map(Piece::getId).toList();
+    return purchaseOrderLineService.saveOrderLine(poLineToSave, getPieceLocations(holder.getPieces(),
+        holder.getPoLineToSave()), requestContext)
+      .onSuccess(v -> log.info("updatePoLine:: PoLine with id: '{}' is updated for pieceIds: {}", poLineToSave.getId(), pieceIds))
+      .onFailure(t -> log.error("Failed to update PO line with id: '{}' for pieceIds: {}", poLineToSave.getId(), pieceIds, t));
   }
 
   private Future<Void> isOperationRestricted(List<String> pieceIds, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineService.java
+++ b/src/main/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineService.java
@@ -1,12 +1,13 @@
 package org.folio.service.pieces.flows.update;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.models.pieces.PieceCreationHolder;
 import org.folio.models.pieces.PieceDeletionHolder;
 import org.folio.models.pieces.PieceUpdateHolder;
-import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.acq.Location;
@@ -18,11 +19,9 @@ import org.folio.service.pieces.flows.BasePieceFlowUpdatePoLineService;
 import org.folio.service.pieces.flows.create.PieceCreateFlowPoLineService;
 import org.folio.service.pieces.flows.delete.PieceDeleteFlowPoLineService;
 
-import io.vertx.core.Future;
-
 public class PieceUpdateFlowPoLineService extends BasePieceFlowUpdatePoLineService<PieceUpdateHolder> {
-  private PieceCreateFlowPoLineService pieceCreateFlowPoLineService;
-  private PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService;
+  private final PieceCreateFlowPoLineService pieceCreateFlowPoLineService;
+  private final PieceDeleteFlowPoLineService pieceDeleteFlowPoLineService;
 
   public PieceUpdateFlowPoLineService(PurchaseOrderStorageService purchaseOrderStorageService, PurchaseOrderLineService purchaseOrderLineService,
               ReceivingEncumbranceStrategy receivingEncumbranceStrategy, PieceCreateFlowPoLineService pieceCreateFlowPoLineService,
@@ -33,22 +32,43 @@ public class PieceUpdateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
   }
 
   @Override
-  public Future<Void> updatePoLine(PieceUpdateHolder holder, RequestContext requestContext) {
-    boolean isLineUpdated = updatePoLineWithoutSave(holder);
-    if (isLineUpdated) {
-      return purchaseOrderLineService.saveOrderLine(holder.getPoLineToSave(), getPieceLocations(holder), requestContext);
-    } else {
-      return Future.succeededFuture();
-    }
-  }
-
-  @Override
   protected List<Location> getPieceLocations(PieceUpdateHolder holder) {
     return PieceUtil.findOrderPieceLineLocation(holder.getPieceToUpdate(), holder.getPoLineToSave());
   }
 
   @Override
-  public boolean poLineUpdateQuantity(PieceUpdateHolder pieceUpdateHolder) {
+  public boolean poLineUpdateCost(PieceUpdateHolder holder) {
+    // Handle a change of piece format, which could affect the cost
+    Piece pieceFromStorage = holder.getPieceFromStorage();
+    Piece pieceToUpdate = holder.getPieceToUpdate();
+    if (pieceFromStorage.getFormat() == pieceToUpdate.getFormat()) {
+      return false;
+    }
+    PoLine lineToSave = holder.getPoLineToSave();
+    Cost cost = lineToSave.getCost();
+    if (pieceFromStorage.getFormat() == Piece.Format.ELECTRONIC) {
+      int prevQty = Optional.ofNullable(cost.getQuantityElectronic()).orElse(0);
+      if (prevQty > 0) {
+        cost.setQuantityElectronic(prevQty - 1);
+      }
+    } else {
+      int prevQty = Optional.ofNullable(cost.getQuantityPhysical()).orElse(0);
+      if (prevQty > 0) {
+        cost.setQuantityPhysical(prevQty - 1);
+      }
+    }
+    if (pieceToUpdate.getFormat() == Piece.Format.ELECTRONIC) {
+      int prevQty = Optional.ofNullable(cost.getQuantityElectronic()).orElse(0);
+      cost.setQuantityElectronic(prevQty + 1);
+    } else {
+      int prevQty = Optional.ofNullable(cost.getQuantityPhysical()).orElse(0);
+      cost.setQuantityPhysical(prevQty + 1);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean poLineUpdateLocations(PieceUpdateHolder pieceUpdateHolder) {
     PoLine lineToSave = pieceUpdateHolder.getPoLineToSave();
     Piece pieceToUpdate = pieceUpdateHolder.getPieceToUpdate();
     Piece pieceFromStorage = pieceUpdateHolder.getPieceFromStorage();
@@ -60,7 +80,7 @@ public class PieceUpdateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
       } else {
         pieceDeletionHolder.withPoLineOnly(lineToSave);
       }
-      boolean isDecreased = pieceDeleteFlowPoLineService.poLineUpdateQuantity(pieceDeletionHolder);
+      boolean isDecreased = pieceDeleteFlowPoLineService.poLineUpdateLocations(pieceDeletionHolder);
       if (isDecreased) {
         PieceCreationHolder pieceCreationHolder = new PieceCreationHolder().withPieceToCreate(pieceToUpdate);
         if (pieceDeletionHolder.getPurchaseOrderToSave() != null) {
@@ -68,7 +88,7 @@ public class PieceUpdateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
         } else {
           pieceCreationHolder.withPoLineOnly(lineToSave);
         }
-        pieceCreateFlowPoLineService.poLineUpdateQuantity(pieceCreationHolder);
+        pieceCreateFlowPoLineService.poLineUpdateLocations(pieceCreationHolder);
         if (pieceCreationHolder.getPurchaseOrderToSave() != null) {
           pieceUpdateHolder.withOrderInformation(pieceCreationHolder.getPurchaseOrderToSave());
         } else {
@@ -80,12 +100,10 @@ public class PieceUpdateFlowPoLineService extends BasePieceFlowUpdatePoLineServi
     return false;
   }
 
-  public boolean updatePoLineWithoutSave(PieceUpdateHolder holder) {
-    boolean isLineUpdated = poLineUpdateQuantity(holder);
-    if (isLineUpdated) {
+  public void updatePoLineWithoutSave(PieceUpdateHolder holder) {
+    if (poLineUpdateCost(holder)) {
       updateEstimatedPrice(holder.getPoLineToSave());
-      return true;
     }
-    return false;
+    poLineUpdateLocations(holder);
   }
 }

--- a/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/create/PieceCreateFlowPoLineServiceTest.java
@@ -32,7 +32,6 @@ import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.Eresource;
 import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.Piece;
-import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.acq.Location;
 import org.folio.service.finance.transaction.ReceivingEncumbranceStrategy;
@@ -126,7 +125,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
@@ -168,7 +169,8 @@ public class PieceCreateFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
 
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityElectronic());
@@ -223,7 +225,7 @@ public class PieceCreateFlowPoLineServiceTest {
     holder.withOrderInformation(purchaseOrder, poLine);
 
     // When
-    pieceCreateFlowPoLineService.poLineUpdateQuantity(holder);
+    pieceCreateFlowPoLineService.poLineUpdateLocations(holder);
 
     // Then
     var poLineToSave = holder.getPoLineToSave();
@@ -255,8 +257,11 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(receivingEncumbranceStrategy).processEncumbrances(incomingUpdateHolder.getPurchaseOrderToSave(),
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
+
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityElectronic());
@@ -297,7 +302,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
@@ -339,7 +346,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
@@ -384,7 +393,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertEquals(1, poLineToSave.getLocations().size());
@@ -429,7 +440,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertEquals(1, poLineToSave.getLocations().size());
@@ -474,7 +487,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertEquals(1, poLineToSave.getLocations().size());
@@ -519,7 +534,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertEquals(1, poLineToSave.getLocations().size());
@@ -562,7 +579,9 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertEquals(0, poLineToSave.getLocations().size());
@@ -607,12 +626,14 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
     assertEquals(expQty, poLineToSave.getCost().getQuantityElectronic());
-    assertEquals(expEstimatedPrice, poLineToSave.getCost().getPoLineEstimatedPrice());
+    // the estimated price is updated when distributeFunds() is called withing processEncumbrances() - it is mocked here
     assertEquals(3, poLineToSave.getLocations().size());
     Location actLoc1 = poLineToSave.getLocations().stream().filter(loc -> locationId1.equals(loc.getLocationId())).findFirst().get();
     Location actLoc2 = poLineToSave.getLocations().stream().filter(loc -> locationId2.equals(loc.getLocationId())).findFirst().get();
@@ -667,12 +688,14 @@ public class PieceCreateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
 
     //When
-    pieceCreateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceCreateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceCreateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
+
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityElectronic());
     assertEquals(expQty, poLineToSave.getCost().getQuantityPhysical());
-    assertEquals(expEstimatedPrice, poLineToSave.getCost().getPoLineEstimatedPrice());
+    // the estimated price is updated when distributeFunds() is called withing processEncumbrances() - it is mocked here
     assertEquals(3, poLineToSave.getLocations().size());
     Location actLoc1 = poLineToSave.getLocations().stream().filter(loc -> locationId1.equals(loc.getLocationId())).findFirst().get();
     Location actLoc2 = poLineToSave.getLocations().stream().filter(loc -> locationId2.equals(loc.getLocationId())).findFirst().get();

--- a/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowManagerTest.java
@@ -176,7 +176,8 @@ public class PieceDeleteFlowManagerTest {
     doReturn(succeededFuture(new ArrayList<JsonObject>())).when(inventoryItemManager).getItemsByHoldingId(holdingId,  requestContext);
 
     final ArgumentCaptor<PieceDeletionHolder> pieceDeletionHolderCapture = ArgumentCaptor.forClass(PieceDeletionHolder.class);
-    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updateLocationsAndSavePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
 
     //When
     pieceDeleteFlowManager.deletePiece(piece.getId(), true, requestContext).result();
@@ -189,7 +190,7 @@ public class PieceDeleteFlowManagerTest {
     //Then
     assertNull(poLine.getLocations().get(0).getLocationId());
     assertEquals(holdingId, poLine.getLocations().get(0).getHoldingId());
-    verify(pieceDeleteFlowPoLineService, times(0)).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    verify(pieceDeleteFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceDeletionHolderCapture.capture(), eq(requestContext));
     verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(holder, requestContext);
   }
 
@@ -236,66 +237,7 @@ public class PieceDeleteFlowManagerTest {
 
     assertNull(poLine.getLocations().get(0).getLocationId());
     assertEquals(holdingId, poLine.getLocations().get(0).getHoldingId());
-    verify(pieceDeleteFlowPoLineService, times(0)).updatePoLine(any(), any());
-    verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(holder, requestContext);
-  }
-
-  @Test
-  void shouldNotUpdateLineQuantityIfPoLineIsNotPackageAndManualPieceCreateTrueAndDeleteHoldingAndItemAndPiece()  {
-    String orderId = UUID.randomUUID().toString();
-    String holdingId = UUID.randomUUID().toString();
-    String lineId = UUID.randomUUID().toString();
-    String titleId = UUID.randomUUID().toString();
-    String itemId = UUID.randomUUID().toString();
-    String locationId = UUID.randomUUID().toString();
-    JsonObject item = new JsonObject().put(ID, itemId);
-    item.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ItemStatus.ON_ORDER.value()));
-    JsonObject holding = new JsonObject().put(ID, holdingId);
-    holding.put(HOLDING_PERMANENT_LOCATION_ID, locationId);
-    Piece piece = new Piece().withId(UUID.randomUUID().toString()).withPoLineId(lineId).withItemId(itemId).withTitleId(titleId)
-      .withHoldingId(holdingId).withFormat(Piece.Format.ELECTRONIC);
-    Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
-    Cost cost = new Cost().withQuantityElectronic(1)
-      .withListUnitPriceElectronic(1d).withExchangeRate(1d).withCurrency("USD")
-      .withPoLineEstimatedPrice(1d);
-    PoLine poLine = new PoLine().withIsPackage(false).withPurchaseOrderId(orderId).withId(lineId)
-      .withLocations(List.of(loc)).withCost(cost).withCheckinItems(true);
-    PurchaseOrder purchaseOrder = new PurchaseOrder().withId(orderId).withWorkflowStatus(PurchaseOrder.WorkflowStatus.OPEN);
-    Title title = new Title().withId(titleId);
-
-    doReturn(succeededFuture(piece)).when(pieceStorageService).getPieceById(piece.getId(), requestContext);
-    doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
-    doReturn(succeededFuture(null)).when(pieceStorageService).deletePiece(eq(piece.getId()), eq(true), eq(requestContext));
-    doReturn(succeededFuture(null)).when(circulationRequestsRetriever).getNumberOfRequestsByItemId(eq(piece.getItemId()), eq(requestContext));
-    doReturn(succeededFuture(item)).when(inventoryItemManager).getItemRecordById(itemId, true, requestContext);
-    doReturn(succeededFuture(null)).when(inventoryItemManager).deleteItem(itemId, true, requestContext);
-    doReturn(succeededFuture(holding)).when(inventoryHoldingManager).getHoldingById(holdingId, true, requestContext);
-    doReturn(succeededFuture(null)).when(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(piece, requestContext);
-    doReturn(succeededFuture(new ArrayList<JsonObject>())).when(inventoryItemManager).getItemsByHoldingId(holdingId,  requestContext);
-    final ArgumentCaptor<PieceDeletionHolder> PieceDeletionHolderCapture = ArgumentCaptor.forClass(PieceDeletionHolder.class);
-    doAnswer((Answer<Future<Void>>) invocation -> {
-      PieceDeletionHolder answerHolder = invocation.getArgument(0);
-      answerHolder.withOrderInformation(purchaseOrder, poLine);
-      return succeededFuture(null);
-    }).when(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(PieceDeletionHolderCapture.capture(), eq(requestContext));
-    doAnswer((Answer<Future<Void>>) invocation -> {
-      PieceDeletionHolder answerHolder = invocation.getArgument(0);
-      answerHolder.withTitleInformation(title);
-      return succeededFuture(null);
-    }).when(basePieceFlowHolderBuilder).updateHolderWithTitleInformation(PieceDeletionHolderCapture.capture(), eq(requestContext));
-
-    final ArgumentCaptor<PieceDeletionHolder> pieceDeletionHolderCapture = ArgumentCaptor.forClass(PieceDeletionHolder.class);
-    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
-    //When
-    pieceDeleteFlowManager.deletePiece(piece.getId(), true, requestContext).result();
-    //Then
-    PieceDeletionHolder holder = PieceDeletionHolderCapture.getValue();
-    assertNull(poLine.getLocations().get(0).getLocationId());
-    assertEquals(holdingId, poLine.getLocations().get(0).getHoldingId());
-    verify(pieceStorageService).deletePiece(eq(piece.getId()), eq(true), eq(requestContext));
-    verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(piece, requestContext);
-    verify(inventoryItemManager).deleteItem(itemId, true, requestContext);
-    verify(pieceDeleteFlowPoLineService, times(0)).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    verify(pieceDeleteFlowPoLineService, times(0)).updatePoLineCostAndProcessEncumbrances(any(), any());
     verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(holder, requestContext);
   }
 
@@ -340,7 +282,8 @@ public class PieceDeleteFlowManagerTest {
     }).when(basePieceFlowHolderBuilder).updateHolderWithTitleInformation(PieceDeletionHolderCapture.capture(), eq(requestContext));
 
     final ArgumentCaptor<PieceDeletionHolder> pieceDeletionHolderCapture = ArgumentCaptor.forClass(PieceDeletionHolder.class);
-    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updateLocationsAndSavePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
 
     //When
     pieceDeleteFlowManager.deletePiece(piece.getId(), true, requestContext).result();
@@ -350,7 +293,7 @@ public class PieceDeleteFlowManagerTest {
     verify(inventoryItemManager, times(0)).deleteItem(itemId, true, requestContext);
     verify(inventoryHoldingManager, times(0)).deleteHoldingById(holdingId, true, requestContext);
     verify(pieceStorageService, times(1)).deletePiece(eq(piece.getId()), eq(true), eq(requestContext));
-    verify(pieceDeleteFlowPoLineService).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    verify(pieceDeleteFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceDeletionHolderCapture.capture(), eq(requestContext));
     verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(holder, requestContext);
   }
 
@@ -404,7 +347,8 @@ public class PieceDeleteFlowManagerTest {
     }).when(basePieceFlowHolderBuilder).updateHolderWithTitleInformation(PieceDeletionHolderCapture.capture(), eq(requestContext));
 
     final ArgumentCaptor<PieceDeletionHolder> pieceDeletionHolderCapture = ArgumentCaptor.forClass(PieceDeletionHolder.class);
-    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceDeleteFlowPoLineService).updateLocationsAndSavePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
     //When
     pieceDeleteFlowManager.deletePiece(piece.getId(), true, requestContext).result();
     //Then
@@ -413,7 +357,7 @@ public class PieceDeleteFlowManagerTest {
     verify(inventoryItemManager, times(0)).deleteItem(itemId, true, requestContext);
     verify(pieceUpdateInventoryService).deleteHoldingConnectedToPiece(piece, requestContext);
     verify(pieceStorageService, times(1)).deletePiece(eq(piece.getId()), eq(true), eq(requestContext));
-    verify(pieceDeleteFlowPoLineService).updatePoLine(pieceDeletionHolderCapture.capture(), eq(requestContext));
+    verify(pieceDeleteFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceDeletionHolderCapture.capture(), eq(requestContext));
     verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(holder, requestContext);
   }
 

--- a/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowPoLineServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/delete/PieceDeleteFlowPoLineServiceTest.java
@@ -126,7 +126,8 @@ public class PieceDeleteFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityElectronic());
@@ -166,7 +167,8 @@ public class PieceDeleteFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityElectronic());
@@ -206,7 +208,8 @@ public class PieceDeleteFlowPoLineServiceTest {
           incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
@@ -246,7 +249,8 @@ public class PieceDeleteFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityElectronic());
@@ -283,7 +287,8 @@ public class PieceDeleteFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
@@ -320,7 +325,8 @@ public class PieceDeleteFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
@@ -365,7 +371,8 @@ public class PieceDeleteFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityPhysical());
@@ -409,7 +416,8 @@ public class PieceDeleteFlowPoLineServiceTest {
       incomingUpdateHolder.getPurchaseOrderToSave(), requestContext);
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(eq(incomingUpdateHolder.getPoLineToSave()), anyList(), eq(requestContext));
     //When
-    pieceDeleteFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceDeleteFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceDeleteFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToSave = incomingUpdateHolder.getPoLineToSave();
     assertNull(poLineToSave.getCost().getQuantityElectronic());

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowManagerTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
@@ -51,7 +50,6 @@ import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 import org.folio.service.pieces.PieceService;
 import org.folio.service.pieces.PieceStorageService;
-import org.folio.service.pieces.PieceUtil;
 import org.folio.service.pieces.flows.BasePieceFlowHolderBuilder;
 import org.folio.service.pieces.flows.DefaultPieceFlowsValidator;
 import org.folio.service.titles.TitlesService;
@@ -136,134 +134,6 @@ public class PieceUpdateFlowManagerTest {
   }
 
   @Test
-  void shouldNotUpdateLineQuantityIfPoLineIsPackageAndShouldRunProcessInventory() {
-    String orderId = UUID.randomUUID().toString();
-    String holdingId = UUID.randomUUID().toString();
-    String holdingIdTpUpdate = UUID.randomUUID().toString();
-    String lineId = UUID.randomUUID().toString();
-    String titleId = UUID.randomUUID().toString();
-    String itemId = UUID.randomUUID().toString();
-    String pieceId = UUID.randomUUID().toString();
-    String locationId = UUID.randomUUID().toString();
-
-    JsonObject item = new JsonObject().put(ID, itemId);
-    item.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ItemStatus.ON_ORDER.value()));
-    JsonObject holding = new JsonObject().put(ID, holdingId);
-    holding.put(HOLDING_PERMANENT_LOCATION_ID, locationId);
-    Piece pieceFromStorage = new Piece().withId(pieceId).withPoLineId(lineId).withItemId(itemId).withTitleId(titleId)
-      .withHoldingId(holdingId).withFormat(Piece.Format.ELECTRONIC).withSequenceNumber(1);
-    Piece pieceToUpdate = new Piece().withId(pieceId).withPoLineId(lineId).withItemId(itemId).withTitleId(titleId)
-      .withHoldingId(holdingIdTpUpdate).withFormat(Piece.Format.ELECTRONIC).withSequenceNumber(1);
-    Cost cost = new Cost().withQuantityElectronic(1);
-    Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
-    Eresource eresource = new Eresource().withCreateInventory(INSTANCE_HOLDING_ITEM);
-    PoLine poLine = new PoLine().withIsPackage(true).withPurchaseOrderId(orderId).withId(lineId)
-      .withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE)
-      .withEresource(eresource)
-      .withLocations(List.of(loc)).withCost(cost);
-    PurchaseOrder purchaseOrder = new PurchaseOrder().withId(orderId)
-      .withOrderType(PurchaseOrder.OrderType.ONE_TIME).withWorkflowStatus(PurchaseOrder.WorkflowStatus.OPEN);
-    Title title = new Title().withId(titleId).withNextSequenceNumber(2);
-
-    doReturn(succeededFuture(pieceFromStorage)).when(pieceStorageService).getPieceById(pieceToUpdate.getId(), requestContext);
-    doReturn(succeededFuture(null)).when(pieceStorageService).updatePiece(pieceToUpdate, requestContext);
-    givenPoLineHasPieces(lineId, List.of());
-
-    final ArgumentCaptor<PieceUpdateHolder> pieceUpdateHolderCapture = ArgumentCaptor.forClass(PieceUpdateHolder.class);
-    doAnswer((Answer<Future<Void>>) invocation -> {
-      PieceUpdateHolder answerHolder = invocation.getArgument(0);
-      answerHolder.withOrderInformation(purchaseOrder, poLine);
-      return succeededFuture(null);
-    }).when(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    doAnswer((Answer<Future<Void>>) invocation -> {
-      PieceUpdateHolder answerHolder = invocation.getArgument(0);
-      answerHolder.withTitleInformation(title);
-      return succeededFuture(null);
-    }).when(basePieceFlowHolderBuilder).updateHolderWithTitleInformation(pieceUpdateHolderCapture.capture(), eq(requestContext));
-
-    doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
-    doReturn(succeededFuture(null)).when(pieceUpdateFlowInventoryManager).processInventory(any(PieceUpdateHolder.class), eq(requestContext));
-    doNothing().when(pieceService).receiptConsistencyPiecePoLine(anyString(), eq(requestContext));
-    doReturn(succeededFuture(null)).when(pieceUpdateFlowPoLineService).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    doReturn(succeededFuture(null))
-      .when(purchaseOrderLineService).saveOrderLine(any(PoLine.class),
-        eq(PieceUtil.findOrderPieceLineLocation(pieceToUpdate, poLine)),
-        eq(requestContext));
-
-    //When
-    pieceUpdateFlowManager.updatePiece(pieceToUpdate, true, true, requestContext).result();
-    //Then
-    PieceUpdateHolder holder = pieceUpdateHolderCapture.getValue();
-    assertNull(poLine.getLocations().get(0).getLocationId());
-    assertEquals(holdingId, poLine.getLocations().get(0).getHoldingId());
-    verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(holder, requestContext);
-    verify(pieceUpdateFlowPoLineService, times(0)).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    verify(pieceUpdateFlowInventoryManager).processInventory(any(PieceUpdateHolder.class), eq(requestContext));
-    verify(pieceStorageService).updatePiece(pieceToUpdate, requestContext);
-  }
-
-  @Test
-  void shouldNotUpdateLineQuantityIfManualPieceCreateTrueAndShouldRunProcessInventory() {
-    String orderId = UUID.randomUUID().toString();
-    String holdingId = UUID.randomUUID().toString();
-    String holdingIdTpUpdate = UUID.randomUUID().toString();
-    String lineId = UUID.randomUUID().toString();
-    String titleId = UUID.randomUUID().toString();
-    String itemId = UUID.randomUUID().toString();
-    String locationId = UUID.randomUUID().toString();
-    String pieceId = UUID.randomUUID().toString();
-
-    JsonObject item = new JsonObject().put(ID, itemId);
-    item.put(ITEM_STATUS, new JsonObject().put(ITEM_STATUS_NAME, ItemStatus.ON_ORDER.value()));
-    JsonObject holding = new JsonObject().put(ID, holdingId);
-    holding.put(HOLDING_PERMANENT_LOCATION_ID, locationId);
-    Piece pieceFromStorage = new Piece().withId(pieceId).withPoLineId(lineId).withItemId(itemId).withTitleId(titleId)
-      .withHoldingId(holdingId).withFormat(Piece.Format.ELECTRONIC).withSequenceNumber(1);
-    Piece pieceToUpdate = new Piece().withId(pieceId).withPoLineId(lineId).withItemId(itemId).withTitleId(titleId)
-      .withHoldingId(holdingIdTpUpdate).withFormat(Piece.Format.ELECTRONIC).withSequenceNumber(1);
-    Cost cost = new Cost().withQuantityElectronic(1);
-    Location loc = new Location().withHoldingId(holdingId).withQuantityElectronic(1).withQuantity(1);
-    Eresource eresource = new Eresource().withCreateInventory(INSTANCE_HOLDING_ITEM);
-    PoLine poLine = new PoLine().withIsPackage(false).withCheckinItems(true).withPurchaseOrderId(orderId).withId(lineId)
-      .withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE)
-      .withEresource(eresource)
-      .withLocations(List.of(loc)).withCost(cost);
-    PurchaseOrder purchaseOrder = new PurchaseOrder().withId(orderId).withWorkflowStatus(PurchaseOrder.WorkflowStatus.OPEN);
-    Title title = new Title().withId(titleId).withNextSequenceNumber(2);
-
-    doReturn(succeededFuture(pieceFromStorage)).when(pieceStorageService).getPieceById(pieceToUpdate.getId(), requestContext);
-    doReturn(succeededFuture(null)).when(pieceStorageService).updatePiece(pieceToUpdate, requestContext);
-    givenPoLineHasPieces(lineId, List.of());
-
-    final ArgumentCaptor<PieceUpdateHolder> pieceUpdateHolderCapture = ArgumentCaptor.forClass(PieceUpdateHolder.class);
-    doAnswer((Answer<Future<Void>>) invocation -> {
-      PieceUpdateHolder answerHolder = invocation.getArgument(0);
-      answerHolder.withOrderInformation(purchaseOrder, poLine);
-      return succeededFuture(null);
-    }).when(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    doAnswer((Answer<Future<Void>>) invocation -> {
-      PieceUpdateHolder answerHolder = invocation.getArgument(0);
-      answerHolder.withTitleInformation(title);
-      return succeededFuture(null);
-    }).when(basePieceFlowHolderBuilder).updateHolderWithTitleInformation(pieceUpdateHolderCapture.capture(), eq(requestContext));
-
-    doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
-    doReturn(succeededFuture(null)).when(pieceUpdateFlowInventoryManager).processInventory(any(PieceUpdateHolder.class), eq(requestContext));
-    doNothing().when(pieceService).receiptConsistencyPiecePoLine(anyString(), eq(requestContext));
-    doReturn(succeededFuture(null)).when(pieceUpdateFlowPoLineService).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    //When
-    pieceUpdateFlowManager.updatePiece(pieceToUpdate, true, true, requestContext).result();
-    //Then
-    PieceUpdateHolder holder = pieceUpdateHolderCapture.getValue();
-    assertNull(poLine.getLocations().get(0).getLocationId());
-    assertEquals(holdingId, poLine.getLocations().get(0).getHoldingId());
-    verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(holder, requestContext);
-    verify(pieceUpdateFlowPoLineService, times(0)).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    verify(pieceUpdateFlowInventoryManager).processInventory(any(PieceUpdateHolder.class), eq(requestContext));
-    verify(pieceStorageService).updatePiece(pieceToUpdate, requestContext);
-  }
-
-  @Test
   void shouldUpdateLineQuantityIfPoLineIsNotPackageAndHoldingReferenceChangedAndShouldRunProcessInventory() {
     String orderId = UUID.randomUUID().toString();
     String oldHoldingId = UUID.randomUUID().toString();
@@ -312,7 +182,8 @@ public class PieceUpdateFlowManagerTest {
 
     doReturn(succeededFuture(null)).when(protectionService).isOperationRestricted(any(), any(ProtectedOperationType.class), eq(requestContext));
     doReturn(succeededFuture(null)).when(pieceUpdateFlowInventoryManager).processInventory(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    doReturn(succeededFuture(null)).when(pieceUpdateFlowPoLineService).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceUpdateFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceUpdateHolderCapture.capture(), eq(requestContext));
+    doReturn(succeededFuture(null)).when(pieceUpdateFlowPoLineService).updateLocationsAndSavePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
 
     //When
     pieceUpdateFlowManager.updatePiece(incomingPieceToUpdate, true, true, requestContext).result();
@@ -322,7 +193,7 @@ public class PieceUpdateFlowManagerTest {
 
     assertNotNull(pieceToUpdate.getStatusUpdatedDate());
     verify(basePieceFlowHolderBuilder).updateHolderWithOrderInformation(pieceUpdateHolderCapture.capture(), eq(requestContext));
-    verify(pieceUpdateFlowPoLineService).updatePoLine(pieceUpdateHolderCapture.capture(), eq(requestContext));
+    verify(pieceUpdateFlowPoLineService).updatePoLineCostAndProcessEncumbrances(pieceUpdateHolderCapture.capture(), eq(requestContext));
     verify(pieceUpdateFlowInventoryManager).processInventory(any(PieceUpdateHolder.class), eq(requestContext));
     verify(pieceStorageService).updatePiece(pieceToUpdate, requestContext);
   }
@@ -344,7 +215,7 @@ public class PieceUpdateFlowManagerTest {
     doReturn(succeededFuture(poLine1)).when(purchaseOrderLineService).getOrderLineById(poLine1.getId(), requestContext);
     doReturn(succeededFuture(poLine2)).when(purchaseOrderLineService).getOrderLineById(poLine2.getId(), requestContext);
     doReturn(succeededFuture(purchaseOrder)).when(purchaseOrderStorageService).getPurchaseOrderById(purchaseOrder.getId(), requestContext);
-    doReturn(succeededFuture()).when(pieceUpdateFlowPoLineService).updatePoLine(any(), eq(requestContext));
+    doReturn(succeededFuture()).when(pieceUpdateFlowPoLineService).updatePoLineCostAndProcessEncumbrances(any(), eq(requestContext));
     doReturn(succeededFuture()).when(pieceStorageService).updatePiecesBatch(any(), eq(requestContext));
     doNothing().when(pieceService).receiptConsistencyPiecePoLine(anyString(), eq(requestContext));
 

--- a/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineServiceTest.java
+++ b/src/test/java/org/folio/service/pieces/flows/update/PieceUpdateFlowPoLineServiceTest.java
@@ -132,7 +132,8 @@ public class PieceUpdateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(poLineToSaveCapture.capture(), anyList(), eq(requestContext));
 
     //When
-    pieceUpdateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceUpdateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceUpdateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToUpdate = poLineToSaveCapture.getValue();
     assertNull(pieceToUpdate.getLocationId());
@@ -183,7 +184,8 @@ public class PieceUpdateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(poLineToSaveCapture.capture(), anyList(), eq(requestContext));
 
     //When
-    pieceUpdateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceUpdateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceUpdateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToUpdate = poLineToSaveCapture.getValue();
     assertNull(pieceToUpdate.getLocationId());
@@ -242,7 +244,8 @@ public class PieceUpdateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(poLineToSaveCapture.capture(), anyList(), eq(requestContext));
 
     //When
-    pieceUpdateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceUpdateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceUpdateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToUpdate = poLineToSaveCapture.getValue();
     assertEquals(locationToUpdate, pieceToUpdate.getLocationId());
@@ -302,7 +305,8 @@ public class PieceUpdateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(poLineToSaveCapture.capture(), anyList(), eq(requestContext));
 
     //When
-    pieceUpdateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceUpdateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceUpdateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToUpdate = poLineToSaveCapture.getValue();
     assertEquals(holdingToUpdate, pieceToUpdate.getHoldingId());
@@ -363,7 +367,8 @@ public class PieceUpdateFlowPoLineServiceTest {
     doReturn(succeededFuture(null)).when(purchaseOrderLineService).saveOrderLine(poLineToSaveCapture.capture(), anyList(), eq(requestContext));
 
     //When
-    pieceUpdateFlowPoLineService.updatePoLine(incomingUpdateHolder, requestContext).result();
+    pieceUpdateFlowPoLineService.updatePoLineCostAndProcessEncumbrances(incomingUpdateHolder, requestContext);
+    pieceUpdateFlowPoLineService.updateLocationsAndSavePoLine(incomingUpdateHolder, requestContext);
     //Then
     PoLine poLineToUpdate = poLineToSaveCapture.getValue();
     assertEquals(holdingToUpdate, pieceToUpdate.getHoldingId());


### PR DESCRIPTION
## 13.1.1 - Released (Trillium R2 2025)
This release focused on fixing holdings and items creation/deletion logic when budget or ledger restrictions prevent operation

[Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.1.0...v13.1.1)

### Bug Fixes
* [MODORDERS-1435](https://folio-org.atlassian.net/browse/MODORDERS-1435) - Changing a piece format: encumbrance not updated
* [MODORDERS-1434](https://folio-org.atlassian.net/browse/MODORDERS-1434) - Batch create pieces: encumbrance is not updated
* [MODORDERS-1415](https://folio-org.atlassian.net/browse/MODORDERS-1415) - Fix holdings and items creation/deletion logic when budget or ledger restrictions prevent operation