### PR TITLE
[MODFISTO-559] Remove order type selection for rollover

### DIFF
--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -154,7 +154,7 @@ public class OrderRolloverService {
     // Rollover the orders by funds without ever loading all orders or all order lines into memory.
     // Batches are optimized to avoid processing too few or too many at a time.
     logger.info("rolloverOrders(openOrders={}):: start", openOrders);
-    var poIdIterator = getOrderIds(fundIds, ledgerFYRollover, openOrders, requestContext);
+    var poIdIterator = getOrderIds(fundIds, openOrders, requestContext);
     var poLinesIterator = getPoLines(poIdIterator, requestContext);
     var lineHolderIterator = getEncumbrances(poLinesIterator, ledgerFYRollover, requestContext);
     var modifiedPoLineIterator = FutureIterator.applyFunction(lineHolderIterator,
@@ -167,8 +167,7 @@ public class OrderRolloverService {
   /**
    * Get the order ids from orders matching the funds, without loading all orders into memory
    */
-  private FutureIterator<String> getOrderIds(List<String> fundIds, LedgerFiscalYearRollover ledgerFYRollover,
-      boolean openOrders, RequestContext requestContext) {
+  private FutureIterator<String> getOrderIds(List<String> fundIds, boolean openOrders, RequestContext requestContext) {
     var fundIdsIterator = FutureIterator.chunk(FutureIterator.fromIterator(fundIds.listIterator()), MAX_IDS_FOR_GET_RQ_15);
     var posIteratorIterator = FutureIterator.applyFunction(fundIdsIterator,
       fundIdsChunk -> {

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -172,7 +172,7 @@ public class OrderRolloverService {
     var fundIdsIterator = FutureIterator.chunk(FutureIterator.fromIterator(fundIds.listIterator()), MAX_IDS_FOR_GET_RQ_15);
     var posIteratorIterator = FutureIterator.applyFunction(fundIdsIterator,
       fundIdsChunk -> {
-        String baseQuery = buildBaseOrderQuery(fundIdsChunk, openOrders, ledgerFYRollover);
+        String baseQuery = buildBaseOrderQuery(fundIdsChunk, openOrders);
         return succeededFuture(purchaseOrderStorageService.getPurchaseOrderIterator(baseQuery, requestContext));
       });
     var poIterator = FutureIterator.dechunk(FutureIterator.flatten(posIteratorIterator));
@@ -188,7 +188,7 @@ public class OrderRolloverService {
     });
   }
 
-  protected String buildBaseOrderQuery(List<String> fundIds, boolean openOrders, LedgerFiscalYearRollover ledgerFYRollover) {
+  protected String buildBaseOrderQuery(List<String> fundIds, boolean openOrders) {
     StringBuilder resultQuery = new StringBuilder();
     resultQuery.append("(").append(buildOrderStatusQuery(openOrders)).append(")")
       .append(AND)

--- a/src/main/java/org/folio/service/orders/OrderRolloverService.java
+++ b/src/main/java/org/folio/service/orders/OrderRolloverService.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
@@ -41,12 +40,10 @@ import org.folio.rest.core.exceptions.ErrorCodes;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Cost;
-import org.folio.rest.jaxrs.model.EncumbranceRollover;
 import org.folio.rest.jaxrs.model.FundDistribution;
 import org.folio.rest.jaxrs.model.FundDistribution.DistributionType;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRollover;
 import org.folio.rest.jaxrs.model.PoLine;
-import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.RolloverStatus;
 import org.folio.service.caches.CommonSettingsCache;
 import org.folio.service.exchange.CacheableExchangeRateService;
@@ -69,7 +66,6 @@ public class OrderRolloverService {
   // Following cql query filters orders whose po lines do not contain 'encumbrance' value in the entire fundDistribution array.
   // That condition skips orders already processed in previous fiscal years.
   private static final String PO_LINE_NON_EMPTY_ENCUMBRANCE_QUERY = "poLine.fundDistribution == \"*\\\"encumbrance\\\": \\\"*\"";
-  private static final String ORDER_TYPE_QUERY = "orderType == %s";
   private static final String ENCUMBR_FY_QUERY = "fiscalYearId == \"%s\"";
   private static final String OR = " or ";
   private static final String AND = " and ";
@@ -194,9 +190,6 @@ public class OrderRolloverService {
 
   protected String buildBaseOrderQuery(List<String> fundIds, boolean openOrders, LedgerFiscalYearRollover ledgerFYRollover) {
     StringBuilder resultQuery = new StringBuilder();
-    if (!ledgerFYRollover.getEncumbrancesRollover().isEmpty()) {
-      resultQuery.append("(").append(buildOrderTypesQuery(ledgerFYRollover)).append(")").append(AND);
-    }
     resultQuery.append("(").append(buildOrderStatusQuery(openOrders)).append(")")
       .append(AND)
       .append("(").append(buildFundIdQuery(fundIds)).append(")");
@@ -205,22 +198,6 @@ public class OrderRolloverService {
       resultQuery.append(AND).append("(").append(PO_LINE_NON_EMPTY_ENCUMBRANCE_QUERY).append(")");
     }
     return resultQuery.toString();
-  }
-
-  private String buildOrderTypesQuery(LedgerFiscalYearRollover ledgerFYRollover) {
-    return ledgerFYRollover.getEncumbrancesRollover().stream()
-      .map(encumbrancesRollover -> convertToOrderType(encumbrancesRollover.getOrderType()))
-      .map(PurchaseOrder.OrderType::toString)
-      .distinct()
-      .map(orderType -> String.format(ORDER_TYPE_QUERY, orderType))
-      .collect(Collectors.joining(OR));
-  }
-
-  private PurchaseOrder.OrderType convertToOrderType(EncumbranceRollover.OrderType encumberRolloverType) {
-    if (EncumbranceRollover.OrderType.ONE_TIME == encumberRolloverType) {
-      return PurchaseOrder.OrderType.ONE_TIME;
-    }
-    return PurchaseOrder.OrderType.ONGOING;
   }
 
   private String buildOrderStatusQuery(boolean openOrders) {

--- a/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
@@ -763,27 +763,6 @@ public class OrderRolloverServiceTest {
   private static Stream<Arguments> testBuildOrderQueryArgs() {
     return Stream.of(
       Arguments.of("(workflowStatus==Open) and (poLine.fundDistribution =/@fundId (%s))",
-        true,
-        List.of(new EncumbranceRollover().withOrderType(EncumbranceRollover.OrderType.ONE_TIME).withBasedOn(EncumbranceRollover.BasedOn.INITIAL_AMOUNT).withIncreaseBy(0d))),
-      Arguments.of("(workflowStatus<>Open) and (poLine.fundDistribution =/@fundId (%s)) and (poLine.fundDistribution == \"*\\\"encumbrance\\\": \\\"*\")",
-        false,
-        List.of(new EncumbranceRollover().withOrderType(EncumbranceRollover.OrderType.ONE_TIME).withBasedOn(EncumbranceRollover.BasedOn.INITIAL_AMOUNT).withIncreaseBy(0d)))
-    );
-  }
-
-  @ParameterizedTest
-  @MethodSource("testBuildOrderQueryArgs")
-  void testBuildOrderQuery(String expectedQueryTemplate, boolean openOrders, List<EncumbranceRollover> encumbranceRollovers) {
-    var fundId = UUID.randomUUID().toString();
-    var ledgerFiscalYearRollover = new LedgerFiscalYearRollover().withId(UUID.randomUUID().toString()).withEncumbrancesRollover(encumbranceRollovers);
-    var expectedQuery = String.format(expectedQueryTemplate, fundId);
-    var actualQuery = orderRolloverService.buildBaseOrderQuery(List.of(fundId), openOrders, ledgerFiscalYearRollover);
-    Assertions.assertEquals(expectedQuery, actualQuery);
-  }
-
-  private static Stream<Arguments> testBuildOrderQueryWithoutSettingsArgs() {
-    return Stream.of(
-      Arguments.of("(workflowStatus==Open) and (poLine.fundDistribution =/@fundId (%s))",
         true),
       Arguments.of("(workflowStatus<>Open) and (poLine.fundDistribution =/@fundId (%s)) and (poLine.fundDistribution == \"*\\\"encumbrance\\\": \\\"*\")",
         false)
@@ -791,12 +770,11 @@ public class OrderRolloverServiceTest {
   }
 
   @ParameterizedTest
-  @MethodSource("testBuildOrderQueryWithoutSettingsArgs")
-  void testBuildOrderQueryWithoutSettings(String expectedQueryTemplate, boolean openOrders) {
+  @MethodSource("testBuildOrderQueryArgs")
+  void testBuildOrderQuery(String expectedQueryTemplate, boolean openOrders) {
     var fundId = UUID.randomUUID().toString();
-    var ledgerFiscalYearRollover = new LedgerFiscalYearRollover().withId(UUID.randomUUID().toString()).withEncumbrancesRollover(List.of());
     var expectedQuery = String.format(expectedQueryTemplate, fundId);
-    var actualQuery = orderRolloverService.buildBaseOrderQuery(List.of(fundId), openOrders, ledgerFiscalYearRollover);
+    var actualQuery = orderRolloverService.buildBaseOrderQuery(List.of(fundId), openOrders);
     Assertions.assertEquals(expectedQuery, actualQuery);
   }
 }

--- a/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
+++ b/src/test/java/org/folio/service/orders/OrderRolloverServiceTest.java
@@ -762,10 +762,10 @@ public class OrderRolloverServiceTest {
 
   private static Stream<Arguments> testBuildOrderQueryArgs() {
     return Stream.of(
-      Arguments.of("(orderType == One-Time) and (workflowStatus==Open) and (poLine.fundDistribution =/@fundId (%s))",
+      Arguments.of("(workflowStatus==Open) and (poLine.fundDistribution =/@fundId (%s))",
         true,
         List.of(new EncumbranceRollover().withOrderType(EncumbranceRollover.OrderType.ONE_TIME).withBasedOn(EncumbranceRollover.BasedOn.INITIAL_AMOUNT).withIncreaseBy(0d))),
-      Arguments.of("(orderType == One-Time) and (workflowStatus<>Open) and (poLine.fundDistribution =/@fundId (%s)) and (poLine.fundDistribution == \"*\\\"encumbrance\\\": \\\"*\")",
+      Arguments.of("(workflowStatus<>Open) and (poLine.fundDistribution =/@fundId (%s)) and (poLine.fundDistribution == \"*\\\"encumbrance\\\": \\\"*\")",
         false,
         List.of(new EncumbranceRollover().withOrderType(EncumbranceRollover.OrderType.ONE_TIME).withBasedOn(EncumbranceRollover.BasedOn.INITIAL_AMOUNT).withIncreaseBy(0d)))
     );


### PR DESCRIPTION
## Purpose
[MODFISTO-559](https://folio-org.atlassian.net/browse/MODFISTO-559) - Fix ledger rollover logic to handle encumbrances correctly when only one type is selected

## Approach
Encumbrances of orders in the rolled over ledger but not selected by order type are also affected by the rollover for open orders, because we create released encumbrances for them. So we should not select orders by type when processing them. This PR simply removes that selection.

## Related PRs
- [mod-finance-storage](https://github.com/folio-org/mod-finance-storage/pull/559)
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2390)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
