### PR TITLE
[MODORDERS-1456] Auto-change order status like user

### DIFF
--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -27,6 +27,7 @@ import static org.folio.service.orders.utils.StatusUtils.changeOrderStatusForOrd
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -208,7 +209,7 @@ public class PurchaseOrderHelper {
           throw new HttpException(RestConstants.VALIDATION_ERROR, errors);
         }
         return null;
-      }).compose(v -> updateOrder(compPO, deleteHoldings, requestContext))
+      }).compose(v -> updateOrderWithValidation(compPO, deleteHoldings, requestContext))
       .onSuccess(v -> logger.info("putCompositeOrderById :: Successfully updated order, id: {}", compPO.getId()))
       .onFailure(t -> logger.error("putCompositeOrderById :: Failed to update order", t));
   }
@@ -218,77 +219,78 @@ public class PurchaseOrderHelper {
    * @param compPO updated {@link CompositePurchaseOrder} purchase order
    * @return completable future holding response indicating success (204 No Content) or error if failed
    */
-  public Future<Void> updateOrder(CompositePurchaseOrder compPO, boolean deleteHoldings, RequestContext requestContext) {
+  public Future<Void> updateOrderWithValidation(CompositePurchaseOrder compPO, boolean deleteHoldings, RequestContext requestContext) {
     return purchaseOrderStorageService.getPurchaseOrderByIdAsJson(compPO.getId(), requestContext)
       .map(jsonPoFromStorage -> validateIfPOProtectedAndOngoingFieldsChanged(compPO, jsonPoFromStorage))
       .map(HelperUtils::convertToCompositePurchaseOrder)
       .compose(poFromStorage -> purchaseOrderLineService.populateOrderLines(poFromStorage, requestContext))
       .compose(poFromStorage -> {
-        CompositePurchaseOrder clonedPoFromStorage = JsonObject.mapFrom(poFromStorage).mapTo(CompositePurchaseOrder.class);
         if (Objects.nonNull(poFromStorage.getDateOrdered()) && Objects.isNull(compPO.getDateOrdered())) {
           compPO.setDateOrdered(poFromStorage.getDateOrdered());
         }
-        boolean isTransitionToOpen = isTransitionToOpen(poFromStorage, compPO);
-        return validateUserUnaffiliatedPoLineLocations(clonedPoFromStorage.getPoLines(), requestContext)
+        if (isTransitionToReopen(poFromStorage, compPO)) {
+          checkOrderReopenPermissions(requestContext);
+        }
+        if (isTransitionToOpen(poFromStorage, compPO)) {
+          poLineValidationService.checkPurchaseOrderHasPoLines(
+            CollectionUtils.isEmpty(compPO.getPoLines()) ? poFromStorage.getPoLines() : compPO.getPoLines());
+        }
+        return validateUserUnaffiliatedPoLineLocations(poFromStorage.getPoLines(), requestContext)
           .compose(v -> orderValidationService.validateOrderForUpdate(compPO, poFromStorage, requestContext))
-          .compose(ok -> {
-            if (isTransitionToPending(poFromStorage, compPO)) {
-              return unOpenCompositeOrderManager.process(compPO, poFromStorage, deleteHoldings, requestContext);
-            }
-            return Future.succeededFuture();
-          })
           .compose(v -> {
-            if (isTransitionToOpen && CollectionUtils.isEmpty(compPO.getPoLines())) {
-              compPO.setPoLines(clonedPoFromStorage.getPoLines());
+            if (isTransitionToOpen(poFromStorage, compPO)) {
+              return orderValidationService.checkOrderApprovalRequired(compPO, requestContext);
             }
             return Future.succeededFuture();
           })
-          .compose(v -> {
-            if (isTransitionToOpen) {
-              return validatePurchaseOrderHasPoLines(compPO);
-            }
-            return Future.succeededFuture();
-          })
-          .compose(v -> {
-            if (isTransitionToClosed(poFromStorage, compPO)) {
-              return closeOrder(compPO, poFromStorage, requestContext);
-            }
-            return Future.succeededFuture();
-          })
-          .compose(v -> {
-            if (isTransitionToOpen) {
-              compPO.getPoLines().forEach(poLine -> PoLineCommonUtil.updateLocationsQuantity(poLine.getLocations()));
-            }
-            return Future.succeededFuture();
-          })
-          .compose(ok -> {
-            if (isTransitionToReopen(poFromStorage, compPO)) {
-              return Future.succeededFuture()
-                .map(v -> {
-                  checkOrderReopenPermissions(requestContext);
-                  return null;
-                })
-                .compose(v -> reOpenCompositeOrderManager.process(compPO, poFromStorage, requestContext));
-            }
-            return Future.succeededFuture();
-          })
-          .compose(v -> purchaseOrderLineHelper.updatePoLines(poFromStorage, compPO, requestContext))
-          .compose(v -> {
-            if (isTransitionToOpen) {
-              return orderValidationService.checkOrderApprovalRequired(compPO, requestContext)
-                .compose(ok -> commonSettingsCache.loadSettings(requestContext))
-                .compose(tenantConfiguration -> openCompositeOrderManager.process(compPO, poFromStorage, tenantConfiguration, requestContext));
-            } else {
-              return Future.succeededFuture();
-            }
-          })
-          .compose(ok -> handleFinalOrderStatus(compPO, poFromStorage.getWorkflowStatus().value(), requestContext))
-          .compose(v -> encumbranceService.updateEncumbrancesOrderStatusAndReleaseIfClosed(compPO, requestContext));
+          .compose(v -> updateOrderWithoutValidation(compPO, poFromStorage, deleteHoldings, requestContext));
       });
   }
 
-  private Future<Void> validatePurchaseOrderHasPoLines(CompositePurchaseOrder purchaseOrder) {
-    return poLineValidationService.validatePurchaseOrderHasPoLines(purchaseOrder.getPoLines());
+  public Future<Void> updateOrderWithoutValidation(CompositePurchaseOrder compPO, CompositePurchaseOrder poFromStorage,
+      boolean deleteHoldings, RequestContext requestContext) {
+    CompositePurchaseOrder clonedPoFromStorage = JsonObject.mapFrom(poFromStorage).mapTo(CompositePurchaseOrder.class);
+    boolean isTransitionToOpen = isTransitionToOpen(poFromStorage, compPO);
+    if (isTransitionToOpen && CollectionUtils.isEmpty(compPO.getPoLines())) {
+      compPO.setPoLines(clonedPoFromStorage.getPoLines());
+    }
+    return Future.succeededFuture()
+      .compose(v -> {
+        if (isTransitionToPending(poFromStorage, compPO)) {
+          return unOpenCompositeOrderManager.process(compPO, poFromStorage, deleteHoldings, requestContext);
+        }
+        return Future.succeededFuture();
+      })
+      .compose(v -> {
+        if (isTransitionToClosed(poFromStorage, compPO)) {
+          return closeOrder(compPO, poFromStorage, requestContext);
+        }
+        return Future.succeededFuture();
+      })
+      .map(v -> {
+        if (isTransitionToOpen) {
+          compPO.getPoLines().forEach(poLine -> PoLineCommonUtil.updateLocationsQuantity(poLine.getLocations()));
+        }
+        return null;
+      })
+      .compose(v -> {
+        if (isTransitionToReopen(poFromStorage, compPO)) {
+          return reOpenCompositeOrderManager.process(compPO, poFromStorage, requestContext);
+        }
+        return Future.succeededFuture();
+      })
+      .compose(v -> purchaseOrderLineHelper.updatePoLines(poFromStorage, compPO, requestContext))
+      .compose(v -> {
+        if (isTransitionToOpen) {
+          setOrderApprovalDetails(compPO, requestContext);
+          return commonSettingsCache.loadSettings(requestContext)
+            .compose(tenantConfiguration -> openCompositeOrderManager.process(compPO, poFromStorage, tenantConfiguration, requestContext));
+        } else {
+          return Future.succeededFuture();
+        }
+      })
+      .compose(v -> handleFinalOrderStatus(compPO, poFromStorage.getWorkflowStatus().value(), requestContext))
+      .compose(v -> encumbranceService.updateEncumbrancesOrderStatusAndReleaseIfClosed(compPO, requestContext));
   }
 
   private Future<Void> validateUserUnaffiliatedPoLineLocations(List<PoLine> poLines, RequestContext requestContext) {
@@ -485,6 +487,10 @@ public class PurchaseOrderHelper {
         if (finalStatus == OPEN) {
           compPO.setWorkflowStatus(OPEN);
           return orderValidationService.checkOrderApprovalRequired(compPO, requestContext)
+            .map(v -> {
+              setOrderApprovalDetails(compPO, requestContext);
+              return null;
+            })
             .compose(v -> purchaseOrderLineService.populateOrderLines(compPO, requestContext))
             .compose(po -> openCompositeOrderManager.process(po, null, cachedTenantConfiguration, requestContext))
             .compose(ok -> handleFinalOrderStatus(compPO, finalStatus.value(), requestContext));
@@ -610,6 +616,15 @@ public class PurchaseOrderHelper {
 
   private List<PoLine> getNonPackageLines(List<PoLine> poLines) {
     return poLines.stream().filter(line -> !line.getIsPackage()).toList();
+  }
+
+  public void setOrderApprovalDetails(CompositePurchaseOrder compPO, RequestContext requestContext) {
+    if (compPO.getApprovedById() == null) {
+      compPO.setApprovedById(getCurrentUserId(requestContext.getHeaders()));
+    }
+    if (compPO.getApprovalDate() == null) {
+      compPO.setApprovalDate(new Date());
+    }
   }
 
 }

--- a/src/main/java/org/folio/helper/PurchaseOrderHelper.java
+++ b/src/main/java/org/folio/helper/PurchaseOrderHelper.java
@@ -618,7 +618,7 @@ public class PurchaseOrderHelper {
     return poLines.stream().filter(line -> !line.getIsPackage()).toList();
   }
 
-  public void setOrderApprovalDetails(CompositePurchaseOrder compPO, RequestContext requestContext) {
+  private void setOrderApprovalDetails(CompositePurchaseOrder compPO, RequestContext requestContext) {
     if (compPO.getApprovedById() == null) {
       compPO.setApprovedById(getCurrentUserId(requestContext.getHeaders()));
     }

--- a/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
+++ b/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
@@ -13,7 +13,6 @@ import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.CompositePurchaseOrder;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
-import org.folio.service.finance.transaction.EncumbranceService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 
@@ -26,16 +25,13 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public abstract class AbstractOrderStatusHandler extends BaseHelper implements Handler<Message<JsonObject>> {
-  private final EncumbranceService encumbranceService;
   private final PurchaseOrderStorageService purchaseOrderStorageService;
   private final PurchaseOrderHelper purchaseOrderHelper;
   private final PurchaseOrderLineService purchaseOrderLineService;
 
-  protected AbstractOrderStatusHandler(Context ctx, EncumbranceService encumbranceService,
-                              PurchaseOrderStorageService purchaseOrderStorageService, PurchaseOrderHelper purchaseOrderHelper,
-    PurchaseOrderLineService purchaseOrderLineService) {
+  protected AbstractOrderStatusHandler(Context ctx, PurchaseOrderStorageService purchaseOrderStorageService,
+      PurchaseOrderHelper purchaseOrderHelper, PurchaseOrderLineService purchaseOrderLineService) {
     super(ctx);
-    this.encumbranceService = encumbranceService;
     this.purchaseOrderStorageService = purchaseOrderStorageService;
     this.purchaseOrderHelper = purchaseOrderHelper;
     this.purchaseOrderLineService = purchaseOrderLineService;
@@ -82,17 +78,12 @@ public abstract class AbstractOrderStatusHandler extends BaseHelper implements H
   }
 
   protected Future<Void> updateOrderStatus(PurchaseOrder purchaseOrder, List<PoLine> poLines, RequestContext requestContext) {
-    var initialStatus = purchaseOrder.getWorkflowStatus();
-    return ctx.owner().executeBlocking(() -> changeOrderStatusForPoLineUpdate(purchaseOrder, poLines), false)
-      .compose(isStatusChanged -> {
-        if (Boolean.TRUE.equals(isStatusChanged)) {
-          return purchaseOrderHelper.handleFinalOrderItemsStatus(purchaseOrder, poLines, initialStatus.value(), requestContext)
-            .compose(aVoid -> purchaseOrderStorageService.saveOrder(purchaseOrder, requestContext))
-            .compose(purchaseOrderParam -> encumbranceService.updateEncumbrancesOrderStatusAndReleaseIfClosed(
-              convert(purchaseOrder, poLines), requestContext));
-        }
-        return Future.succeededFuture();
-      });
+    CompositePurchaseOrder poFromStorage = convert(purchaseOrder, poLines);
+    if (!changeOrderStatusForPoLineUpdate(purchaseOrder, poLines)) {
+      return Future.succeededFuture();
+    }
+    CompositePurchaseOrder compPO = convert(purchaseOrder, null);
+    return purchaseOrderHelper.updateOrderWithoutValidation(compPO, poFromStorage, true, requestContext);
   }
 
   protected JsonArray messageAsJsonArray(String rootElement, Message<JsonObject> message) {

--- a/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
+++ b/src/main/java/org/folio/orders/events/handlers/AbstractOrderStatusHandler.java
@@ -77,7 +77,14 @@ public abstract class AbstractOrderStatusHandler extends BaseHelper implements H
     completeAllFutures(futures, message);
   }
 
-  protected Future<Void> updateOrderStatus(PurchaseOrder purchaseOrder, List<PoLine> poLines, RequestContext requestContext) {
+  protected abstract boolean isOrdersStatusChangeSkip(PurchaseOrder purchaseOrder, JsonObject ordersPayload);
+
+  private JsonArray messageAsJsonArray(String rootElement, Message<JsonObject> message) {
+    JsonObject body = message.body();
+    return body.getJsonArray(rootElement);
+  }
+
+  private Future<Void> updateOrderStatus(PurchaseOrder purchaseOrder, List<PoLine> poLines, RequestContext requestContext) {
     CompositePurchaseOrder poFromStorage = convert(purchaseOrder, poLines);
     if (!changeOrderStatusForPoLineUpdate(purchaseOrder, poLines)) {
       return Future.succeededFuture();
@@ -86,14 +93,7 @@ public abstract class AbstractOrderStatusHandler extends BaseHelper implements H
     return purchaseOrderHelper.updateOrderWithoutValidation(compPO, poFromStorage, true, requestContext);
   }
 
-  protected JsonArray messageAsJsonArray(String rootElement, Message<JsonObject> message) {
-    JsonObject body = message.body();
-    return body.getJsonArray(rootElement);
-  }
-
-  protected CompositePurchaseOrder convert(PurchaseOrder po, List<PoLine> poLines) {
+  private CompositePurchaseOrder convert(PurchaseOrder po, List<PoLine> poLines) {
     return JsonObject.mapFrom(po).mapTo(CompositePurchaseOrder.class).withPoLines(poLines);
   }
-
-  protected abstract boolean isOrdersStatusChangeSkip(PurchaseOrder purchaseOrder, JsonObject ordersPayload);
 }

--- a/src/main/java/org/folio/orders/events/handlers/CheckInOrderStatusChangeChangeHandler.java
+++ b/src/main/java/org/folio/orders/events/handlers/CheckInOrderStatusChangeChangeHandler.java
@@ -4,7 +4,6 @@ import static org.folio.helper.CheckinHelper.IS_ITEM_ORDER_CLOSED_PRESENT;
 
 import org.folio.helper.PurchaseOrderHelper;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
-import org.folio.service.finance.transaction.EncumbranceService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,9 +17,9 @@ import io.vertx.core.json.JsonObject;
 public class CheckInOrderStatusChangeChangeHandler extends AbstractOrderStatusHandler {
 
   @Autowired
-  public CheckInOrderStatusChangeChangeHandler(Vertx vertx, EncumbranceService encumbranceService,
-          PurchaseOrderStorageService purchaseOrderStorageService, PurchaseOrderHelper purchaseOrderHelper, PurchaseOrderLineService purchaseOrderLineService) {
-    super(vertx.getOrCreateContext(), encumbranceService, purchaseOrderStorageService, purchaseOrderHelper, purchaseOrderLineService);
+  public CheckInOrderStatusChangeChangeHandler(Vertx vertx, PurchaseOrderStorageService purchaseOrderStorageService,
+      PurchaseOrderHelper purchaseOrderHelper, PurchaseOrderLineService purchaseOrderLineService) {
+    super(vertx.getOrCreateContext(), purchaseOrderStorageService, purchaseOrderHelper, purchaseOrderLineService);
   }
 
   @Override

--- a/src/main/java/org/folio/orders/events/handlers/ReceiveOrderStatusChangeHandler.java
+++ b/src/main/java/org/folio/orders/events/handlers/ReceiveOrderStatusChangeHandler.java
@@ -2,7 +2,6 @@ package org.folio.orders.events.handlers;
 
 import org.folio.helper.PurchaseOrderHelper;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
-import org.folio.service.finance.transaction.EncumbranceService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,9 +14,9 @@ import io.vertx.core.json.JsonObject;
 public class ReceiveOrderStatusChangeHandler extends AbstractOrderStatusHandler {
 
   @Autowired
-  public ReceiveOrderStatusChangeHandler(Vertx vertx, EncumbranceService encumbranceService,
-    PurchaseOrderStorageService purchaseOrderStorageService, PurchaseOrderHelper purchaseOrderHelper, PurchaseOrderLineService purchaseOrderLineService) {
-    super(vertx.getOrCreateContext(), encumbranceService, purchaseOrderStorageService, purchaseOrderHelper,
+  public ReceiveOrderStatusChangeHandler(Vertx vertx, PurchaseOrderStorageService purchaseOrderStorageService,
+      PurchaseOrderHelper purchaseOrderHelper, PurchaseOrderLineService purchaseOrderLineService) {
+    super(vertx.getOrCreateContext(), purchaseOrderStorageService, purchaseOrderHelper,
         purchaseOrderLineService);
   }
 

--- a/src/main/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandler.java
+++ b/src/main/java/org/folio/service/dataimport/handlers/OrderPostProcessingEventHandler.java
@@ -102,7 +102,7 @@ public class OrderPostProcessingEventHandler implements EventHandler {
     return purchaseOrderStorageService.getPurchaseOrderByIdAsJson(poLine.getPurchaseOrderId(), requestContext)
       .map(HelperUtils::convertToCompositePurchaseOrder)
       .map(order -> order.withWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.OPEN))
-      .compose(order -> purchaseOrderHelper.updateOrder(order, false, requestContext));
+      .compose(order -> purchaseOrderHelper.updateOrderWithValidation(order, false, requestContext));
   }
 
   private Future<Void> ensurePoLineWithInstanceId(PoLine poLine, DataImportEventPayload dataImportEventPayload,

--- a/src/main/java/org/folio/service/orders/OrderValidationService.java
+++ b/src/main/java/org/folio/service/orders/OrderValidationService.java
@@ -224,8 +224,6 @@ public class OrderValidationService {
         if (isApprovalRequired && !compPO.getApproved().equals(Boolean.TRUE)) {
           throw new HttpException(400, APPROVAL_REQUIRED_TO_OPEN);
         }
-        compPO.setApprovedById(getCurrentUserId(requestContext.getHeaders()));
-        compPO.setApprovalDate(new Date());
         return null;
       });
   }

--- a/src/main/java/org/folio/service/orders/PoLineValidationService.java
+++ b/src/main/java/org/folio/service/orders/PoLineValidationService.java
@@ -352,11 +352,10 @@ public class PoLineValidationService extends BaseValidationService {
     }
   }
 
-  public Future<Void> validatePurchaseOrderHasPoLines(List<PoLine> poLines) {
+  public void checkPurchaseOrderHasPoLines(List<PoLine> poLines) {
     if (CollectionUtils.isEmpty(poLines)) {
-      return Future.failedFuture(new HttpException(org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY, ErrorCodes.COMPOSITE_ORDER_MISSING_PO_LINES));
+      throw new HttpException(org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY, ErrorCodes.COMPOSITE_ORDER_MISSING_PO_LINES);
     }
-    return Future.succeededFuture();
   }
 
   public Future<Void> validateUserUnaffiliatedLocations(String poLineId, List<Location> locations, RequestContext requestContext) {

--- a/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
+++ b/src/test/java/org/folio/helper/PurchaseOrderHelperTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -225,8 +226,8 @@ public class PurchaseOrderHelperTest {
       .when(purchaseOrderStorageService).saveOrder(any(PurchaseOrder.class), eq(requestContext));
     doReturn(succeededFuture(null))
       .when(encumbranceService).updateEncumbrancesOrderStatusAndReleaseIfClosed(any(CompositePurchaseOrder.class), eq(requestContext));
-    doReturn(succeededFuture(null))
-      .when(poLineValidationService).validatePurchaseOrderHasPoLines(any());
+    doNothing()
+      .when(poLineValidationService).checkPurchaseOrderHasPoLines(any());
     doReturn(succeededFuture(null))
       .when(poLineValidationService).validateUserUnaffiliatedLocations(anyString(), any(), eq(requestContext));
 
@@ -337,8 +338,8 @@ public class PurchaseOrderHelperTest {
     doReturn(succeededFuture(null))
       .when(orderValidationService).validateOrderForUpdate(any(CompositePurchaseOrder.class), any(CompositePurchaseOrder.class),
         eq(requestContext));
-    doReturn(succeededFuture(null))
-      .when(poLineValidationService).validatePurchaseOrderHasPoLines(any());
+    doNothing()
+      .when(poLineValidationService).checkPurchaseOrderHasPoLines(any());
     doReturn(succeededFuture(null))
       .when(poLineValidationService).validateUserUnaffiliatedLocations(anyString(), any(), eq(requestContext));
     doReturn(succeededFuture(null))

--- a/src/test/java/org/folio/orders/events/handlers/CheckInOrderStatusChangeChangeHandlerIT.java
+++ b/src/test/java/org/folio/orders/events/handlers/CheckInOrderStatusChangeChangeHandlerIT.java
@@ -56,7 +56,6 @@ import org.folio.helper.PurchaseOrderHelper;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.PurchaseOrder.WorkflowStatus;
-import org.folio.service.finance.transaction.EncumbranceService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 import org.junit.jupiter.api.AfterAll;
@@ -86,8 +85,6 @@ public class CheckInOrderStatusChangeChangeHandlerIT {
   private static Vertx vertx;
 
   @Autowired
-  private EncumbranceService encumbranceService;
-  @Autowired
   private PurchaseOrderStorageService purchaseOrderStorageService;
   @Autowired
   private PurchaseOrderHelper purchaseOrderHelper;
@@ -114,7 +111,7 @@ public class CheckInOrderStatusChangeChangeHandlerIT {
     okapiHeadersMock.put(X_OKAPI_TENANT.getName(), X_OKAPI_TENANT.getValue());
     okapiHeadersMock.put(X_OKAPI_USER_ID.getName(), X_OKAPI_USER_ID.getValue());
     autowireDependencies(this);
-    vertx.eventBus().consumer(MessageAddress.CHECKIN_ORDER_STATUS_UPDATE.address, new CheckInOrderStatusChangeChangeHandler(vertx, encumbranceService,
+    vertx.eventBus().consumer(MessageAddress.CHECKIN_ORDER_STATUS_UPDATE.address, new CheckInOrderStatusChangeChangeHandler(vertx,
                           purchaseOrderStorageService, purchaseOrderHelper, purchaseOrderLineService));
   }
 
@@ -135,7 +132,7 @@ public class CheckInOrderStatusChangeChangeHandlerIT {
     logger.info("=== Test case when order status update is expected from Open to Closed ===");
     sendEvent(createBody(false, PO_ID_OPEN_TO_BE_CLOSED), context.succeeding(result -> {
       assertThat(getPurchaseOrderRetrievals(), hasSize(1));
-      assertThat(getPoLineSearches(), hasSize(1));
+      assertThat(getPoLineSearches(), hasSize(2));
       assertThat(getPurchaseOrderUpdates(), hasSize(1));
 
       PurchaseOrder purchaseOrder = getPurchaseOrderUpdates().get(0).mapTo(PurchaseOrder.class);
@@ -182,7 +179,7 @@ public class CheckInOrderStatusChangeChangeHandlerIT {
     sendEvent(createBody(false, PO_ID_CLOSED_STATUS), context.succeeding(result -> {
       context.verify(() -> {
         assertThat(getPurchaseOrderRetrievals(), hasSize(1));
-        assertThat(getPoLineSearches(), hasSize(2));
+        assertThat(getPoLineSearches(), hasSize(4));
         assertThat(getPurchaseOrderUpdates(), hasSize(1));
         assertThat(getPurchaseOrderUpdates().get(0).mapTo(PurchaseOrder.class).getWorkflowStatus(), is(WorkflowStatus.OPEN));
         assertThat(result.body(), equalTo(Response.Status.OK.getReasonPhrase()));
@@ -237,7 +234,7 @@ public class CheckInOrderStatusChangeChangeHandlerIT {
     sendEvent(createBody(false, PO_ID_CLOSED_STATUS, PO_ID_OPEN_STATUS), context.succeeding(result -> {
       context.verify(() -> {
         assertThat(getPurchaseOrderRetrievals(), hasSize(2));
-        assertThat(getPoLineSearches(), hasSize(3));
+        assertThat(getPoLineSearches(), hasSize(5));
         assertThat(getPurchaseOrderUpdates(), hasSize(1));
         assertThat(getPurchaseOrderUpdates().get(0).mapTo(PurchaseOrder.class).getWorkflowStatus(), is(WorkflowStatus.OPEN));
         assertThat(result.body(), equalTo(Response.Status.OK.getReasonPhrase()));
@@ -321,7 +318,7 @@ public class CheckInOrderStatusChangeChangeHandlerIT {
 
         context.verify(() -> {
           assertThat(getPurchaseOrderRetrievals(), hasSize(1));
-          assertThat(getPoLineSearches(), hasSize(1));
+          assertThat(getPoLineSearches(), hasSize(2));
           assertThat(getPurchaseOrderUpdates(), hasSize(1));
           assertThat(result, instanceOf(ReplyException.class));
           assertThat(((ReplyException) result).failureCode(), is(500));

--- a/src/test/java/org/folio/orders/events/handlers/ReceiveOrderStatusChangeHandlerIT.java
+++ b/src/test/java/org/folio/orders/events/handlers/ReceiveOrderStatusChangeHandlerIT.java
@@ -50,7 +50,6 @@ import org.folio.helper.PurchaseOrderHelper;
 import org.folio.orders.utils.HelperUtils;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.PurchaseOrder.WorkflowStatus;
-import org.folio.service.finance.transaction.EncumbranceService;
 import org.folio.service.orders.PurchaseOrderLineService;
 import org.folio.service.orders.PurchaseOrderStorageService;
 import org.junit.jupiter.api.AfterAll;
@@ -81,8 +80,6 @@ public class ReceiveOrderStatusChangeHandlerIT {
   private static boolean runningOnOwn;
 
   @Autowired
-  private EncumbranceService encumbranceService;
-  @Autowired
   private PurchaseOrderStorageService purchaseOrderStorageService;
   @Autowired
   private PurchaseOrderHelper purchaseOrderHelper;
@@ -103,7 +100,7 @@ public class ReceiveOrderStatusChangeHandlerIT {
   @BeforeEach
   void initMocks(){
     autowireDependencies(this);
-    vertx.eventBus().consumer(MessageAddress.RECEIVE_ORDER_STATUS_UPDATE.address, new ReceiveOrderStatusChangeHandler(vertx, encumbranceService,
+    vertx.eventBus().consumer(MessageAddress.RECEIVE_ORDER_STATUS_UPDATE.address, new ReceiveOrderStatusChangeHandler(vertx,
         purchaseOrderStorageService, purchaseOrderHelper, purchaseOrderLineService));
   }
 
@@ -124,7 +121,7 @@ public class ReceiveOrderStatusChangeHandlerIT {
     logger.info("=== Test case when order status update is expected from Open to Closed ===");
     sendEvent(createBody(PO_ID_OPEN_TO_BE_CLOSED), context.succeeding(result -> {
       assertThat(getPurchaseOrderRetrievals(), hasSize(1));
-      assertThat(getPoLineSearches(), hasSize(1));
+      assertThat(getPoLineSearches(), hasSize(2));
       assertThat(getPurchaseOrderUpdates(), hasSize(1));
 
       PurchaseOrder purchaseOrder = getPurchaseOrderUpdates().get(0).mapTo(PurchaseOrder.class);
@@ -163,7 +160,7 @@ public class ReceiveOrderStatusChangeHandlerIT {
     logger.info("=== Test case when order update is expected for Closed order ===");
     sendEvent(createBody(PO_ID_CLOSED_STATUS), context.succeeding(result -> {
       assertThat(getPurchaseOrderRetrievals(), hasSize(1));
-      assertThat(getPoLineSearches(), hasSize(2));
+      assertThat(getPoLineSearches(), hasSize(4));
       assertThat(getPurchaseOrderUpdates(), hasSize(1));
       assertThat(getPurchaseOrderUpdates().get(0).mapTo(PurchaseOrder.class).getWorkflowStatus(), is(WorkflowStatus.OPEN));
       assertThat(result.body(), equalTo(Response.Status.OK.getReasonPhrase()));
@@ -211,7 +208,7 @@ public class ReceiveOrderStatusChangeHandlerIT {
     logger.info("=== Test case when order update is expected for Closed order ===");
     sendEvent(createBody(PO_ID_CLOSED_STATUS, PO_ID_OPEN_STATUS), context.succeeding(result -> {
       assertThat(getPurchaseOrderRetrievals(), hasSize(2));
-      assertThat(getPoLineSearches(), hasSize(3));
+      assertThat(getPoLineSearches(), hasSize(5));
       assertThat(getPurchaseOrderUpdates(), hasSize(1));
       assertThat(getPurchaseOrderUpdates().get(0).mapTo(PurchaseOrder.class).getWorkflowStatus(), is(WorkflowStatus.OPEN));
       assertThat(result.body(), equalTo(Response.Status.OK.getReasonPhrase()));
@@ -267,7 +264,7 @@ public class ReceiveOrderStatusChangeHandlerIT {
     logger.info("=== Test case when order update fails ===");
     sendEvent(createBody(PO_ID_OPEN_TO_BE_CLOSED_500_ON_UPDATE), context.failing(result -> {
       assertThat(getPurchaseOrderRetrievals(), hasSize(1));
-      assertThat(getPoLineSearches(), hasSize(1));
+      assertThat(getPoLineSearches(), hasSize(2));
       assertThat(getPurchaseOrderUpdates(), hasSize(1));
       assertThat(result, instanceOf(ReplyException.class));
       assertThat(((ReplyException) result).failureCode(), is(500));

--- a/src/test/java/org/folio/service/orders/PoLineValidationServiceTest.java
+++ b/src/test/java/org/folio/service/orders/PoLineValidationServiceTest.java
@@ -539,41 +539,46 @@ public class PoLineValidationServiceTest {
 
   @Test
   @CopilotGenerated(partiallyGenerated = true)
-  void shouldFailValidationWhenCompositePurchaseOrderHasNullPoLines(VertxTestContext testContext) {
+  void shouldFailValidationWhenCompositePurchaseOrderHasNullPoLines() {
     var compPO = new CompositePurchaseOrder();
     compPO.setPoLines(null);
 
-    poLineValidationService.validatePurchaseOrderHasPoLines(compPO.getPoLines())
-      .onComplete(testContext.failing(cause -> testContext.verify(() -> {
-        assertInstanceOf(HttpException.class, cause);
-        assertEquals(COMPOSITE_ORDER_MISSING_PO_LINES.getCode(), ((HttpException) cause).getError().getCode());
-        testContext.completeNow();
-      })));
+    try {
+      poLineValidationService.checkPurchaseOrderHasPoLines(compPO.getPoLines());
+      fail("Validation should not pass");
+    } catch (Exception ex) {
+      assertInstanceOf(HttpException.class, ex);
+      assertEquals(COMPOSITE_ORDER_MISSING_PO_LINES.getCode(), ((HttpException) ex).getError().getCode());
+    }
   }
 
   @Test
   @CopilotGenerated(partiallyGenerated = true)
-  void shouldFailValidationWhenCompositePurchaseOrderHasEmptyPoLines(VertxTestContext testContext) {
+  void shouldFailValidationWhenCompositePurchaseOrderHasEmptyPoLines() {
     var compPO = new CompositePurchaseOrder();
     compPO.setPoLines(Collections.emptyList());
 
-    poLineValidationService.validatePurchaseOrderHasPoLines(compPO.getPoLines())
-      .onComplete(testContext.failing(cause -> testContext.verify(() -> {
-        assertInstanceOf(HttpException.class, cause);
-        assertEquals(COMPOSITE_ORDER_MISSING_PO_LINES.getCode(), ((HttpException) cause).getError().getCode());
-        testContext.completeNow();
-      })));
+    try {
+      poLineValidationService.checkPurchaseOrderHasPoLines(compPO.getPoLines());
+      fail("Validation should not pass");
+    } catch (Exception ex) {
+      assertInstanceOf(HttpException.class, ex);
+      assertEquals(COMPOSITE_ORDER_MISSING_PO_LINES.getCode(), ((HttpException) ex).getError().getCode());
+    }
   }
 
   @Test
   @CopilotGenerated(partiallyGenerated = true)
-  void shouldPassValidationWhenCompositePurchaseOrderHasPoLines(VertxTestContext testContext) {
+  void shouldPassValidationWhenCompositePurchaseOrderHasPoLines() {
     var compPO = new CompositePurchaseOrder();
     var poLine = new PoLine();
     poLine.setId(UUID.randomUUID().toString());
     compPO.setPoLines(List.of(poLine));
 
-    poLineValidationService.validatePurchaseOrderHasPoLines(compPO.getPoLines())
-      .onComplete(testContext.succeeding(result -> testContext.verify(testContext::completeNow)));
+    try {
+      poLineValidationService.checkPurchaseOrderHasPoLines(compPO.getPoLines());
+    } catch (Exception ex) {
+      fail(ex);
+    }
   }
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-1456](https://folio-org.atlassian.net/browse/MODORDERS-1456) - When cancelling an invoice, order is reopened but encumbrance is not created

## Approach
- Split `PurchaseOrderHelper$updateOrder` to separate validation
- Call `updateOrderWithoutValidation()` when changing the order status automatically instead of a custom method which did not create encumbrances as needed
- Fixed a bug with approval by and approval date being reset when an order is opened
- Updated tests

## Related PR
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2437)

## TODO
Investigate a way to pass user permissions for async processing with event handlers.

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
