### PR TITLE
[MODORDERS-1439] Changed order status automatic update logic

### DIFF
--- a/src/main/java/org/folio/helper/CheckinHelper.java
+++ b/src/main/java/org/folio/helper/CheckinHelper.java
@@ -7,7 +7,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.Objects;
 import one.util.streamex.StreamEx;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.models.pieces.PiecesHolder;
@@ -16,6 +15,7 @@ import org.folio.orders.utils.StreamUtils;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CheckInPiece;
 import org.folio.rest.jaxrs.model.CheckinCollection;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.ProcessingStatus;
@@ -73,7 +73,7 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
   private Future<ReceivingResults> processCheckInPieces(CheckinCollection checkinCollection, boolean deleteHoldings, RequestContext requestContext) {
     PiecesHolder holder = new PiecesHolder();
     // 1. Get purchase order and poLine from storage
-    return findAndSetPurchaseOrderPoLinePair(extractPoLineId(checkinCollection), holder, requestContext)
+    return findAndSetPurchaseOrderAndPoLine(extractPoLineId(checkinCollection), holder, requestContext)
       // 2. Get piece records from storage
       .compose(voidResult -> createItemsWithPieceUpdate(checkinCollection, holder, requestContext))
       // 3. Filter locationId
@@ -84,8 +84,8 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
       .map(this::updatePieceRecordsWithoutItems)
       // 6. Update received piece records in the storage
       .compose(piecesGroupedByPoLine -> storeUpdatedPieceRecords(piecesGroupedByPoLine, requestContext))
-      // 7. Update PO Line status
-      .compose(piecesGroupedByPoLine -> updateOrderAndPoLinesStatus(holder.getPiecesFromStorage(), piecesGroupedByPoLine, checkinCollection, requestContext))
+      // 7. Update PO Line and order status
+      .compose(piecesGroupedByPoLine -> updateOrderAndPoLinesStatus(holder, piecesGroupedByPoLine, checkinCollection, requestContext))
       // 8. Delete abandoned holdings
       .compose(piecesGroupedByPoLine -> {
         var pieceByHoldingIds = holder.getPiecesByHoldingIds();
@@ -114,8 +114,8 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
           .forEach(checkInPiece -> pieces.forEach(piece -> {
             var srcTenantId = piece.getReceivingTenantId();
             var dstTenantId = checkInPiece.getReceivingTenantId();
-            var purchaseOrder = holder.getPurchaseOrderPoLinePair().getKey();
-            var poLine = holder.getPurchaseOrderPoLinePair().getValue();
+            var purchaseOrder = holder.getPurchaseOrder();
+            var poLine = holder.getPoLine();
             if (checkInPiece.getId().equals(piece.getId()) && Boolean.TRUE.equals(checkInPiece.getCreateItem())) {
               pieceFutures.add(pieceCreateFlowInventoryManager.processInventory(purchaseOrder, poLine, piece, checkInPiece.getCreateItem(), requestContext)
                 .map(voidResult -> new PiecesHolder.PiecePoLineDto(poLineId, piece)));
@@ -293,20 +293,22 @@ public class CheckinHelper extends CheckinReceivePiecesHelper<CheckInPiece> {
       });
   }
 
-  private Future<Map<String, List<Piece>>> updateOrderAndPoLinesStatus(Map<String, List<Piece>> piecesFromStorage,
+  private Future<Map<String, List<Piece>>> updateOrderAndPoLinesStatus(PiecesHolder holder,
                                                                        Map<String, List<Piece>> piecesGroupedByPoLine,
                                                                        CheckinCollection checkinCollection, RequestContext requestContext) {
+    CompositePurchaseOrder compPo = holder.getPurchaseOrder();
+    Map<String, List<Piece>> piecesFromStorage = holder.getPiecesFromStorage();
     return updateOrderAndPoLinesStatus(
       piecesFromStorage,
       piecesGroupedByPoLine,
       requestContext,
-      poLines -> updateOrderStatus(poLines, checkinCollection, requestContext)
+      poLines -> updateOrderStatus(compPo, poLines, piecesGroupedByPoLine, checkinCollection, requestContext)
     );
   }
 
-  private void updateOrderStatus(List<PoLine> poLines, CheckinCollection checkinCollection, RequestContext requestContext) {
-    if (CollectionUtils.isEmpty(poLines)) {
-      logger.info("updateOrderStatus::poLines empty, returning");
+  private void updateOrderStatus(CompositePurchaseOrder compPo, List<PoLine> poLines, Map<String, List<Piece>> piecesGroupedByPoLine,
+      CheckinCollection checkinCollection, RequestContext requestContext) {
+    if (skipOrderStatusUpdate(compPo, poLines, piecesGroupedByPoLine)) {
       return;
     }
     logger.debug("updateOrderStatus::sending event to verify order status");

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -97,6 +97,7 @@ import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.AWAITING_RECEIPT;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.FULLY_RECEIVED;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.PARTIALLY_RECEIVED;
 import static org.folio.service.inventory.InventoryItemManager.ITEM_HOLDINGS_RECORD_ID;
+import static org.folio.service.orders.utils.StatusUtils.poLinePaymentStatusIsFinal;
 
 public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
 
@@ -469,6 +470,10 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
       return true;
     }
     List<Piece> pieces = piecesGroupedByPoLine.values().stream().flatMap(List::stream).toList();
+    if (compPo.getWorkflowStatus() == CLOSED && poLines.stream().anyMatch(poLine -> !poLinePaymentStatusIsFinal(poLine))) {
+      logger.info("updateOrderStatus::order is closed and a payment status is non-final, skip order status update");
+      return true;
+    }
     if (compPo.getWorkflowStatus() == CLOSED && pieces.stream().allMatch(piece -> piece.getReceivingStatus() == RECEIVED)) {
       logger.info("updateOrderStatus::pieces are received and order is already closed, skip order status update");
       return true;

--- a/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
+++ b/src/main/java/org/folio/helper/CheckinReceivePiecesHelper.java
@@ -8,7 +8,6 @@ import one.util.streamex.StreamEx;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.folio.models.PoLineLocationsPair;
 import org.folio.models.pieces.PieceUpdateHolder;
 import org.folio.models.pieces.PiecesHolder;
@@ -86,6 +85,8 @@ import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_NOT_RETRIEVED;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_POL_MISMATCH;
 import static org.folio.rest.core.exceptions.ErrorCodes.PIECE_UPDATE_FAILED;
 import static org.folio.rest.core.exceptions.ErrorCodes.USER_HAS_NO_PERMISSIONS;
+import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.CLOSED;
+import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
 import static org.folio.rest.jaxrs.model.Piece.ReceivingStatus.CLAIM_DELAYED;
 import static org.folio.rest.jaxrs.model.Piece.ReceivingStatus.CLAIM_SENT;
 import static org.folio.rest.jaxrs.model.Piece.ReceivingStatus.EXPECTED;
@@ -161,14 +162,15 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
    * @param requestContext The request context that holds the headers needed proper query resolution
    * @return A pair consistigng of a purchase order and its order line
    */
-  public Future<Void> findAndSetPurchaseOrderPoLinePair(String poLineId, PiecesHolder holder, RequestContext requestContext) {
+  public Future<Void> findAndSetPurchaseOrderAndPoLine(String poLineId, PiecesHolder holder, RequestContext requestContext) {
     return purchaseOrderLineService.getOrderLineById(poLineId, requestContext)
       .compose(poLine -> purchaseOrderStorageService.getPurchaseOrderByIdAsJson(poLine.getPurchaseOrderId(), requestContext)
         .map(HelperUtils::convertToCompositePurchaseOrder)
         .map(purchaseOrder -> {
           logger.info("findAndSetPurchaseOrderPoLinePair:: Found purchase order & poLine, order id: {}, poLineId: {}",
             purchaseOrder.getId(), poLine.getId());
-          holder.withPurchaseOrderPoLinePair(Pair.of(purchaseOrder, poLine));
+          holder.withPurchaseOrder(purchaseOrder)
+            .withPoLine(poLine);
           return null;
         }));
   }
@@ -459,6 +461,23 @@ public abstract class CheckinReceivePiecesHelper<T> extends BaseHelper {
     }
     // If pieces were rolled-back to Expected we check if there is any Received piece in the storage
     return receivedPiecesQuantity == 0 ? AWAITING_RECEIPT : PARTIALLY_RECEIVED;
+  }
+
+  protected boolean skipOrderStatusUpdate(CompositePurchaseOrder compPo, List<PoLine> poLines, Map<String, List<Piece>> piecesGroupedByPoLine) {
+    if (CollectionUtils.isEmpty(poLines)) {
+      logger.info("updateOrderStatus::poLines empty, returning");
+      return true;
+    }
+    List<Piece> pieces = piecesGroupedByPoLine.values().stream().flatMap(List::stream).toList();
+    if (compPo.getWorkflowStatus() == CLOSED && pieces.stream().allMatch(piece -> piece.getReceivingStatus() == RECEIVED)) {
+      logger.info("updateOrderStatus::pieces are received and order is already closed, skip order status update");
+      return true;
+    }
+    if (compPo.getWorkflowStatus() == OPEN && pieces.stream().allMatch(piece -> piece.getReceivingStatus() == EXPECTED)) {
+      logger.info("updateOrderStatus::pieces are expected and order is already open, skip order status update");
+      return true;
+    }
+    return false;
   }
 
   //-------------------------------------------------------------------------------------

--- a/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderLineHelper.java
@@ -24,6 +24,7 @@ import static org.folio.service.finance.EncumbranceUtils.collectAllowedEncumbran
 import static org.folio.service.orders.utils.StatusUtils.areAllPoLinesCanceled;
 import static org.folio.service.orders.utils.StatusUtils.isStatusCanceledCompositePoLine;
 import static org.folio.service.orders.utils.StatusUtils.isStatusChanged;
+import static org.folio.service.orders.utils.StatusUtils.shouldTriggerOrderStatusUpdate;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -281,14 +282,14 @@ public class PurchaseOrderLineHelper {
           .compose(v -> validateAccessProviders(poLine, requestContext))
           .compose(v -> poLineValidationService.validateUserUnaffiliatedLocations(poLine.getId(), poLine.getLocations(), requestContext))
           .compose(v -> expenseClassValidationService.validateExpenseClassesForOpenedOrder(compOrder, Collections.singletonList(poLine), requestContext))
-          .compose(v -> processPoLineEncumbrances(compOrder, poLine, poLineFromStorage, requestContext)))
-        .map(v -> poLine.withPoLineNumber(poLineFromStorage.getPoLineNumber())) // PoLine number must not be modified during PoLine update, set original value
-        .map(v -> new PoLineInvoiceLineHolder(poLine, poLineFromStorage))
-        .compose(v -> createShadowInstanceIfNeeded(poLine, requestContext))
-        .compose(v -> updateOrderLineInStorage(poLine, requestContext))
-        .compose(v -> updateEncumbranceStatus(poLine, poLineFromStorage, requestContext))
-        .compose(v -> updateInventoryItemStatus(poLine, poLineFromStorage, requestContext))
-        .compose(v -> updateOrderStatusIfNeeded(poLine, poLineFromStorage, requestContext)));
+          .compose(v -> processPoLineEncumbrances(compOrder, poLine, poLineFromStorage, requestContext))
+          .map(v -> poLine.withPoLineNumber(poLineFromStorage.getPoLineNumber())) // PoLine number must not be modified during PoLine update, set original value
+          .map(v -> new PoLineInvoiceLineHolder(poLine, poLineFromStorage))
+          .compose(v -> createShadowInstanceIfNeeded(poLine, requestContext))
+          .compose(v -> updateOrderLineInStorage(poLine, requestContext))
+          .compose(v -> updateEncumbranceStatus(poLine, poLineFromStorage, requestContext))
+          .compose(v -> updateInventoryItemStatus(poLine, poLineFromStorage, requestContext))
+          .compose(v -> updateOrderStatusIfNeeded(compOrder, poLine, poLineFromStorage, requestContext))));
   }
 
   private Future<Void> updateEncumbranceStatus(PoLine compOrderLine, PoLine poLineFromStorage, RequestContext requestContext) {
@@ -651,9 +652,9 @@ public class PurchaseOrderLineHelper {
       });
   }
 
-  public Future<Void> updateOrderStatusIfNeeded(PoLine compOrderLine, PoLine poLineFromStorage, RequestContext requestContext) {
-    // See MODORDERS-218
-    if (isStatusChanged(compOrderLine, poLineFromStorage)) {
+  public Future<Void> updateOrderStatusIfNeeded(CompositePurchaseOrder compOrder, PoLine compOrderLine, PoLine poLineFromStorage,
+      RequestContext requestContext) {
+    if (shouldTriggerOrderStatusUpdate(compOrder, compOrderLine, poLineFromStorage)) {
       var updateOrderMessage = JsonObject.of(EVENT_PAYLOAD, JsonArray.of(JsonObject.of(ORDER_ID, compOrderLine.getPurchaseOrderId())));
       HelperUtils.sendEvent(MessageAddress.RECEIVE_ORDER_STATUS_UPDATE, updateOrderMessage, requestContext);
     }

--- a/src/main/java/org/folio/helper/ReceivingHelper.java
+++ b/src/main/java/org/folio/helper/ReceivingHelper.java
@@ -6,13 +6,13 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.EnumSet;
 import one.util.streamex.StreamEx;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.models.pieces.PiecesHolder;
 import org.folio.orders.events.handlers.MessageAddress;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.ProcessingStatus;
@@ -35,6 +35,8 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.folio.orders.utils.ResourcePathResolver.RECEIVING_HISTORY;
 import static org.folio.orders.utils.ResourcePathResolver.resourcesPath;
+import static org.folio.rest.jaxrs.model.Piece.ReceivingStatus.EXPECTED;
+import static org.folio.rest.jaxrs.model.Piece.ReceivingStatus.RECEIVED;
 
 public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
 
@@ -71,7 +73,7 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
   private Future<ReceivingResults> processReceiveItems(ReceivingCollection receivingCollection, RequestContext requestContext) {
     PiecesHolder holder = new PiecesHolder();
     // 1. Get purchase order and poLine from storage
-    return findAndSetPurchaseOrderPoLinePair(extractPoLineId(receivingCollection), holder, requestContext)
+    return findAndSetPurchaseOrderAndPoLine(extractPoLineId(receivingCollection), holder, requestContext)
       // 2. Get piece records from storage
       .compose(voidResult -> retrievePieceRecords(requestContext))
       // 3. Filter locationId
@@ -85,40 +87,33 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
       .map(this::updatePieceRecordsWithoutItems)
       // 6. Update received piece records in the storage
       .compose(piecesByPoLineIds -> storeUpdatedPieceRecords(piecesByPoLineIds, requestContext))
-      // 7. Update PO Line status
-      .compose(piecesByPoLineIds -> updateOrderAndPoLinesStatus(holder.getPiecesFromStorage(), piecesByPoLineIds, requestContext))
+      // 7. Update PO Line and order status
+      .compose(piecesByPoLineIds -> updateOrderAndPoLinesStatus(holder, piecesByPoLineIds, requestContext))
       // 8. Return results to the client
       .map(piecesGroupedByPoLine -> prepareResponseBody(receivingCollection, piecesGroupedByPoLine));
   }
 
-  private Future<Map<String, List<Piece>>> updateOrderAndPoLinesStatus(Map<String, List<Piece>> piecesFromStorage,
+  private Future<Map<String, List<Piece>>> updateOrderAndPoLinesStatus(PiecesHolder holder,
                                                                        Map<String, List<Piece>> piecesGroupedByPoLine,
                                                                        RequestContext requestContext) {
+    CompositePurchaseOrder compPo = holder.getPurchaseOrder();
+    Map<String, List<Piece>> piecesFromStorage = holder.getPiecesFromStorage();
     return updateOrderAndPoLinesStatus(
       piecesFromStorage,
       piecesGroupedByPoLine,
       requestContext,
-      poLines -> updateOrderStatus(poLines, requestContext)
+      poLines -> updateOrderStatus(compPo, poLines, piecesGroupedByPoLine, requestContext)
     );
   }
 
-  private void updateOrderStatus(List<PoLine> poLines, RequestContext requestContext) {
-    if (CollectionUtils.isEmpty(poLines)) {
-      logger.info("updateOrderStatus::poLines empty, returning");
+  private void updateOrderStatus(CompositePurchaseOrder compPo, List<PoLine> poLines, Map<String, List<Piece>> piecesGroupedByPoLine,
+      RequestContext requestContext) {
+    if (skipOrderStatusUpdate(compPo, poLines, piecesGroupedByPoLine)) {
       return;
     }
-    logger.debug("updateOrderStatus::Sending event to verify order status");
-
-    // Collect order ids which should be processed
-    List<JsonObject> poIds = StreamEx
-      .of(poLines)
-      .map(PoLine::getPurchaseOrderId)
-      .distinct()
-      .map(orderId -> new JsonObject().put(ORDER_ID, orderId))
-      .toList();
-
+    logger.debug("updateOrderStatus::Sending event to verify order status for {}", compPo.getId());
+    List<JsonObject> poIds = List.of(new JsonObject().put(ORDER_ID, compPo.getId()));
     sendMessage(MessageAddress.RECEIVE_ORDER_STATUS_UPDATE, new JsonArray(poIds), requestContext);
-
     logger.debug("updateOrderStatus::Event to verify order status - sent");
   }
 
@@ -234,10 +229,10 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
     // Piece record might be received or rolled-back to Expected if item status is "On-order" or "Order Closed"
     if (isOnOrderItemStatus(receivedItem)) {
       piece.setReceivedDate(null);
-      piece.setReceivingStatus(Piece.ReceivingStatus.EXPECTED);
+      piece.setReceivingStatus(EXPECTED);
     } else {
       piece.setReceivedDate(new Date());
-      piece.setReceivingStatus(Piece.ReceivingStatus.RECEIVED);
+      piece.setReceivingStatus(RECEIVED);
     }
   }
 
@@ -258,7 +253,7 @@ public class ReceivingHelper extends CheckinReceivePiecesHelper<ReceivedItem> {
 
   @Override
   protected boolean isRevertToOnOrder(Piece piece) {
-    return piece.getReceivingStatus() == Piece.ReceivingStatus.RECEIVED && isOnOrderItemStatus(getByPiece(piece));
+    return piece.getReceivingStatus() == RECEIVED && isOnOrderItemStatus(getByPiece(piece));
   }
 
   private boolean isOnOrderItemStatus(ReceivedItem receivedItem) {

--- a/src/main/java/org/folio/models/pieces/PiecesHolder.java
+++ b/src/main/java/org/folio/models/pieces/PiecesHolder.java
@@ -16,7 +16,8 @@ import java.util.Set;
 
 public class PiecesHolder {
 
-  private Pair<CompositePurchaseOrder, PoLine> purchaseOrderPoLinePair;
+  private CompositePurchaseOrder purchaseOrder;
+  private PoLine poLine;
   private Map<String, List<Piece>> piecesFromStorage;
   private Map<String, List<PiecePoLineDto>> itemsToRecreate;
   private Map<Pair<String, String>, Set<String>> piecesByHoldingIds;
@@ -66,8 +67,12 @@ public class PiecesHolder {
     }
   }
 
-  public Pair<CompositePurchaseOrder, PoLine> getPurchaseOrderPoLinePair() {
-    return purchaseOrderPoLinePair;
+  public CompositePurchaseOrder getPurchaseOrder() {
+    return purchaseOrder;
+  }
+
+  public PoLine getPoLine() {
+    return poLine;
   }
 
   public Map<String, List<Piece>> getPiecesFromStorage() {
@@ -86,8 +91,13 @@ public class PiecesHolder {
     return processedHoldingIds;
   }
 
-  public PiecesHolder withPurchaseOrderPoLinePair(Pair<CompositePurchaseOrder, PoLine> purchaseOrderPoLinePair) {
-    this.purchaseOrderPoLinePair = purchaseOrderPoLinePair;
+  public PiecesHolder withPurchaseOrder(CompositePurchaseOrder purchaseOrder) {
+    this.purchaseOrder = purchaseOrder;
+    return this;
+  }
+
+  public PiecesHolder withPoLine(PoLine poLine) {
+    this.poLine = poLine;
     return this;
   }
 
@@ -115,4 +125,5 @@ public class PiecesHolder {
     this.piecesByHoldingIds = piecesByHoldingIds;
     return this;
   }
+
 }

--- a/src/main/java/org/folio/service/inventory/InventoryUtils.java
+++ b/src/main/java/org/folio/service/inventory/InventoryUtils.java
@@ -273,12 +273,11 @@ public class InventoryUtils {
   }
 
   private static boolean isOrderClosedOrPoLineCancelled(PiecesHolder holder) {
-    var orderPoLinePair = holder.getPurchaseOrderPoLinePair();
-    if (Objects.isNull(orderPoLinePair)) {
+    var purchaseOrder = holder.getPurchaseOrder();
+    if (Objects.isNull(purchaseOrder)) {
       return false;
     }
-    var purchaseOrder = orderPoLinePair.getKey();
-    var poLine = orderPoLinePair.getValue();
+    var poLine = holder.getPoLine();
     return isPurchaseOrderClosedOrPoLineCancelled(purchaseOrder, poLine);
   }
 

--- a/src/main/java/org/folio/service/orders/utils/StatusUtils.java
+++ b/src/main/java/org/folio/service/orders/utils/StatusUtils.java
@@ -3,6 +3,7 @@ package org.folio.service.orders.utils;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.CloseReason;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLine.PaymentStatus;
@@ -18,6 +19,8 @@ import static org.folio.helper.CheckinReceivePiecesHelper.EXPECTED_STATUSES;
 import static org.folio.helper.CheckinReceivePiecesHelper.RECEIVED_STATUSES;
 import static org.folio.orders.utils.HelperUtils.REASON_CANCELLED;
 import static org.folio.orders.utils.HelperUtils.REASON_COMPLETE;
+import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.CLOSED;
+import static org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus.OPEN;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.AWAITING_RECEIPT;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.FULLY_RECEIVED;
 import static org.folio.rest.jaxrs.model.PoLine.ReceiptStatus.PARTIALLY_RECEIVED;
@@ -31,6 +34,11 @@ public class StatusUtils {
   public static boolean isStatusChanged(PoLine compOrderLine, PoLine lineFromStorage) {
     return !StringUtils.equals(lineFromStorage.getReceiptStatus().value(), compOrderLine.getReceiptStatus().value()) ||
       !StringUtils.equals(lineFromStorage.getPaymentStatus().value(), compOrderLine.getPaymentStatus().value());
+  }
+
+  public static boolean shouldTriggerOrderStatusUpdate(CompositePurchaseOrder compOrder, PoLine poLine, PoLine lineFromStorage) {
+    return (compOrder.getWorkflowStatus() == CLOSED && isCompletedPoLine(lineFromStorage) && !isCompletedPoLine(poLine)) ||
+      (compOrder.getWorkflowStatus() == OPEN && !isCompletedPoLine(lineFromStorage) && isCompletedPoLine(poLine));
   }
 
   public static boolean areAllPoLinesCanceled(List<PoLine> poLines) {
@@ -73,17 +81,12 @@ public class StatusUtils {
 
   private static boolean toBeReopened(PurchaseOrder purchaseOrder, List<PoLine> poLines) {
     return isOrderClosed(purchaseOrder)
-      && poLines.stream().anyMatch(StatusUtils::isNonResolutionPoLine);
+      && poLines.stream().anyMatch(line -> !isCompletedPoLine(line));
   }
 
   private static boolean isCompletedPoLine(PoLine line) {
     return resolutionPaymentStatus.contains(line.getPaymentStatus().value())
       && resolutionReceiptStatus.contains(line.getReceiptStatus().value());
-  }
-
-  private static boolean isNonResolutionPoLine(PoLine line) {
-    return !resolutionPaymentStatus.contains(line.getPaymentStatus().value())
-      && !resolutionReceiptStatus.contains(line.getReceiptStatus().value());
   }
 
   private static boolean isCancelledPoLine(PoLine poLine) {

--- a/src/main/java/org/folio/service/orders/utils/StatusUtils.java
+++ b/src/main/java/org/folio/service/orders/utils/StatusUtils.java
@@ -69,6 +69,10 @@ public class StatusUtils {
     return false;
   }
 
+  public static boolean poLinePaymentStatusIsFinal(PoLine poLine) {
+    return resolutionPaymentStatus.contains(poLine.getPaymentStatus().value());
+  }
+
   private static boolean toBeClosed(PurchaseOrder purchaseOrder, List<PoLine> poLines) {
     return isOrderOpen(purchaseOrder)
       && poLines.stream().allMatch(StatusUtils::isCompletedPoLine);

--- a/src/test/java/org/folio/helper/CheckinHelperIT.java
+++ b/src/test/java/org/folio/helper/CheckinHelperIT.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import org.apache.commons.lang3.tuple.Pair;
 import org.folio.ApiTestSuiteIT;
 import org.folio.models.pieces.PiecesHolder;
 import org.folio.rest.core.exceptions.ErrorCodes;
@@ -267,7 +266,7 @@ public class CheckinHelperIT {
             .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     PoLine poLine = new PoLine().withId(poLineId).withPurchaseOrderId(purchaseOrderId);
     PiecesHolder pieceHolder =
-        new PiecesHolder().withPurchaseOrderPoLinePair(Pair.of(purchaseOrder, poLine));
+        new PiecesHolder().withPurchaseOrder(purchaseOrder).withPoLine(poLine);
     CheckinCollection checkinCollection = getCheckinCollection(poLineId, pieceId);
     when(inventoryItemManager.updateItem(any(JsonObject.class), any(RequestContext.class)))
         .thenReturn(Future.succeededFuture());
@@ -298,7 +297,7 @@ public class CheckinHelperIT {
             .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     PoLine poLine = new PoLine().withId(poLineId).withPurchaseOrderId(purchaseOrderId);
     PiecesHolder pieceHolder =
-        new PiecesHolder().withPurchaseOrderPoLinePair(Pair.of(purchaseOrder, poLine));
+        new PiecesHolder().withPurchaseOrder(purchaseOrder).withPoLine(poLine);
     CheckinCollection checkinCollection = getCheckinCollection(poLineId, pieceId);
     when(inventoryItemManager.updateItem(any(JsonObject.class), any(RequestContext.class)))
         .thenReturn(
@@ -336,7 +335,7 @@ public class CheckinHelperIT {
             .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN);
     PoLine poLine = new PoLine().withId(poLineId).withPurchaseOrderId(purchaseOrderId);
     PiecesHolder pieceHolder =
-        new PiecesHolder().withPurchaseOrderPoLinePair(Pair.of(purchaseOrder, poLine));
+        new PiecesHolder().withPurchaseOrder(purchaseOrder).withPoLine(poLine);
     CheckinCollection checkinCollection = getCheckinCollection(poLineId, pieceId);
     when(inventoryItemManager.updateItem(any(JsonObject.class), any(RequestContext.class)))
         .thenReturn(Future.failedFuture(new HttpException(500, "Service failure")));

--- a/src/test/java/org/folio/orders/utils/StatusUtilsTest.java
+++ b/src/test/java/org/folio/orders/utils/StatusUtilsTest.java
@@ -12,12 +12,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.folio.CopilotGenerated;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.service.orders.utils.StatusUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @CopilotGenerated(partiallyGenerated = true)
 public class StatusUtilsTest {
@@ -55,6 +58,34 @@ public class StatusUtilsTest {
     poLine1.setPaymentStatus(PoLine.PaymentStatus.PENDING);
 
     assertFalse(StatusUtils.isStatusChanged(compOrderLine, poLine1));
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = {"Closed,Fully Paid,Awaiting Receipt,Awaiting Payment,Awaiting Receipt,false",
+      "Closed,Awaiting Payment,Fully Received,Awaiting Payment,Awaiting Receipt,false",
+      "Closed,Awaiting Payment,Awaiting Receipt,Fully Paid,Awaiting Receipt,false",
+      "Closed,Awaiting Payment,Fully Received,Awaiting Payment,Awaiting Receipt,false",
+      "Closed,Awaiting Payment,Fully Received,Fully Paid,Fully Received,true",
+      "Closed,Fully Paid,Awaiting Receipt,Fully Paid,Fully Received,true",
+      "Open,Fully Paid,Awaiting Receipt,Fully Paid,Fully Received,false",
+      "Open,Awaiting Payment,Fully Received,Fully Paid,Fully Received,false",
+      "Open,Fully Paid,Fully Received,Fully Paid,Awaiting Receipt,true",
+      "Open,Fully Paid,Fully Received,Awaiting Payment,Fully Received,true"
+    },
+    delimiterString = ",")
+  void shouldTriggerOrderStatusUpdateTest(String workflowStatus, String paymentStatus, String receiptStatus,
+      String storagePaymentStatus, String storageReceiptStatus, boolean expectedResult) {
+    CompositePurchaseOrder compOrder = new CompositePurchaseOrder()
+      .withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.fromValue(workflowStatus));
+    PoLine poLine = new PoLine()
+      .withPaymentStatus(PoLine.PaymentStatus.fromValue(paymentStatus))
+      .withReceiptStatus(PoLine.ReceiptStatus.fromValue(receiptStatus));
+    PoLine lineFromStorage = new PoLine()
+      .withPaymentStatus(PoLine.PaymentStatus.fromValue(storagePaymentStatus))
+      .withReceiptStatus(PoLine.ReceiptStatus.fromValue(storageReceiptStatus));
+    boolean result = StatusUtils.shouldTriggerOrderStatusUpdate(compOrder, poLine, lineFromStorage);
+    assertEquals(expectedResult, result);
   }
 
   @Test

--- a/src/test/java/org/folio/orders/utils/StatusUtilsTest.java
+++ b/src/test/java/org/folio/orders/utils/StatusUtilsTest.java
@@ -65,7 +65,7 @@ public class StatusUtilsTest {
     value = {"Closed,Fully Paid,Awaiting Receipt,Awaiting Payment,Awaiting Receipt,false",
       "Closed,Awaiting Payment,Fully Received,Awaiting Payment,Awaiting Receipt,false",
       "Closed,Awaiting Payment,Awaiting Receipt,Fully Paid,Awaiting Receipt,false",
-      "Closed,Awaiting Payment,Fully Received,Awaiting Payment,Awaiting Receipt,false",
+      "Closed,Awaiting Payment,Awaiting Receipt,Awaiting Payment,Fully Received,false",
       "Closed,Awaiting Payment,Fully Received,Fully Paid,Fully Received,true",
       "Closed,Fully Paid,Awaiting Receipt,Fully Paid,Fully Received,true",
       "Open,Fully Paid,Awaiting Receipt,Fully Paid,Fully Received,false",

--- a/src/test/java/org/folio/rest/impl/CheckinReceivingApiIT.java
+++ b/src/test/java/org/folio/rest/impl/CheckinReceivingApiIT.java
@@ -399,8 +399,8 @@ public class CheckinReceivingApiIT {
       assertThat(poLine.getReceiptDate(), is(nullValue()));
     }
 
-    // Verify message is sent via event bus
-    verifyCheckinOrderStatusUpdateEvent(1);
+    // Verify message is not sent via event bus
+    verifyCheckinOrderStatusUpdateEvent(0);
   }
 
   @Test
@@ -1050,8 +1050,8 @@ public class CheckinReceivingApiIT {
       assertThat(poLine.getReceiptDate(), is(nullValue()));
     }
 
-    // Verify no status updated for cancelled order but is updated for other POL statuses
-    verifyOrderStatusUpdateEvent(isPoLineCancelled ? 0 : 1);
+    // No order status is needed
+    verifyOrderStatusUpdateEvent(0);
   }
 
   @Test
@@ -2741,8 +2741,8 @@ public class CheckinReceivingApiIT {
       assertThat(poLine.getReceiptDate(), is(nullValue()));
     }
 
-    // Verify messages sent via event bus
-    verifyOrderStatusUpdateEvent(1);
+    // Verify messages not sent via event bus
+    verifyOrderStatusUpdateEvent(0);
   }
 
   @Test
@@ -2811,8 +2811,8 @@ public class CheckinReceivingApiIT {
       assertThat(poLine.getReceiptDate(), is(nullValue()));
     }
 
-    // Verify messages sent via event bus
-    verifyOrderStatusUpdateEvent(1);
+    // Verify messages not sent via event bus
+    verifyOrderStatusUpdateEvent(0);
   }
 
   private void checkResultWithErrors(CheckinCollection request, int expectedNumOfErrors) {

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiIT.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiIT.java
@@ -649,7 +649,7 @@ public class PurchaseOrderLinesApiIT {
     assertEquals(location.getQuantityPhysical(), location.getQuantity());
 
     // Verify messages sent via event bus
-    HandlersTestHelper.verifyOrderStatusUpdateEvent(1);
+    HandlersTestHelper.verifyOrderStatusUpdateEvent(0);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[MODORDERS-1439](https://folio-org.atlassian.net/browse/MODORDERS-1439) - Cancelling an invoice does not update order correctly

## Approach
Taking the current status of the order into account to decide whether to trigger an automatic status update based on a change to a po line status.

The following rules should be respected:
- A closed order should not be reopened when a line status is changed to final
- A closed order should not be reopened when the initial line statuses are non-final (because the order was not closed automatically)
- A closed order should be reopened when line statuses are changed from final to non-final
- An open order should not be closed when a line status is changed to non-final
- An open order should be closed when a status change makes both line statuses final

Similarly, when receiving or unreceiving a piece, the order status is only updated when it makes sense:
- When a piece is received, the order status is only updated if the order is not closed
- When a piece is unreceived, the order status is only updated if the order is not open

## Related PRs
- [mod-invoice](https://github.com/folio-org/mod-invoice/pull/617)
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2295)

---

## Pre-Review Checklist

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
