### PR TITLE
Trillium Bugfix v13.1.2 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-## 13.1.1 - Released (Trillium R2 2025)
+## 13.1.2 - Released (Trillium R1 2026)
+This release focused on fixing issue when received pieces are not counted, causing extra expected pieces to be created after opening previously unopened synchronized order.
+
+[Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.1.1...v13.1.2)
+
+### Bug Fixes
+* [MODORDERS-1421](https://folio-org.atlassian.net/browse/MODORDERS-1421) - ECS | Received pieces are not counted, causing extra expected pieces to be created after opening previously unopened synchronized order
+
+## 13.1.1 - Released (Trillium R1 2026)
 This release focused on fixing holdings and items creation/deletion logic when budget or ledger restrictions prevent operation
 
 [Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.0.0...v13.1.1)
@@ -8,7 +16,7 @@ This release focused on fixing holdings and items creation/deletion logic when b
 * [MODORDERS-1434](https://folio-org.atlassian.net/browse/MODORDERS-1434) - Batch create pieces: encumbrance is not updated
 * [MODORDERS-1415](https://folio-org.atlassian.net/browse/MODORDERS-1415) - Fix holdings and items creation/deletion logic when budget or ledger restrictions prevent operation
 
-## 13.1.0 - Released (Trillium R2 2025)
+## 13.1.0 - Released (Trillium R1 2026)
 This release focused on upgrading to Vert.x 5.0, improving holdings/instance connection handling, enhancing fiscal year and encumbrance logic, piece/receiving improvements, and a large round of bug fixes across the acquisitions flow.
 
 [Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.0.0...v13.1.0)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>13.1.2-SNAPSHOT</version>
+  <version>13.1.2</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v13.1.0</tag>
+    <tag>v13.1.2</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>13.1.2</version>
+  <version>13.1.3-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v13.1.2</tag>
+    <tag>v13.1.0</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/org/folio/service/inventory/InventoryItemManager.java
+++ b/src/main/java/org/folio/service/inventory/InventoryItemManager.java
@@ -189,49 +189,45 @@ public class InventoryItemManager {
       return Future.succeededFuture(Collections.emptyList());
     }
 
-    // Search for already existing items
-    return searchStorageExistingItems(poLine.getId(), location.getHoldingId(), piecesWithItemsQty, requestContext)
-      .compose(existingItems -> {
-        List<Future<List<Piece>>> pieces = new ArrayList<>(Piece.Format.values().length);
+    // Clone the request context once for the location's tenant, used for both item search and creation
+    return consortiumConfigurationService.cloneRequestContextIfNeeded(requestContext, location)
+      .compose(locationContext -> searchStorageExistingItems(poLine.getId(), location.getHoldingId(), piecesWithItemsQty, locationContext)
+        .compose(existingItems -> {
+          List<Future<List<Piece>>> pieces = new ArrayList<>(Piece.Format.values().length);
 
-        for (Map.Entry<Piece.Format, Integer> pieceEntry : piecesWithItemsQuantities.entrySet()) {
-          Piece.Format pieceFormat = pieceEntry.getKey();
-          Integer expectedQuantity = pieceEntry.getValue();
+          for (Map.Entry<Piece.Format, Integer> pieceEntry : piecesWithItemsQuantities.entrySet()) {
+            Piece.Format pieceFormat = pieceEntry.getKey();
+            Integer expectedQuantity = pieceEntry.getValue();
 
-          // The expected quantity might be zero for particular piece format if the PO Line's order format is P/E Mix
-          if (expectedQuantity > 0) {
-            // Depending on piece format get already existing existingItemIds and send requests to create missing existingItemIds
-            Piece pieceWithHoldingId = new Piece().withHoldingId(location.getHoldingId());
+            // The expected quantity might be zero for particular piece format if the PO Line's order format is P/E Mix
+            if (expectedQuantity > 0) {
+              // Depending on piece format get already existing existingItemIds and send requests to create missing existingItemIds
+              Piece pieceWithHoldingId = new Piece().withHoldingId(location.getHoldingId());
 
-            var future = consortiumConfigurationService.cloneRequestContextIfNeeded(requestContext, location)
-              .compose(updatedRequestContext -> {
-                List<String> existingItemIds;
-                if (pieceFormat == Piece.Format.ELECTRONIC) {
-                  existingItemIds = getElectronicItemIds(poLine, existingItems);
-                  return createMissingElectronicItems(comPO, poLine, pieceWithHoldingId,
-                    expectedQuantity - existingItemIds.size(), updatedRequestContext)
-                    .map(createdItemIds -> buildPieces(location, poLine, pieceFormat, createdItemIds, existingItemIds));
-                } else {
-                  existingItemIds = getPhysicalItemIds(poLine, existingItems);
-                  return createMissingPhysicalItems(comPO, poLine, pieceWithHoldingId,
-                    expectedQuantity - existingItemIds.size(), updatedRequestContext)
-                    .map(createdItemIds -> buildPieces(location, poLine, pieceFormat, createdItemIds, existingItemIds));
-                }
-              });
-            // Build piece records once new existingItemIds are created
-            pieces.add(future);
+              List<String> existingItemIds;
+              if (pieceFormat == Piece.Format.ELECTRONIC) {
+                existingItemIds = getElectronicItemIds(poLine, existingItems);
+                pieces.add(createMissingElectronicItems(comPO, poLine, pieceWithHoldingId,
+                  expectedQuantity - existingItemIds.size(), locationContext)
+                  .map(createdItemIds -> buildPieces(location, poLine, pieceFormat, createdItemIds, existingItemIds)));
+              } else {
+                existingItemIds = getPhysicalItemIds(poLine, existingItems);
+                pieces.add(createMissingPhysicalItems(comPO, poLine, pieceWithHoldingId,
+                  expectedQuantity - existingItemIds.size(), locationContext)
+                  .map(createdItemIds -> buildPieces(location, poLine, pieceFormat, createdItemIds, existingItemIds)));
+              }
+            }
           }
-        }
 
-        // Wait for all items to be created and corresponding pieces are built
-        return collectResultsOnSuccess(pieces)
-          .map(results -> {
-            validateItemsCreation(poLine.getId(), pieces.size(), results.size());
-            return results.stream()
-              .flatMap(List::stream)
-              .collect(toList());
-          });
-      });
+          // Wait for all items to be created and corresponding pieces are built
+          return collectResultsOnSuccess(pieces)
+            .map(results -> {
+              validateItemsCreation(poLine.getId(), pieces.size(), results.size());
+              return results.stream()
+                .flatMap(List::stream)
+                .collect(toList());
+            });
+        }));
   }
 
   private Future<List<JsonObject>> searchStorageExistingItems(String poLineId, String holdingId, int expectedQuantity,


### PR DESCRIPTION
## 13.1.2 - Released (Trillium R1 2026)
This release focused on fixing issue when received pieces are not counted, causing extra expected pieces to be created after opening previously unopened synchronized order.

[Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.1.1...v13.1.2)

### Bug Fixes
* [MODORDERS-1421](https://folio-org.atlassian.net/browse/MODORDERS-1421) - ECS | Received pieces are not counted, causing extra expected pieces to be created after opening previously unopened synchronized order