### PR TITLE
MODORDSTOR-488. Introduce header to bypath settings cache for Karate

### DIFF
--- a/src/main/java/org/folio/service/caches/AbstractConfigCache.java
+++ b/src/main/java/org/folio/service/caches/AbstractConfigCache.java
@@ -9,6 +9,7 @@ import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.tools.utils.TenantTool;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.function.BiFunction;
 
 @Log4j2
@@ -17,18 +18,30 @@ import java.util.function.BiFunction;
 public class AbstractConfigCache {
 
   private static final String UNIQUE_CACHE_KEY_PATTERN = "%s_%s";
+  public static final String BYPASS_CACHE_HEADER = "x-okapi-bypass-cache";
 
   protected <T> Future<T> cacheData(String url, String query, AsyncCache<String, T> cache,
                                     BiFunction<RequestEntry, RequestContext, Future<T>> configExtractor,
                                     boolean byPassCache, RequestContext requestContext) {
     var requestEntry = new RequestEntry(url).withQuery(query).withOffset(0).withLimit(Integer.MAX_VALUE);
     var cacheKey = buildUniqueKey(requestEntry, requestContext);
-    log.debug("loadSettingsData:: Loading setting data, url: '{}', query: '{}', bypass-cache mode: '{}'", url, query, byPassCache);
-    if (byPassCache) {
+    boolean cacheBypassRequested = isCacheBypassRequested(requestContext.getHeaders());
+    log.debug("loadSettingsData:: Loading setting data, url: '{}', query: '{}', bypass-cache mode: '{}', cache-bypass header: '{}'",
+      url, query, byPassCache, cacheBypassRequested);
+    if (byPassCache || cacheBypassRequested) {
       return extractData(configExtractor, requestContext, requestEntry);
     }
     return Future.fromCompletionStage(cache.get(cacheKey, (key, executor) ->
       extractData(configExtractor, requestContext, requestEntry).toCompletionStage().toCompletableFuture()));
+  }
+
+  private static boolean isCacheBypassRequested(Map<String, String> headers) {
+    if (headers == null) {
+      return false;
+    }
+    return headers.entrySet().stream()
+      .anyMatch(entry -> BYPASS_CACHE_HEADER.equalsIgnoreCase(entry.getKey())
+        && Boolean.parseBoolean(entry.getValue()));
   }
 
   private <T> Future<T> extractData(BiFunction<RequestEntry, RequestContext, Future<T>> extractor,

--- a/src/test/java/org/folio/service/caches/CommonSettingsCacheTest.java
+++ b/src/test/java/org/folio/service/caches/CommonSettingsCacheTest.java
@@ -115,6 +115,24 @@ public class CommonSettingsCacheTest {
   }
 
   @Test
+  void shouldBypassCacheWhenCacheBypassHeaderIsPresent() {
+    var headersWithBypass = Map.of(
+      "x-okapi-tenant", "test-tenant",
+      "x-okapi-bypass-cache", "true"
+    );
+    when(requestContextMock.getHeaders()).thenReturn(headersWithBypass);
+
+    var config = new JsonObject().put("k", "v");
+    when(commonSettingsRetrieverMock.getLocalSettings(any(RequestEntry.class), any(RequestContext.class)))
+      .thenReturn(Future.succeededFuture(config));
+
+    commonSettingsCache.loadSettings(requestContextMock);
+    commonSettingsCache.loadSettings(requestContextMock);
+
+    verify(commonSettingsRetrieverMock, times(2)).getLocalSettings(any(RequestEntry.class), any(RequestContext.class));
+  }
+
+  @Test
   void shouldBypassCacheWhenByPassCacheIsTrue() throws Exception {
     // Arrange - Set byPassCache to true using reflection to test bypass behavior
     var byPassCacheField = CommonSettingsCache.class.getDeclaredField("byPassCache");


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODORDSTOR-488

### **Approach**

- When a request contains the header bypath-cache, the service must skip the cache and fetch data directly from the remote source.

- If the header is not present, the service should use the cache as usual.

- This feature should be leveraged in Karate tests to ensure fresh data is retrieved and cache is not used.

Related Karate PR: https://github.com/folio-org/folio-integration-tests/pull/2428
---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
