### PR TITLE
MODORDERS-1452. Restore typed error propagation from mod-finance/mod-invoice in mod-orders after Vert.x 5 upgrade

### DIFF
--- a/src/main/java/org/folio/rest/core/RestClient.java
+++ b/src/main/java/org/folio/rest/core/RestClient.java
@@ -270,10 +270,10 @@ public class RestClient {
       .onFailure(t -> log.error("error occurred invoking POST {}", endpoint));
   }
 
-  private static <T> Future<HttpResponse<T>> convertHttpResponse(HttpResponse<T> response) {
+  static <T> Future<HttpResponse<T>> convertHttpResponse(HttpResponse<T> response) {
     return HttpResponseExpectation.SC_SUCCESS.test(response)
       ? Future.succeededFuture(response)
-      : Future.failedFuture(new HttpException(response.statusCode(), response.bodyAsString()));
+      : Future.failedFuture(getHttpException(response.statusCode(), response.bodyAsString()));
   }
 
 }

--- a/src/test/java/org/folio/rest/core/RestClientTest.java
+++ b/src/test/java/org/folio/rest/core/RestClientTest.java
@@ -4,13 +4,23 @@ import static org.folio.TestConstants.X_OKAPI_TOKEN;
 import static org.folio.TestConstants.X_OKAPI_USER_ID;
 import static org.folio.rest.RestConstants.OKAPI_URL;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.core.exceptions.ErrorCodes.GENERIC_ERROR_CODE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
+import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -24,6 +34,8 @@ public class RestClientTest {
   private Context ctxMock;
   @Mock
   private WebClient httpClient;
+  @Mock
+  private HttpResponse<Buffer> bufferResponseMock;
 
   private Map<String, String> okapiHeaders;
   private RequestContext requestContext;
@@ -39,6 +51,51 @@ public class RestClientTest {
     requestContext = new RequestContext(ctxMock, okapiHeaders);
   }
 
+  @Test
+  void convertHttpResponseShouldSucceedForSuccessStatus() {
+    when(bufferResponseMock.statusCode()).thenReturn(200);
+
+    Future<HttpResponse<Buffer>> result = RestClient.convertHttpResponse(bufferResponseMock);
+
+    assertTrue(result.succeeded());
+    assertEquals(bufferResponseMock, result.result());
+  }
+
+  @Test
+  void convertHttpResponseShouldParseJsonErrorsBody() {
+    String errorJson = """
+      {
+        "errors" : [ {
+          "message" : "Cannot convert UAH into USD",
+          "code" : "cannotConvertAmountInvalidCurrency",
+          "parameters" : [ ]
+        } ],
+        "total_records" : 1
+      }""";
+    when(bufferResponseMock.statusCode()).thenReturn(404);
+    when(bufferResponseMock.bodyAsString()).thenReturn(errorJson);
+
+    Future<HttpResponse<Buffer>> result = RestClient.convertHttpResponse(bufferResponseMock);
+
+    assertTrue(result.failed());
+    HttpException ex = assertInstanceOf(HttpException.class, result.cause());
+    assertEquals(404, ex.getCode());
+    assertEquals("cannotConvertAmountInvalidCurrency", ex.getError().getCode());
+    assertEquals("Cannot convert UAH into USD", ex.getError().getMessage());
+  }
+
+  @Test
+  void convertHttpResponseShouldFallbackToGenericErrorForPlainTextBody() {
+    when(bufferResponseMock.statusCode()).thenReturn(500);
+    when(bufferResponseMock.bodyAsString()).thenReturn("Module failure");
+
+    Future<HttpResponse<Buffer>> result = RestClient.convertHttpResponse(bufferResponseMock);
+
+    assertTrue(result.failed());
+    HttpException ex = assertInstanceOf(HttpException.class, result.cause());
+    assertEquals(500, ex.getCode());
+    assertEquals(GENERIC_ERROR_CODE.getCode(), ex.getError().getCode());
+    assertEquals("Module failure", ex.getError().getMessage());
+  }
+
 }
-
-


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODORDERS-1452

### **Approach**
Use exsiting method getHttpException that is used before that is capable to process json errors from downstream services
https://github.com/folio-org/mod-orders/commit/348049f789e0ba0c71b4ab50e26502b5de4080c6#diff-f695200a0953f109601e796e8d77f7e2bb1eb261935eb7aebb76b3045c7eeb1aL37
---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
