### PR TITLE
Trillium release v13.1.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## 13.1.4 - Released (Trillium R1 2026)
+This release focused on resolving issue with deleting abandoned holding if related piece exists.
+
+[Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.1.3...v13.1.4)
+
+### Bug Fixes
+* [MODORDERS-1443](https://folio-org.atlassian.net/browse/MODORDERS-1443) - Abandoned holding is not deleted after changing instance connection if related piece exists
+
 ## 13.1.3 - Released (Trillium R1 2026)
 This release focused on updaing acq-models schemas to fix issues with nextPoLineNumber and nextInvoiceLineNumber.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>13.1.4-SNAPSHOT</version>
+  <version>13.1.4</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v13.1.0</tag>
+    <tag>v13.1.4</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders</artifactId>
-  <version>13.1.4</version>
+  <version>13.1.5-SNAPSHOT</version>
 
   <name>Orders Business Logic</name>
   <description>Business logic to manage orders in FOLIO</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-orders.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders.git</developerConnection>
-    <tag>v13.1.4</tag>
+    <tag>v13.1.0</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/org/folio/models/HoldingDataExclusionConfig.java
+++ b/src/main/java/org/folio/models/HoldingDataExclusionConfig.java
@@ -7,9 +7,10 @@ public record HoldingDataExclusionConfig(HoldingDataExclusionMode mode,
                                          Set<String> pendingPoLineIds,
                                          Set<String> excludePieceIds) {
 
+  // Must only be used by PURCHASE_ORDER_UNOPEN mode, because it is not concerned with Pieces
   public HoldingDataExclusionConfig(HoldingDataExclusionMode mode,
-                             Set<String> excludePoLinesIds,
-                             Set<String> pendingPoLineIds) {
+                                    Set<String> excludePoLinesIds,
+                                    Set<String> pendingPoLineIds) {
     this(mode, excludePoLinesIds, pendingPoLineIds, Set.of());
   }
 }

--- a/src/main/java/org/folio/service/HoldingDeletionService.java
+++ b/src/main/java/org/folio/service/HoldingDeletionService.java
@@ -47,6 +47,7 @@ public class HoldingDeletionService {
     if (Objects.isNull(holding) || holding.isEmpty()) {
       return Future.succeededFuture(Pair.of(false, new JsonObject()));
     }
+    log.info("getHoldingLinkedData:: Exclusion config mode={}", exclusionConfig.mode());
 
     var holdingId = holding.getString(ID);
     return consortiumUserTenantService.getUserTenantsIfNeeded(requestContext)

--- a/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -282,15 +282,18 @@ public class WithHoldingOrderLineUpdateInstanceStrategy extends BaseOrderLineUpd
     for (var location : uniqueLocations) {
       var holdingId = location.getHoldingId();
       var locationContext = createContextWithNewTenantId(requestContext, location.getTenantId());
-      var exclusionConfig = new HoldingDataExclusionConfig(HoldingDataExclusionMode.PO_LINE_CHANGE_INSTANCE, Set.of(holder.getStoragePoLine().getId()), Set.of());
       var future = inventoryHoldingManager.getHoldingById(holdingId, true, locationContext)
-        .compose(holding -> holdingDeletionService.getHoldingLinkedData(holding, exclusionConfig, requestContext, locationContext)
-          .compose(deletableHoldings -> holdingDeletionService.deleteHoldingIfPossible(deletableHoldings, locationContext).map(deletableHoldings))
-          .compose(deletableHoldings -> asFuture(() -> {
-            var deletedHoldings = getDeletedHoldings(deletableHoldings);
-            holder.getDeletedHoldingIds().addAll(deletedHoldings);
-          }))
-        );
+        .compose(holding -> pieceStorageService.getPiecesByHoldingId(holdingId, requestContext)
+          .map(pieces -> Pair.of(holding, pieces.stream().map(Piece::getId).collect(Collectors.toSet()))))
+        .compose(holdingAndPieces -> {
+          var exclusionConfig = new HoldingDataExclusionConfig(HoldingDataExclusionMode.PO_LINE_CHANGE_INSTANCE, Set.of(holder.getStoragePoLine().getId()), Set.of(), holdingAndPieces.getRight());
+          return holdingDeletionService.getHoldingLinkedData(holdingAndPieces.getLeft(), exclusionConfig, requestContext, locationContext)
+            .compose(deletableHoldings -> holdingDeletionService.deleteHoldingIfPossible(deletableHoldings, locationContext).map(deletableHoldings))
+            .compose(deletableHoldings -> asFuture(() -> {
+              var deletedHoldings = getDeletedHoldings(deletableHoldings);
+              holder.getDeletedHoldingIds().addAll(deletedHoldings);
+            }));
+        });
       futures.add(future);
     }
     return collectResultsOnSuccess(futures)

--- a/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
+++ b/src/test/java/org/folio/service/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategyTest.java
@@ -431,6 +431,10 @@ public class WithHoldingOrderLineUpdateInstanceStrategyTest {
     when(inventoryItemManager.batchUpdatePartialItems(any(), eq(requestContext))).thenReturn(succeededFuture(null));
     when(pieceStorageService.getPiecesByHoldingIds(holdingIds, requestContext)).thenReturn(succeededFuture(List.of(new Piece().withHoldingId(usedHoldingId))));
     when(purchaseOrderLineService.getPoLinesByHoldingIds(holdingIds, requestContext)).thenReturn(succeededFuture(List.of(new PoLine().withLocations(List.of(new Location().withHoldingId(usedHoldingId))))));
+    // getPiecesByHoldingId (singular) is called per-holding in deleteAbandonedHoldingsAndUpdateHolder to build excludePieceIds for HoldingDataExclusionConfig (4-arg constructor, PO_LINE_CHANGE_INSTANCE mode)
+    when(pieceStorageService.getPiecesByHoldingId(eq(holdingIds.get(0)), any(RequestContext.class))).thenReturn(succeededFuture(List.of()));
+    when(pieceStorageService.getPiecesByHoldingId(eq(holdingIds.get(1)), any(RequestContext.class))).thenReturn(succeededFuture(List.of()));
+    when(pieceStorageService.getPiecesByHoldingId(eq(usedHoldingId), any(RequestContext.class))).thenReturn(succeededFuture(List.of(new Piece().withId(UUID.randomUUID().toString()).withHoldingId(usedHoldingId))));
     when(batchTrackingService.createBatchTrackingRecord(anyString(), anyInt(), eq(requestContext))).thenReturn(succeededFuture());
     // Mock HoldingDeletionService methods
     when(holdingDeletionService.getHoldingLinkedData(any(), any(), any(), any())).thenAnswer(invocation -> {


### PR DESCRIPTION
## 13.1.4 - Released (Trillium R1 2026)
This release focused on resolving issue with deleting abandoned holding if related piece exists.

[Full Changelog](https://github.com/folio-org/mod-orders/compare/v13.1.3...v13.1.4)

### Bug Fixes
* [MODORDERS-1443](https://folio-org.atlassian.net/browse/MODORDERS-1443) - Abandoned holding is not deleted after changing instance connection if related piece exists