### PR TITLE
[MODORDERS-1449] Check invoice lines when opening order to set encumbrance status

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -319,13 +319,12 @@ public class ApplicationConfig {
   }
 
   @Bean
-  EncumbranceWorkflowStrategy pendingToOpenEncumbranceStrategy(EncumbranceService encumbranceService,
-          FundsDistributionService fundsDistributionService, BudgetRestrictionService budgetRestrictionService,
-          EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder,
-          EncumbrancesProcessingHolderBuilder encumbrancesProcessingHolderBuilder, POLInvoiceLineRelationService polInvoiceLineRelationService) {
-    return new PendingToOpenEncumbranceStrategy(encumbranceService, fundsDistributionService,
-                                                budgetRestrictionService, encumbranceRelationsHoldersBuilder,
-                                                encumbrancesProcessingHolderBuilder, polInvoiceLineRelationService);
+  EncumbranceWorkflowStrategy pendingToOpenEncumbranceStrategy(EncumbranceService encumbranceService, FundsDistributionService fundsDistributionService,
+      BudgetRestrictionService budgetRestrictionService, EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder,
+      EncumbrancesProcessingHolderBuilder encumbrancesProcessingHolderBuilder, POLInvoiceLineRelationService polInvoiceLineRelationService,
+      InvoiceLineService invoiceLineService) {
+    return new PendingToOpenEncumbranceStrategy(encumbranceService, fundsDistributionService, budgetRestrictionService,
+      encumbranceRelationsHoldersBuilder, encumbrancesProcessingHolderBuilder, polInvoiceLineRelationService, invoiceLineService);
   }
 
   @Bean

--- a/src/main/java/org/folio/models/EncumbranceRelationsHolder.java
+++ b/src/main/java/org/folio/models/EncumbranceRelationsHolder.java
@@ -24,6 +24,7 @@ public class EncumbranceRelationsHolder {
   private Transaction oldEncumbrance;
   private String ledgerId;
   private boolean restrictEncumbrance;
+  private boolean invoiceWithReleaseEncumbrance;
 
   public EncumbranceRelationsHolder withNewEncumbrance(Transaction transaction) {
     this.newEncumbrance = transaction;
@@ -152,5 +153,14 @@ public class EncumbranceRelationsHolder {
 
   public String getCurrentFiscalYearId() {
     return currentFiscalYearId;
+  }
+
+  public EncumbranceRelationsHolder withInvoiceWithReleaseEncumbrance(boolean invoiceWithReleaseEncumbrance) {
+    this.invoiceWithReleaseEncumbrance = invoiceWithReleaseEncumbrance;
+    return this;
+  }
+
+  public boolean getInvoiceWithReleaseEncumbrance() {
+    return invoiceWithReleaseEncumbrance;
   }
 }

--- a/src/main/java/org/folio/service/finance/EncumbranceUtils.java
+++ b/src/main/java/org/folio/service/finance/EncumbranceUtils.java
@@ -87,15 +87,4 @@ public class EncumbranceUtils {
       && encumbrance.getAmountCredited() == 0
       && encumbrance.getAmountAwaitingPayment() == 0);
   }
-
-  public static boolean allowEncumbranceToReleaseOnReopen(Encumbrance encumbrance) {
-    if (Objects.isNull(encumbrance)) {
-      log.warn("allowEncumbranceToReleaseOnReopen:: Invalid transaction or encumbrance");
-      return false;
-    }
-    return encumbrance.getStatus() == Encumbrance.Status.PENDING
-      && (encumbrance.getAmountExpended() > 0
-      || encumbrance.getAmountCredited() > 0
-      || encumbrance.getAmountAwaitingPayment() > 0);
-  }
 }

--- a/src/main/java/org/folio/service/finance/transaction/EncumbranceRelationsHoldersBuilder.java
+++ b/src/main/java/org/folio/service/finance/transaction/EncumbranceRelationsHoldersBuilder.java
@@ -29,7 +29,8 @@ import org.folio.service.finance.budget.BudgetService;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
-import static org.folio.service.finance.EncumbranceUtils.allowEncumbranceToReleaseOnReopen;
+import static org.folio.rest.acq.model.finance.Encumbrance.Status.PENDING;
+import static org.folio.rest.acq.model.finance.Encumbrance.Status.RELEASED;
 
 public class EncumbranceRelationsHoldersBuilder extends FinanceHoldersBuilder {
 
@@ -165,9 +166,8 @@ public class EncumbranceRelationsHoldersBuilder extends FinanceHoldersBuilder {
           .withAmountExpended(existingEncumbrance.getAmountExpended())
           .withAmountCredited(existingEncumbrance.getAmountCredited())
           .withAmountAwaitingPayment(existingEncumbrance.getAmountAwaitingPayment());
-        // release if encumbrance amountExpended + amountCredited + amountAwaitingPayment > 0 (if we have approved/paid invoices)
-        if (existingEncumbrance.getStatus() == Encumbrance.Status.RELEASED || allowEncumbranceToReleaseOnReopen(existingEncumbrance))
-          newTransaction.getEncumbrance().setStatus(Encumbrance.Status.RELEASED);
+        if (existingEncumbrance.getStatus() == RELEASED || (existingEncumbrance.getStatus() == PENDING && holder.getInvoiceWithReleaseEncumbrance()))
+          newTransaction.getEncumbrance().setStatus(RELEASED);
       }));
   }
 

--- a/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
@@ -91,6 +91,9 @@ public class PendingToOpenEncumbranceStrategy implements EncumbranceWorkflowStra
   }
 
   private Future<Void> withInvoiceWithReleaseEncumbrance(String fiscalYearId, List<EncumbranceRelationsHolder> holders, RequestContext requestContext) {
+    if (holders.isEmpty()) {
+      return Future.succeededFuture();
+    }
     List<String> polIds = holders.stream()
       .map(EncumbranceRelationsHolder::getPoLineId)
       .distinct()

--- a/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
@@ -118,7 +118,7 @@ public class PendingToOpenEncumbranceStrategy implements EncumbranceWorkflowStra
   private String queryToGetRelatedInvoiceLinesByPoLineIds(String fiscalYearId, List<String> poLineIds) {
     return "invoiceLineStatus == (Approved OR Paid)" + AND +
       "releaseEncumbrance == true" + AND +
-      (fiscalYearId == null ? "" : "invoices.fiscalYearId == " + fiscalYearId + AND) +
+      "invoices.fiscalYearId == " + fiscalYearId + AND +
       convertIdsToCqlQuery(poLineIds, "poLineId");
   }
 }

--- a/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
@@ -99,7 +99,7 @@ public class PendingToOpenEncumbranceStrategy implements EncumbranceWorkflowStra
       .distinct()
       .toList();
     return invoiceLineService.getInvoiceLinesByIdsAndQuery(polIds,
-        ids -> queryToGetRelatedInvoiceLinesByPoLineIds(fiscalYearId, polIds), requestContext)
+        ids -> queryToGetRelatedInvoiceLinesByPoLineIds(fiscalYearId, ids), requestContext)
       .map(invoiceLines -> {
         Map<String, List<InvoiceLine>> polIdToInvoiceLine = invoiceLines.stream()
           .collect(groupingBy(InvoiceLine::getPoLineId));

--- a/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
+++ b/src/main/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategy.java
@@ -1,16 +1,21 @@
 package org.folio.service.finance.transaction;
 
+import static java.util.stream.Collectors.groupingBy;
 import static org.folio.orders.utils.FundDistributionUtils.validateFundDistributionTotal;
+import static org.folio.orders.utils.QueryUtils.convertIdsToCqlQuery;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import lombok.extern.log4j.Log4j2;
 import org.folio.models.EncumbranceRelationsHolder;
+import org.folio.rest.acq.model.invoice.InvoiceLine;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.service.FundsDistributionService;
 import org.folio.service.finance.budget.BudgetRestrictionService;
+import org.folio.service.invoice.InvoiceLineService;
 import org.folio.service.invoice.POLInvoiceLineRelationService;
 import org.folio.service.orders.OrderWorkflowType;
 
@@ -19,22 +24,27 @@ import io.vertx.core.Future;
 @Log4j2
 public class PendingToOpenEncumbranceStrategy implements EncumbranceWorkflowStrategy {
 
+  private static final String AND = " AND ";
+
   private final EncumbranceService encumbranceService;
   private final FundsDistributionService fundsDistributionService;
   private final BudgetRestrictionService budgetRestrictionService;
   private final EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder;
   private final EncumbrancesProcessingHolderBuilder encumbrancesProcessingHolderBuilder;
   private final POLInvoiceLineRelationService polInvoiceLineRelationService;
+  private final InvoiceLineService invoiceLineService;
 
   public PendingToOpenEncumbranceStrategy(EncumbranceService encumbranceService, FundsDistributionService fundsDistributionService,
-                                          BudgetRestrictionService budgetRestrictionService, EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder,
-                                          EncumbrancesProcessingHolderBuilder encumbrancesProcessingHolderBuilder, POLInvoiceLineRelationService polInvoiceLineRelationService) {
+      BudgetRestrictionService budgetRestrictionService, EncumbranceRelationsHoldersBuilder encumbranceRelationsHoldersBuilder,
+      EncumbrancesProcessingHolderBuilder encumbrancesProcessingHolderBuilder, POLInvoiceLineRelationService polInvoiceLineRelationService,
+      InvoiceLineService invoiceLineService) {
     this.encumbranceService = encumbranceService;
     this.fundsDistributionService = fundsDistributionService;
     this.budgetRestrictionService = budgetRestrictionService;
     this.encumbranceRelationsHoldersBuilder = encumbranceRelationsHoldersBuilder;
     this.encumbrancesProcessingHolderBuilder = encumbrancesProcessingHolderBuilder;
     this.polInvoiceLineRelationService = polInvoiceLineRelationService;
+    this.invoiceLineService = invoiceLineService;
   }
 
   @Override
@@ -52,14 +62,9 @@ public class PendingToOpenEncumbranceStrategy implements EncumbranceWorkflowStra
     validateFundDistributionTotal(compPO.getPoLines());
     List<EncumbranceRelationsHolder> holders = encumbranceRelationsHoldersBuilder.buildBaseHolders(compPO);
     return encumbranceRelationsHoldersBuilder.withFinances(holders, requestContext)
-      .compose(v -> {
-        holders.stream()
-          .filter(Objects::nonNull)
-          .filter(holder -> Objects.nonNull(holder.getCurrentFiscalYearId()))
-          .findFirst().map(EncumbranceRelationsHolder::getCurrentFiscalYearId)
-          .ifPresent(compPO::withFiscalYearId);
-        return encumbranceRelationsHoldersBuilder.withExistingTransactions(holders, poAndLinesFromStorage, requestContext);
-      })
+      .map(v -> getFiscalYearId(holders, compPO))
+      .compose(fiscalYearId -> withInvoiceWithReleaseEncumbrance(fiscalYearId, holders, requestContext))
+      .compose(v -> encumbranceRelationsHoldersBuilder.withExistingTransactions(holders, poAndLinesFromStorage, requestContext))
       .map(v -> fundsDistributionService.distributeFunds(holders))
       .map(dataHolders -> {
         budgetRestrictionService.checkEncumbranceRestrictions(dataHolders);
@@ -71,5 +76,46 @@ public class PendingToOpenEncumbranceStrategy implements EncumbranceWorkflowStra
   @Override
   public OrderWorkflowType getStrategyName() {
     return OrderWorkflowType.PENDING_TO_OPEN;
+  }
+
+  private String getFiscalYearId(List<EncumbranceRelationsHolder> holders, CompositePurchaseOrder compPO) {
+    String fiscalYearId = holders.stream()
+      .map(EncumbranceRelationsHolder::getCurrentFiscalYearId)
+      .filter(Objects::nonNull)
+      .findFirst()
+      .orElse(null);
+    if (fiscalYearId != null) {
+      compPO.setFiscalYearId(fiscalYearId);
+    }
+    return fiscalYearId;
+  }
+
+  private Future<Void> withInvoiceWithReleaseEncumbrance(String fiscalYearId, List<EncumbranceRelationsHolder> holders, RequestContext requestContext) {
+    List<String> polIds = holders.stream()
+      .map(EncumbranceRelationsHolder::getPoLineId)
+      .distinct()
+      .toList();
+    return invoiceLineService.getInvoiceLinesByIdsAndQuery(polIds,
+        ids -> queryToGetRelatedInvoiceLinesByPoLineIds(fiscalYearId, polIds), requestContext)
+      .map(invoiceLines -> {
+        Map<String, List<InvoiceLine>> polIdToInvoiceLine = invoiceLines.stream()
+          .collect(groupingBy(InvoiceLine::getPoLineId));
+        holders.forEach(holder -> {
+          List<InvoiceLine> relatedInvoiceLines = polIdToInvoiceLine.get(holder.getPoLineId());
+          if (relatedInvoiceLines == null) {
+            holder.withInvoiceWithReleaseEncumbrance(false);
+          } else {
+            holder.withInvoiceWithReleaseEncumbrance(relatedInvoiceLines.stream().anyMatch(InvoiceLine::getReleaseEncumbrance));
+          }
+        });
+        return null;
+      });
+  }
+
+  private String queryToGetRelatedInvoiceLinesByPoLineIds(String fiscalYearId, List<String> poLineIds) {
+    return "invoiceLineStatus == (Approved OR Paid)" + AND +
+      "releaseEncumbrance == true" + AND +
+      (fiscalYearId == null ? "" : "invoices.fiscalYearId == " + fiscalYearId + AND) +
+      convertIdsToCqlQuery(poLineIds, "poLineId");
   }
 }

--- a/src/main/java/org/folio/service/invoice/InvoiceLineService.java
+++ b/src/main/java/org/folio/service/invoice/InvoiceLineService.java
@@ -10,6 +10,7 @@ import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ_15;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -75,6 +76,18 @@ public class InvoiceLineService {
     return collectResultsOnSuccess(futures)
       .map(listList -> listList.stream().flatMap(Collection::stream).collect(toList()))
       .map(invoiceLines -> invoiceLines.stream().distinct().collect(Collectors.toList()));
+  }
+
+  public Future<List<InvoiceLine>> getInvoiceLinesByIdsAndQuery(List<String> ids,
+      Function<List<String>, String> queryFunction, RequestContext requestContext) {
+    List<Future<List<InvoiceLine>>> futureList = StreamEx
+      .ofSubLists(ids, MAX_IDS_FOR_GET_RQ_15)
+      .map(queryFunction)
+      .map(query -> retrieveInvoiceLines(query, requestContext))
+      .toList();
+
+    return collectResultsOnSuccess(futureList)
+      .map(col -> col.stream().flatMap(List::stream).toList());
   }
 
   public Future<Void> removeEncumbranceLinks(List<InvoiceLine> invoiceLines, List<String> transactionIds, RequestContext requestContext) {

--- a/src/main/java/org/folio/service/invoice/POLInvoiceLineRelationService.java
+++ b/src/main/java/org/folio/service/invoice/POLInvoiceLineRelationService.java
@@ -51,6 +51,9 @@ public class POLInvoiceLineRelationService {
     var forDelete = processingHolder.getEncumbrancesForDelete().stream()
       .map(EncumbranceRelationsHolder::getOldEncumbrance)
       .toList();
+    if (forDelete.isEmpty()) {
+      return Future.succeededFuture(processingHolder);
+    }
     var forCreate = processingHolder.getEncumbrancesForCreate().stream()
       .map(EncumbranceRelationsHolder::getNewEncumbrance)
       .toList();
@@ -63,10 +66,7 @@ public class POLInvoiceLineRelationService {
          invoiceLineService.getInvoiceLinesByOrderLineIds(poLineIds, requestContext)
           .compose(invoiceLines -> {
             validateInvoiceLineStatuses(invoiceLines);
-            if (forCreate.isEmpty() && forDelete.isEmpty()) {
-              return Future.succeededFuture(processingHolder);
-            }
-            if (!forCreate.isEmpty() && !forDelete.isEmpty()) {
+            if (!forCreate.isEmpty()) {
               var currency = getCurrency(processingHolder);
               var invoiceFiscalYearId = invoices.stream()
                 .filter(Objects::nonNull)
@@ -74,11 +74,7 @@ public class POLInvoiceLineRelationService {
                 .findFirst().orElse("");
               var matchingReleaseYear = StringUtils.equals(processingHolder.getCurrentFiscalYearId(), invoiceFiscalYearId);
               copyAmountsAndRecalculateNewEncumbrance(matchingReleaseYear, forCreate, forDelete, invoiceLines, currency);
-            }
-            if (forDelete.isEmpty()) {
-              return Future.succeededFuture(processingHolder);
-            }
-            if (forCreate.isEmpty()) {
+            } else {
               forDelete.forEach(TransactionValidator::validateEncumbranceForDeletion);
             }
             var encumbranceForDeleteIds = forDelete.stream()

--- a/src/test/java/org/folio/service/finance/EncumbranceUtilsTest.java
+++ b/src/test/java/org/folio/service/finance/EncumbranceUtilsTest.java
@@ -254,50 +254,31 @@ public class EncumbranceUtilsTest {
     assertEquals(expected, invokeHasReleaseEncumbranceFalseAndIsApprovedOrPaid(payment, List.of(invoiceLine)));
   }
 
-  // 5. allowEncumbranceToUnrelease & allowEncumbranceToReleaseOnReopen (public)
+  // 5. allowEncumbranceToUnrelease (public)
   @ParameterizedTest
   @CsvSource({
-    // allowEncumbranceToUnrelease
-    "RELEASED,0,0,0,true",
-    "RELEASED,1,0,0,false",
-    "RELEASED,0,1,0,false",
-    "RELEASED,0,0,1,false",
-    "PENDING,0,0,0,false",
-    // allowEncumbranceToReleaseOnReopen
-    "PENDING,1,0,0,true",
-    "PENDING,0,1,0,true",
-    "PENDING,0,0,1,true",
-    "PENDING,0,0,0,false",
-    "RELEASED,1,0,0,false"
+    "0,0,0,true",
+    "1,0,0,false",
+    "0,1,0,false",
+    "0,0,1,false"
   })
-  void testAllowEncumbranceToUnrelease_and_ReleaseOnReopen(
-    Encumbrance.Status status,
+  void testAllowEncumbranceToUnrelease(
     double amountExpended,
     double amountCredited,
     double amountAwaitingPayment,
     boolean expected
   ) {
     var encumbrance = mock(Encumbrance.class);
-    when(encumbrance.getStatus()).thenReturn(status);
+    when(encumbrance.getStatus()).thenReturn(Encumbrance.Status.RELEASED);
     when(encumbrance.getAmountExpended()).thenReturn(amountExpended);
     when(encumbrance.getAmountCredited()).thenReturn(amountCredited);
     when(encumbrance.getAmountAwaitingPayment()).thenReturn(amountAwaitingPayment);
 
     var transaction = mock(Transaction.class);
     when(transaction.getEncumbrance()).thenReturn(encumbrance);
-    // Test allowEncumbranceToUnrelease
-    var allowUnrelease = EncumbranceUtils.allowEncumbranceToUnrelease(transaction);
-    if (status == Encumbrance.Status.RELEASED) {
-      assertEquals(expected, allowUnrelease);
-    }
 
-    // Test allowEncumbranceToReleaseOnReopen
-    var allowRelease = EncumbranceUtils.allowEncumbranceToReleaseOnReopen(encumbrance);
-    if (status == Encumbrance.Status.PENDING) {
-      assertEquals(expected, allowRelease);
-    } else {
-      assertFalse(allowRelease);
-    }
+    var allowUnrelease = EncumbranceUtils.allowEncumbranceToUnrelease(transaction);
+    assertEquals(expected, allowUnrelease);
   }
 
   // Reflection helpers for private methods

--- a/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
@@ -281,8 +281,6 @@ public class PendingToOpenEncumbranceStrategyTest {
     doReturn(succeededFuture(invoiceLines))
       .doReturn(succeededFuture(invoiceLines))
       .when(invoiceLineService).getInvoiceLinesByOrderLineIds(anyList(), eq(requestContext));
-    doReturn(succeededFuture(invoiceLines))
-      .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
     String expectedQuery = "awaitingPayment.encumbranceId==(" + encumbranceId + ")";
     doReturn(succeededFuture(pendingPayments))
       .when(transactionService).getTransactions(expectedQuery, requestContext);
@@ -358,8 +356,6 @@ public class PendingToOpenEncumbranceStrategyTest {
 
     doReturn(succeededFuture(null))
       .when(invoiceService).getInvoicesByOrderId(nullable(String.class), eq(requestContext));
-    doReturn(succeededFuture(List.of()))
-      .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
     doReturn(succeededFuture(List.of()))
       .when(invoiceLineService).getInvoiceLinesByOrderLineIds(anyList(), eq(requestContext));
     doReturn(succeededFuture(singletonList(released)))

--- a/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
@@ -118,7 +118,7 @@ public class PendingToOpenEncumbranceStrategyTest {
       pendingPaymentService);
     pendingToOpenEncumbranceStrategy = new PendingToOpenEncumbranceStrategy(encumbranceService,
       fundsDistributionService, budgetRestrictionService, encumbranceRelationsHoldersBuilder,
-      encumbrancesProcessingHolderBuilder, polInvoiceLineRelationService);
+      encumbrancesProcessingHolderBuilder, polInvoiceLineRelationService, invoiceLineService);
   }
 
   @Test
@@ -185,7 +185,8 @@ public class PendingToOpenEncumbranceStrategyTest {
       .withFiscalYearId(fiscalYearId);
     InvoiceLine invoiceLine = new InvoiceLine()
       .withId(invoiceLineId)
-      .withInvoiceLineStatus(InvoiceLine.InvoiceLineStatus.CANCELLED);
+      .withInvoiceLineStatus(InvoiceLine.InvoiceLineStatus.CANCELLED)
+      .withPoLineId(poLine.getId());
 
     doReturn(Future.succeededFuture(exchangeRate))
       .when(cacheableExchangeRateService).getExchangeRate(any(), any(), any(), eq(requestContext));
@@ -193,6 +194,8 @@ public class PendingToOpenEncumbranceStrategyTest {
       .when(invoiceService).getInvoicesByOrderId(nullable(String.class), eq(requestContext));
     doReturn(succeededFuture(List.of(invoiceLine)))
       .when(invoiceLineService).getInvoiceLinesByOrderLineIds(anyList(), eq(requestContext));
+    doReturn(succeededFuture(List.of(invoiceLine)))
+      .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
     doReturn(succeededFuture(singletonList(released)))
       .when(transactionService).getTransactionsByIds(argThat(list -> list.size() == 1), eq(requestContext));
     doReturn(succeededFuture(null))
@@ -256,7 +259,8 @@ public class PendingToOpenEncumbranceStrategyTest {
       .withFiscalYearId(fiscalYearId);
     InvoiceLine invoiceLine = new InvoiceLine()
       .withId(invoiceLineId)
-      .withInvoiceLineStatus(InvoiceLine.InvoiceLineStatus.CANCELLED);
+      .withInvoiceLineStatus(InvoiceLine.InvoiceLineStatus.CANCELLED)
+      .withPoLineId(poLine.getId());
     List<InvoiceLine> invoiceLines = List.of(invoiceLine);
 
     Transaction pendingPayment = new Transaction()
@@ -277,6 +281,8 @@ public class PendingToOpenEncumbranceStrategyTest {
     doReturn(succeededFuture(invoiceLines))
       .doReturn(succeededFuture(invoiceLines))
       .when(invoiceLineService).getInvoiceLinesByOrderLineIds(anyList(), eq(requestContext));
+    doReturn(succeededFuture(invoiceLines))
+      .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
     String expectedQuery = "awaitingPayment.encumbranceId==(" + encumbranceId + ")";
     doReturn(succeededFuture(pendingPayments))
       .when(transactionService).getTransactions(expectedQuery, requestContext);
@@ -352,6 +358,8 @@ public class PendingToOpenEncumbranceStrategyTest {
 
     doReturn(succeededFuture(null))
       .when(invoiceService).getInvoicesByOrderId(nullable(String.class), eq(requestContext));
+    doReturn(succeededFuture(List.of()))
+      .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
     doReturn(succeededFuture(List.of()))
       .when(invoiceLineService).getInvoiceLinesByOrderLineIds(anyList(), eq(requestContext));
     doReturn(succeededFuture(singletonList(released)))
@@ -431,6 +439,8 @@ public class PendingToOpenEncumbranceStrategyTest {
       .when(cacheableExchangeRateService).getExchangeRate(any(), any(), any(), eq(requestContext));
     doReturn(Future.succeededFuture(List.of(transaction)))
       .when(transactionService).getTransactionsByIds(anyList(), eq(requestContext));
+    doReturn(succeededFuture(List.of()))
+      .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
 
     // When
     Future<List<EncumbranceRelationsHolder>> future = pendingToOpenEncumbranceStrategy

--- a/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
+++ b/src/test/java/org/folio/service/finance/transaction/PendingToOpenEncumbranceStrategyTest.java
@@ -42,9 +42,13 @@ import org.folio.rest.acq.model.finance.Metadata;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.acq.model.invoice.Invoice;
 import org.folio.rest.acq.model.invoice.InvoiceLine;
+import org.folio.rest.acq.model.invoice.InvoiceLine.InvoiceLineStatus;
 import org.folio.rest.core.exceptions.HttpException;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder.OrderType;
+import org.folio.rest.jaxrs.model.CompositePurchaseOrder.WorkflowStatus;
+import org.folio.rest.jaxrs.model.Cost;
 import org.folio.rest.jaxrs.model.FundDistribution;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.PoLine;
@@ -62,6 +66,8 @@ import org.folio.service.orders.OrderInvoiceRelationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -130,7 +136,6 @@ public class PendingToOpenEncumbranceStrategyTest {
     String fundId1 = fd1.getFundId();
     String fundId2 = "1b6d3338-186e-4e35-9e75-1b886b0da53e";
     String encumbranceId = fd1.getEncumbrance();
-    String invoiceId = UUID.randomUUID().toString();
     String invoiceLineId = UUID.randomUUID().toString();
 
     CompositePurchaseOrder orderFromStorage = JsonObject.mapFrom(order).mapTo(CompositePurchaseOrder.class);
@@ -180,20 +185,13 @@ public class PendingToOpenEncumbranceStrategyTest {
     doReturn(Future.succeededFuture(List.of(budget1, budget2)))
       .when(budgetService).getBudgetsByQuery(anyString(), any());
 
-    Invoice invoice = new Invoice()
-      .withId(invoiceId)
-      .withFiscalYearId(fiscalYearId);
     InvoiceLine invoiceLine = new InvoiceLine()
       .withId(invoiceLineId)
-      .withInvoiceLineStatus(InvoiceLine.InvoiceLineStatus.CANCELLED)
+      .withInvoiceLineStatus(InvoiceLineStatus.CANCELLED)
       .withPoLineId(poLine.getId());
 
     doReturn(Future.succeededFuture(exchangeRate))
       .when(cacheableExchangeRateService).getExchangeRate(any(), any(), any(), eq(requestContext));
-    doReturn(succeededFuture(List.of(invoice)))
-      .when(invoiceService).getInvoicesByOrderId(nullable(String.class), eq(requestContext));
-    doReturn(succeededFuture(List.of(invoiceLine)))
-      .when(invoiceLineService).getInvoiceLinesByOrderLineIds(anyList(), eq(requestContext));
     doReturn(succeededFuture(List.of(invoiceLine)))
       .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
     doReturn(succeededFuture(singletonList(released)))
@@ -259,7 +257,7 @@ public class PendingToOpenEncumbranceStrategyTest {
       .withFiscalYearId(fiscalYearId);
     InvoiceLine invoiceLine = new InvoiceLine()
       .withId(invoiceLineId)
-      .withInvoiceLineStatus(InvoiceLine.InvoiceLineStatus.CANCELLED)
+      .withInvoiceLineStatus(InvoiceLineStatus.CANCELLED)
       .withPoLineId(poLine.getId());
     List<InvoiceLine> invoiceLines = List.of(invoiceLine);
 
@@ -449,6 +447,122 @@ public class PendingToOpenEncumbranceStrategyTest {
         assertEquals(1, holders.size());
         var holder = holders.getFirst();
         assertEquals(fiscalYearId, holder.getCurrentFiscalYearId());
+        vertxTestContext.completeNow();
+      }))
+      .onFailure(vertxTestContext::failNow);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "false,false,Unreleased",
+    "false,true,Released",
+    "true,true,Released"
+  })
+  void testSettingHolderWithInvoiceWithReleaseEncumbrance(boolean releaseEncumbrance1, boolean releaseEncumbrance2,
+      String expectedStatus, VertxTestContext vertxTestContext) {
+    // Given
+    FiscalYear fiscalYear = new FiscalYear()
+      .withId(UUID.randomUUID().toString())
+      .withCurrency("USD");
+    Ledger ledger = new Ledger()
+      .withId(UUID.randomUUID().toString());
+    Fund fund = new Fund()
+      .withId(UUID.randomUUID().toString())
+      .withLedgerId(ledger.getId());
+    FundDistribution fd = new FundDistribution()
+      .withFundId(fund.getId())
+      .withDistributionType(FundDistribution.DistributionType.PERCENTAGE)
+      .withValue(100d)
+      .withCode("CODE");
+    Budget budget = new Budget()
+      .withId(UUID.randomUUID().toString())
+      .withFundId(fund.getId())
+      .withFiscalYearId(fiscalYear.getId());
+    Cost cost = new Cost()
+      .withListUnitPrice(10.0)
+      .withCurrency("USD")
+      .withQuantityPhysical(1)
+      .withPoLineEstimatedPrice(10.0);
+    PoLine poLine = new PoLine()
+      .withId(UUID.randomUUID().toString())
+      .withFundDistribution(List.of(fd))
+      .withCost(cost);
+    CompositePurchaseOrder order = new CompositePurchaseOrder()
+      .withId(UUID.randomUUID().toString())
+      .withWorkflowStatus(WorkflowStatus.OPEN)
+      .withOrderType(OrderType.ONE_TIME)
+      .withPoLines(List.of(poLine));
+    Encumbrance encumbrance = new Encumbrance()
+      .withSourcePurchaseOrderId(order.getId())
+      .withSourcePoLineId(poLine.getId())
+      .withOrderType(Encumbrance.OrderType.fromValue(order.getOrderType().value()))
+      .withInitialAmountEncumbered(10d)
+      .withOrderStatus(Encumbrance.OrderStatus.PENDING)
+      .withStatus(Encumbrance.Status.PENDING);
+    Transaction transaction = new Transaction()
+      .withTransactionType(ENCUMBRANCE)
+      .withAmount(0d)
+      .withId(UUID.randomUUID().toString())
+      .withFromFundId(fund.getId())
+      .withEncumbrance(encumbrance)
+      .withMetadata(new Metadata());
+    fd.setEncumbrance(transaction.getId());
+    Invoice invoice1 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(fiscalYear.getId());
+    Invoice invoice2 = new Invoice()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(fiscalYear.getId());
+    InvoiceLine invoiceLine1 = new InvoiceLine()
+      .withId(UUID.randomUUID().toString())
+      .withInvoiceId(invoice1.getId())
+      .withInvoiceLineStatus(InvoiceLineStatus.APPROVED)
+      .withPoLineId(poLine.getId())
+      .withReleaseEncumbrance(releaseEncumbrance1);
+    InvoiceLine invoiceLine2 = new InvoiceLine()
+      .withId(UUID.randomUUID().toString())
+      .withInvoiceId(invoice2.getId())
+      .withInvoiceLineStatus(InvoiceLineStatus.PAID)
+      .withPoLineId(poLine.getId())
+      .withReleaseEncumbrance(releaseEncumbrance2);
+    List<InvoiceLine> invoiceLines = List.of(invoiceLine1, invoiceLine2);
+
+    CompositePurchaseOrder orderFromStorage = JsonObject.mapFrom(order)
+      .mapTo(CompositePurchaseOrder.class)
+      .withWorkflowStatus(WorkflowStatus.PENDING);
+
+    doReturn(Future.succeededFuture(List.of(fund)))
+      .when(fundService).getAllFunds(anyCollection(), any());
+    doReturn(Future.succeededFuture(List.of(ledger)))
+      .when(ledgerService).getLedgersByIds(anyCollection(), any());
+    doReturn(Future.succeededFuture(fiscalYear))
+      .when(fiscalYearService).getCurrentFiscalYear(anyString(), any());
+    doReturn(Future.succeededFuture(List.of(budget)))
+      .when(budgetService).getBudgetsByQuery(anyString(), any());
+
+    doReturn(Future.succeededFuture(exchangeRate))
+      .when(cacheableExchangeRateService).getExchangeRate(any(), any(), any(), eq(requestContext));
+    doReturn(succeededFuture(invoiceLines))
+      .when(invoiceLineService).getInvoiceLinesByIdsAndQuery(anyList(), any(), eq(requestContext));
+    doReturn(succeededFuture(singletonList(transaction)))
+      .when(transactionService).getTransactionsByIds(argThat(list -> list.size() == 1), eq(requestContext));
+    doReturn(succeededFuture(null))
+      .when(transactionService).batchAllOrNothing(any(), any(), any(), any(), eq(requestContext));
+
+    // When
+    Future<Void> future = pendingToOpenEncumbranceStrategy.processEncumbrances(order, orderFromStorage, requestContext);
+
+    // Then
+    vertxTestContext.assertComplete(future)
+      .onSuccess(result -> vertxTestContext.verify(() -> {
+        verify(transactionService, times(1))
+          .batchAllOrNothing(any(), transactionListCaptor.capture(), any(), any(), eq(requestContext));
+        verify(transactionService, times(1))
+          .getTransactionsByIds(anyList(), eq(requestContext));
+        List<List<Transaction>> transactionLists = transactionListCaptor.getAllValues();
+        assertEquals(1, transactionLists.size());
+        assertEquals(1, transactionLists.getFirst().size());
+        assertEquals(Encumbrance.Status.fromValue(expectedStatus), transactionLists.getFirst().getFirst().getEncumbrance().getStatus());
         vertxTestContext.completeNow();
       }))
       .onFailure(vertxTestContext::failNow);

--- a/src/test/java/org/folio/service/invoice/InvoiceLineServiceTest.java
+++ b/src/test/java/org/folio/service/invoice/InvoiceLineServiceTest.java
@@ -1,5 +1,7 @@
 package org.folio.service.invoice;
 
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.orders.utils.QueryUtils.encodeQuery;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -27,6 +29,7 @@ import org.folio.rest.core.models.RequestEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -197,5 +200,26 @@ public class InvoiceLineServiceTest {
 
     assertTrue(result.succeeded());
     assertEquals("enc1", invoiceLine.getFundDistributions().get(0).getEncumbrance());
+  }
+
+  @Test
+  public void testGetInvoiceLinesByIdsAndQuery() {
+    List<String> ids = List.of("id1", "id2");
+    List<InvoiceLine> invoiceLines = List.of(new InvoiceLine());
+    InvoiceLineCollection invoiceLineCollection = new InvoiceLineCollection()
+      .withInvoiceLines(invoiceLines)
+      .withTotalRecords(1);
+
+    ArgumentCaptor<RequestEntry> requestEntryCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+    when(restClient.get(requestEntryCaptor.capture(), eq(InvoiceLineCollection.class), eq(requestContextMock)))
+      .thenReturn(succeededFuture(invoiceLineCollection));
+
+    Future<List<InvoiceLine>> future = invoiceLineService.getInvoiceLinesByIdsAndQuery(ids, Object::toString, requestContextMock);
+
+    assertTrue(future.succeeded());
+    verify(restClient, times(1)).get(any(RequestEntry.class), any(), any(RequestContext.class));
+    List<RequestEntry> requestEntries = requestEntryCaptor.getAllValues();
+    assertEquals(encodeQuery(ids.toString()), requestEntries.getFirst().getQueryParams().get("query"));
+    assertEquals(invoiceLines, future.result());
   }
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-1449](https://folio-org.atlassian.net/browse/MODORDERS-1449) - Encumbrance is released after un-opening the order with related Paid invoice (release encumbrance = false)

## Approach
When opening an order, check the related invoice lines to determine if encumbrances should be unreleased or released.

## Related PR
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2393)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
