### PR TITLE
[MODINVOICE-647] Silently ignore changes to nextPolNumber

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -1,6 +1,7 @@
 package org.folio.helper;
 
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.folio.orders.utils.HelperUtils.NEXT_POL_NUMBER;
 import static org.folio.orders.utils.HelperUtils.PO_LINES;
 import static org.folio.orders.utils.HelperUtils.REASON_CANCELLED;
 import static org.folio.orders.utils.HelperUtils.WORKFLOW_STATUS;
@@ -338,6 +339,7 @@ public class PurchaseOrderHelper {
 
   public JsonObject validateIfPOProtectedAndOngoingFieldsChanged(CompositePurchaseOrder compPO,
                                                                  JsonObject compPOFromStorageJson) {
+    compPO.setNextPolNumber(compPOFromStorageJson.getInteger(NEXT_POL_NUMBER)); // UIOR-1544 workaround; ignore any change of nextPolNumber
     WorkflowStatus storagePOWorkflowStatus = WorkflowStatus.fromValue(compPOFromStorageJson.getString(WORKFLOW_STATUS));
     if (!PENDING.equals(storagePOWorkflowStatus)) {
       verifyProtectedFieldsChanged(getFieldNames(), compPOFromStorageJson, JsonObject.mapFrom(compPO));

--- a/src/main/java/org/folio/orders/utils/HelperUtils.java
+++ b/src/main/java/org/folio/orders/utils/HelperUtils.java
@@ -65,6 +65,7 @@ public class HelperUtils {
   public static final String PO_LINES_LIMIT_PROPERTY = "poLines-limit";
   public static final String LANG = "lang";
   public static final String WORKFLOW_STATUS = "workflowStatus";
+  public static final String NEXT_POL_NUMBER = "nextPolNumber";
 
   private HelperUtils() {
   }

--- a/src/main/java/org/folio/orders/utils/POProtectedFields.java
+++ b/src/main/java/org/folio/orders/utils/POProtectedFields.java
@@ -10,8 +10,7 @@ public enum POProtectedFields {
   APPROVED("approved"),
   ORDER_TYPE("orderType"),
   RE_ENCUMBER("reEncumber"),
-  TEMPLATE("template"),
-  NEXT_POL_NUMBER("nextPolNumber");
+  TEMPLATE("template");
 
   POProtectedFields(String field) {
     this.field = field;


### PR DESCRIPTION
## Purpose
[MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion

## Approach
Silently ignore changes to `nextPolNumber` (protected fields are only protected after order is opened).
This does not resolve the UI issue that it should get the latest version of an order after saving a line, before modifying it. But at least it won't affect line numbers anymore.

## Related PRs
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1307)
- and others

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
