### PR TITLE
[MODORDERS-1443]. Abandoned holding is not deleted after changing instance connection if related piece exists

### DIFF
--- a/src/main/java/org/folio/models/HoldingDataExclusionConfig.java
+++ b/src/main/java/org/folio/models/HoldingDataExclusionConfig.java
@@ -7,9 +7,10 @@ public record HoldingDataExclusionConfig(HoldingDataExclusionMode mode,
                                          Set<String> pendingPoLineIds,
                                          Set<String> excludePieceIds) {
 
+  // Must only be used by PURCHASE_ORDER_UNOPEN mode, because it is not concerned with Pieces
   public HoldingDataExclusionConfig(HoldingDataExclusionMode mode,
-                             Set<String> excludePoLinesIds,
-                             Set<String> pendingPoLineIds) {
+                                    Set<String> excludePoLinesIds,
+                                    Set<String> pendingPoLineIds) {
     this(mode, excludePoLinesIds, pendingPoLineIds, Set.of());
   }
 }

--- a/src/main/java/org/folio/service/HoldingDeletionService.java
+++ b/src/main/java/org/folio/service/HoldingDeletionService.java
@@ -47,7 +47,7 @@ public class HoldingDeletionService {
     if (Objects.isNull(holding) || holding.isEmpty()) {
       return Future.succeededFuture(Pair.of(false, new JsonObject()));
     }
-    log.info("getHoldingLinkedData:: Exclusion config, mode={}", exclusionConfig.mode());
+    log.info("getHoldingLinkedData:: Exclusion config mode={}", exclusionConfig.mode());
 
     var holdingId = holding.getString(ID);
     return consortiumUserTenantService.getUserTenantsIfNeeded(requestContext)

--- a/src/main/java/org/folio/service/HoldingDeletionService.java
+++ b/src/main/java/org/folio/service/HoldingDeletionService.java
@@ -47,6 +47,7 @@ public class HoldingDeletionService {
     if (Objects.isNull(holding) || holding.isEmpty()) {
       return Future.succeededFuture(Pair.of(false, new JsonObject()));
     }
+    log.info("getHoldingLinkedData:: Exclusion config, mode={}", exclusionConfig.mode());
 
     var holdingId = holding.getString(ID);
     return consortiumUserTenantService.getUserTenantsIfNeeded(requestContext)

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -282,15 +282,18 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
     for (var location : uniqueLocations) {
       var holdingId = location.getHoldingId();
       var locationContext = createContextWithNewTenantId(requestContext, location.getTenantId());
-      var exclusionConfig = new HoldingDataExclusionConfig(HoldingDataExclusionMode.PO_LINE_CHANGE_INSTANCE, Set.of(holder.getStoragePoLine().getId()), Set.of());
       var future = inventoryHoldingManager.getHoldingById(holdingId, true, locationContext)
-        .compose(holding -> holdingDeletionService.getHoldingLinkedData(holding, exclusionConfig, requestContext, locationContext)
-          .compose(deletableHoldings -> holdingDeletionService.deleteHoldingIfPossible(deletableHoldings, locationContext).map(deletableHoldings))
-          .compose(deletableHoldings -> asFuture(() -> {
-            var deletedHoldings = getDeletedHoldings(deletableHoldings);
-            holder.getDeletedHoldingIds().addAll(deletedHoldings);
-          }))
-        );
+        .compose(holding -> pieceStorageService.getPiecesByHoldingId(holdingId, requestContext)
+          .map(pieces -> Pair.of(holding, pieces.stream().map(Piece::getId).collect(Collectors.toSet()))))
+        .compose(holdingAndPieces -> {
+          var exclusionConfig = new HoldingDataExclusionConfig(HoldingDataExclusionMode.PO_LINE_CHANGE_INSTANCE, Set.of(holder.getStoragePoLine().getId()), Set.of(), holdingAndPieces.getRight());
+          return holdingDeletionService.getHoldingLinkedData(holdingAndPieces.getLeft(), exclusionConfig, requestContext, locationContext)
+            .compose(deletableHoldings -> holdingDeletionService.deleteHoldingIfPossible(deletableHoldings, locationContext).map(deletableHoldings))
+            .compose(deletableHoldings -> asFuture(() -> {
+              var deletedHoldings = getDeletedHoldings(deletableHoldings);
+              holder.getDeletedHoldingIds().addAll(deletedHoldings);
+            }));
+        });
       futures.add(future);
     }
     return collectResultsOnSuccess(futures)

--- a/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
+++ b/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
@@ -431,7 +431,7 @@ public class WithHoldingOrderLineUpdateInstanceStrategyTest {
     when(inventoryItemManager.batchUpdatePartialItems(any(), eq(requestContext))).thenReturn(succeededFuture(null));
     when(pieceStorageService.getPiecesByHoldingIds(holdingIds, requestContext)).thenReturn(succeededFuture(List.of(new Piece().withHoldingId(usedHoldingId))));
     when(purchaseOrderLineService.getPoLinesByHoldingIds(holdingIds, requestContext)).thenReturn(succeededFuture(List.of(new PoLine().withLocations(List.of(new Location().withHoldingId(usedHoldingId))))));
-    // getPiecesByHoldingId (singular) is called per-holding in deleteAbandonedHoldingsAndUpdateHolder to build excludePieceIds for HoldingDataExclusionConfig (4-arg constructor, ERM-3619 / PO_LINE_CHANGE_INSTANCE mode)
+    // getPiecesByHoldingId (singular) is called per-holding in deleteAbandonedHoldingsAndUpdateHolder to build excludePieceIds for HoldingDataExclusionConfig (4-arg constructor, PO_LINE_CHANGE_INSTANCE mode)
     when(pieceStorageService.getPiecesByHoldingId(eq(holdingIds.get(0)), any(RequestContext.class))).thenReturn(succeededFuture(List.of()));
     when(pieceStorageService.getPiecesByHoldingId(eq(holdingIds.get(1)), any(RequestContext.class))).thenReturn(succeededFuture(List.of()));
     when(pieceStorageService.getPiecesByHoldingId(eq(usedHoldingId), any(RequestContext.class))).thenReturn(succeededFuture(List.of(new Piece().withId(UUID.randomUUID().toString()).withHoldingId(usedHoldingId))));

--- a/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
+++ b/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
@@ -431,6 +431,10 @@ public class WithHoldingOrderLineUpdateInstanceStrategyTest {
     when(inventoryItemManager.batchUpdatePartialItems(any(), eq(requestContext))).thenReturn(succeededFuture(null));
     when(pieceStorageService.getPiecesByHoldingIds(holdingIds, requestContext)).thenReturn(succeededFuture(List.of(new Piece().withHoldingId(usedHoldingId))));
     when(purchaseOrderLineService.getPoLinesByHoldingIds(holdingIds, requestContext)).thenReturn(succeededFuture(List.of(new PoLine().withLocations(List.of(new Location().withHoldingId(usedHoldingId))))));
+    // getPiecesByHoldingId (singular) is called per-holding in deleteAbandonedHoldingsAndUpdateHolder to build excludePieceIds for HoldingDataExclusionConfig (4-arg constructor, ERM-3619 / PO_LINE_CHANGE_INSTANCE mode)
+    when(pieceStorageService.getPiecesByHoldingId(eq(holdingIds.get(0)), any(RequestContext.class))).thenReturn(succeededFuture(List.of()));
+    when(pieceStorageService.getPiecesByHoldingId(eq(holdingIds.get(1)), any(RequestContext.class))).thenReturn(succeededFuture(List.of()));
+    when(pieceStorageService.getPiecesByHoldingId(eq(usedHoldingId), any(RequestContext.class))).thenReturn(succeededFuture(List.of(new Piece().withId(UUID.randomUUID().toString()).withHoldingId(usedHoldingId))));
     when(batchTrackingService.createBatchTrackingRecord(anyString(), anyInt(), eq(requestContext))).thenReturn(succeededFuture());
     // Mock HoldingDeletionService methods
     when(holdingDeletionService.getHoldingLinkedData(any(), any(), any(), any())).thenAnswer(invocation -> {


### PR DESCRIPTION
### **Purpose**

- <https://folio-org.atlassian.net/browse/MODORDERS-1443>

### **Approach**

- Add Piece retrieval and their exclusion from inside of `HoldingDeletionService::getHoldingLinkedData`
- Update tests

> Snapshot PoLines and Pieces are correctly excluded, allowing the old holding to be deleted

```log
12:38:18:89 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  HoldingDeletionService getHoldingLinkedData:: Exclusion config mode=PO_LINE_CHANGE_INSTANCE
12:38:18:89 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  HoldingDeletionService getHoldingLinkedData:: Searching for linked poLines and pieces in tenant=diku by holding id=40ba26b4-8524-4a0c-9616-94fb3175474f
12:38:19:11 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  HoldingDeletionService excludePoLines:: PoLines before exclusion=[e8677a66-2722-4541-b167-0f38fceb9040], ids to exclude=[e8677a66-2722-4541-b167-0f38fceb9040], final poLines=[]
12:38:19:11 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  HoldingDeletionService excludePieces:: Pieces before exclusion=[7b34eb55-45e1-4a4d-b8dd-215e04f40508], ids to exclude=[7b34eb55-45e1-4a4d-b8dd-215e04f40508], final pieces=[]
12:38:19:11 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  HoldingDeletionService excludeItems:: Items before exclusion=[], ids to exclude=[e5364e09-2d26-4654-baa5-ad8d1c471212], final items=[]
12:38:19:12 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  HoldingDeletionService getUpdatePossibleForHolding:: holdingId=40ba26b4-8524-4a0c-9616-94fb3175474f, linkedPoLines=0, linkedPieces=0, linkedItems=0, isDeletable=true
12:38:19:12 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  HoldingDeletionService deleteHoldingIfPossible:: isDeletable=true, holdingId=40ba26b4-8524-4a0c-9616-94fb3175474f
12:38:19:22 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  OrderLinePatchOperationService updateInstanceForEresource:: Updating instance for eresource type with poLineId: 'e8677a66-2722-4541-b167-0f38fceb9040'
12:38:19:65 [419395/orders] [diku] [bbaf4f7e-6de9-48ac-b28a-20e315ff7658] [mod_orders] INFO  OrderLinePatchOperationService patch:: Successfully patched operation: Replace Instance Ref for poLineId: e8677a66-2722-4541-b167-0f38fceb9040
```